### PR TITLE
refactor: drop SquadMember ABC and split agent prose into single-purpose files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,10 +48,10 @@ Bounty Squad is a six-agent CrewAI pipeline that autonomously selects HackerOne 
 | `models.py` | Pydantic contracts between agents. Change these carefully — they cross agent boundaries. |
 | `crew.py` | Assembles the `Crew`: builds LLM, agents, tasks. No module-level side effects. |
 | `tasks.py` | Pipeline wiring — context dependencies and `human_input` gates. Thin — keep it that way. |
-| `squad/__init__.py` | `SquadMember` ABC. Default `build_agent()` reads `agent.md`; `build_task()` reads `prompt.md`. |
-| `squad/<member>/agent.md` | Role, goal, backstory — 3 sections separated by `---`. Edit to tune agent behaviour. |
-| `squad/<member>/prompt.md` | Task description and expected output — 2 sections separated by `---`. |
-| `squad/<member>/__init__.py` | Tool functions (`@tool`) + `SquadMember` subclass declaring `slug` and `tools`. |
+| `squad/__init__.py` | `SquadMember` dataclass + `build_agent()` / `build_task()` helpers. Each helper reads prose from a single-purpose `.md` file. |
+| `squad/<member>/{role,goal,backstory}.md` | Three single-purpose files driving the CrewAI Agent. Edit to tune agent behaviour. |
+| `squad/<member>/{description,expected_output}.md` | Two single-purpose files driving the Task description and expected output. |
+| `squad/<member>/__init__.py` | Tool functions (`@tool`) + a module-level `MEMBER = SquadMember(...)` constant. |
 | `tools/h1_api.py` | HackerOne REST client. Singleton: `from tools.h1_api import h1`. |
 | `tools/recon_tools.py` | Wraps subfinder, httpx, nmap. Contains the scope guard. |
 | `tools/vuln_tools.py` | Wraps nuclei, sqlmap, custom checks. |
@@ -92,7 +92,7 @@ The model name must include the provider prefix for litellm routing, e.g.
 
 ### Prompts
 
-Each file in `prompts/` must contain exactly one `---` separator on its own line. Everything above is the task `description`; everything below is `expected_output`. The loader in `tasks.py` will raise `ValueError` if the separator is missing.
+Each agent's prose lives in five single-purpose markdown files inside its package: `role.md`, `goal.md`, `backstory.md`, `description.md`, `expected_output.md`. `SquadMember.read("<name>")` loads `<name>.md` and strips whitespace. Missing files raise `FileNotFoundError` at agent/task build time. No separators, no parsing.
 
 ---
 
@@ -130,11 +130,11 @@ Coverage floor is 70%. Every new public function in `tools/` needs a test. Every
 
 ## Adding a new agent
 
-1. Create `squad/<role-name>/` with three files:
-   - `__init__.py` — `@tool` functions + `SquadMember` subclass with `slug` and `tools`
-   - `agent.md` — role, goal, backstory (3 sections, `---` separated)
-   - `prompt.md` — task description, expected output (2 sections, `---` separated)
-2. Add the new class to `_SQUAD` in `crew.py`.
+1. Create `squad/<role-name>/` with:
+   - `__init__.py` — `@tool` functions + `MEMBER = SquadMember(slug=..., dir=Path(__file__).parent, tools=[...])`
+   - `role.md`, `goal.md`, `backstory.md` — drive the CrewAI Agent
+   - `description.md`, `expected_output.md` — drive the Task
+2. Import the new `MEMBER` into `_SQUAD` in `crew.py`.
 3. Wire its task into `build_tasks()` in `tasks.py` with correct `context` dependencies.
 4. Add unit tests covering the new tool's logic.
 

--- a/README.md
+++ b/README.md
@@ -128,11 +128,14 @@ cybersquad/
 ├── models.py          # Pydantic data contracts between agents
 │
 ├── squad/             # One sub-package per agent
-│   ├── __init__.py    # SquadMember ABC — default build_agent() and build_task()
+│   ├── __init__.py    # SquadMember dataclass + build_agent() / build_task() helpers
 │   └── <member>/
-│       ├── __init__.py   # @tool functions + SquadMember subclass
-│       ├── agent.md      # Role, goal, backstory (edit to tune behaviour)
-│       └── prompt.md     # Task description and expected output
+│       ├── __init__.py        # @tool functions + MEMBER = SquadMember(...) constant
+│       ├── role.md            # Agent role line
+│       ├── goal.md            # Agent goal (edit to tune behaviour)
+│       ├── backstory.md       # Agent backstory
+│       ├── description.md     # Task description
+│       └── expected_output.md # Task expected output
 │
 ├── tools/
 │   ├── approval.py    # CliApprovalGate and make_approval_callback
@@ -178,14 +181,14 @@ All five must pass. CI runs the same checks on every push.
 
 ### Adding a new agent
 
-1. Create `squad/<role>/` with `__init__.py`, `agent.md`, and `prompt.md`.
-2. Add the class to `_SQUAD` in `crew.py`.
+1. Create `squad/<role>/` with `__init__.py` (declaring a `MEMBER = SquadMember(...)` constant) and the five prose files: `role.md`, `goal.md`, `backstory.md`, `description.md`, `expected_output.md`.
+2. Import `MEMBER` into `_SQUAD` in `crew.py`.
 3. Wire its task into `build_tasks()` in `tasks.py` with the correct `context` dependencies.
 4. Add unit tests for any new tool functions.
 
 ### Tuning prompts
 
-Edit `squad/<member>/agent.md` (role, goal, backstory) or `squad/<member>/prompt.md` (task description, expected output). No Python changes required. Verify with `--dry-run` and note the rationale in your PR.
+Edit any of the five prose files in `squad/<member>/`: `role.md`, `goal.md`, `backstory.md` (Agent) or `description.md`, `expected_output.md` (Task). No Python changes required. Verify with `--dry-run` and note the rationale in your PR.
 
 ---
 

--- a/crew.py
+++ b/crew.py
@@ -9,22 +9,22 @@ from __future__ import annotations
 from crewai import LLM, Crew, Process
 
 from config import config
-from squad import SquadMember
-from squad.disclosure_coordinator import DisclosureCoordinator
-from squad.osint_analyst import OsintAnalyst
-from squad.penetration_tester import PenetrationTester
-from squad.programme_manager import ProgrammeManager
-from squad.technical_author import TechnicalAuthor
-from squad.vulnerability_researcher import VulnerabilityResearcher
+from squad import SquadMember, build_agent
+from squad.disclosure_coordinator import MEMBER as DISCLOSURE_COORDINATOR
+from squad.osint_analyst import MEMBER as OSINT_ANALYST
+from squad.penetration_tester import MEMBER as PENETRATION_TESTER
+from squad.programme_manager import MEMBER as PROGRAMME_MANAGER
+from squad.technical_author import MEMBER as TECHNICAL_AUTHOR
+from squad.vulnerability_researcher import MEMBER as VULNERABILITY_RESEARCHER
 from tasks import build_tasks
 
-_SQUAD: list[type[SquadMember]] = [
-    ProgrammeManager,
-    OsintAnalyst,
-    PenetrationTester,
-    VulnerabilityResearcher,
-    TechnicalAuthor,
-    DisclosureCoordinator,
+_SQUAD: list[SquadMember] = [
+    PROGRAMME_MANAGER,
+    OSINT_ANALYST,
+    PENETRATION_TESTER,
+    VULNERABILITY_RESEARCHER,
+    TECHNICAL_AUTHOR,
+    DISCLOSURE_COORDINATOR,
 ]
 
 
@@ -43,7 +43,7 @@ def build_crew(verbose: bool | None = None) -> Crew:
         temperature=config.llm.temperature,
         max_tokens=config.llm.max_tokens,
     )
-    agents = {m.slug: m.build_agent(llm, be_verbose) for m in _SQUAD}
+    agents = {m.slug: build_agent(m, llm, be_verbose) for m in _SQUAD}
     tasks = build_tasks(agents)
 
     return Crew(

--- a/models.py
+++ b/models.py
@@ -188,24 +188,3 @@ class RunMetrics(BaseModel):
     findings_raw: int = 0
     findings_verified: int = 0
     submitted: bool = False
-
-
-# ---------------------------------------------------------------------------
-# Benchmark targets (known-vulnerable environments for squad self-evaluation)
-# ---------------------------------------------------------------------------
-
-
-class BenchmarkTarget(BaseModel):
-    """A known-vulnerable target used to measure squad recall and precision.
-
-    Populate from benchmarks/*.json. Platforms: 'thm', 'htb', 'local'.
-    VPN/API access is the caller's responsibility — the squad treats the
-    base_url as a normal in-scope asset.
-    """
-
-    name: str
-    platform: str
-    base_url: str
-    known_vulnerabilities: list[str]
-    difficulty: str = "medium"
-    notes: str = ""

--- a/squad/__init__.py
+++ b/squad/__init__.py
@@ -1,88 +1,61 @@
 """
-squad/__init__.py — Abstract base for every Bounty Squad member.
+squad/__init__.py — shared SquadMember dataclass + agent/task builders.
 
-Each sub-package declares its tools and slug. All prose lives in markdown:
-  agent.md   — role / goal / backstory  (3 sections, '---' separated)
-  prompt.md  — task description / expected output  (2 sections, '---' separated)
+Each sub-package declares one module-level ``MEMBER = SquadMember(...)`` constant.
+Prose lives in five single-purpose markdown files alongside it:
 
-Assembly (LLM wiring, pipeline order, approval gates) lives in crew.py.
+    role.md             goal.md             backstory.md
+    description.md      expected_output.md
+
+Assembly (LLM wiring, pipeline order, approval gates) lives in crew.py / tasks.py.
 """
 
 from __future__ import annotations
 
-import inspect
-from abc import ABC
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import ClassVar
+from typing import Any
 
 from crewai import Agent, Task
 
 
-def _parse_prompt(text: str, source: str) -> tuple[str, str]:
-    """Split prompt.md text on the first '\\n---\\n' separator."""
-    parts = text.split("\n---\n", 1)
-    if len(parts) != 2:  # noqa: PLR2004
-        raise ValueError(f"{source} must contain a '---' separator")
-    return parts[0].strip(), parts[1].strip()
+@dataclass(frozen=True)
+class SquadMember:
+    """A single Bounty Squad member: identity, tools, and prose location."""
+
+    slug: str
+    dir: Path
+    tools: list[Any] = field(default_factory=list)
+
+    def read(self, name: str) -> str:
+        """Read ``<dir>/<name>.md`` and return its stripped contents."""
+        return (self.dir / f"{name}.md").read_text(encoding="utf-8").strip()
 
 
-def _parse_agent_md(text: str, source: str) -> tuple[str, str, str]:
-    """Split agent.md text on the first two '\\n---\\n' separators."""
-    parts = text.split("\n---\n", 2)
-    if len(parts) != 3:  # noqa: PLR2004
-        raise ValueError(f"{source} must contain exactly 2 '---' separators")
-    return parts[0].strip(), parts[1].strip(), parts[2].strip()
+def build_agent(member: SquadMember, llm: object, verbose: bool = False) -> Agent:
+    """Construct a CrewAI Agent from the member's role/goal/backstory files."""
+    return Agent(
+        role=member.read("role"),
+        goal=member.read("goal"),
+        backstory=member.read("backstory"),
+        tools=member.tools,
+        allow_delegation=False,
+        llm=llm,
+        verbose=verbose,
+    )
 
 
-class SquadMember(ABC):
-    """Interface every Bounty Squad member must satisfy."""
-
-    slug: ClassVar[str]
-    tools: ClassVar[list] = []
-
-    @classmethod
-    def _member_dir(cls) -> Path:
-        return Path(inspect.getfile(cls)).parent
-
-    @classmethod
-    def load_agent_md(cls) -> tuple[str, str, str]:
-        """Read (role, goal, backstory) from this member's agent.md."""
-        path = cls._member_dir() / "agent.md"
-        return _parse_agent_md(path.read_text(encoding="utf-8"), str(path))
-
-    @classmethod
-    def load_prompt(cls) -> tuple[str, str]:
-        """Read (description, expected_output) from this member's prompt.md."""
-        path = cls._member_dir() / "prompt.md"
-        return _parse_prompt(path.read_text(encoding="utf-8"), str(path))
-
-    @classmethod
-    def build_agent(cls, llm: object, verbose: bool = False) -> Agent:
-        """Construct a CrewAI Agent from agent.md and cls.tools."""
-        role, goal, backstory = cls.load_agent_md()
-        return Agent(
-            role=role,
-            goal=goal,
-            backstory=backstory,
-            tools=cls.tools,
-            allow_delegation=False,
-            llm=llm,
-            verbose=verbose,
-        )
-
-    @classmethod
-    def build_task(
-        cls,
-        agent: Agent,
-        context: list[Task] | None = None,
-        human_input: bool = False,
-    ) -> Task:
-        """Create a Task wired to the given agent and optional upstream context."""
-        description, expected_output = cls.load_prompt()
-        return Task(
-            description=description,
-            expected_output=expected_output,
-            agent=agent,
-            context=context or [],
-            human_input=human_input,
-        )
+def build_task(
+    member: SquadMember,
+    agent: Agent,
+    context: list[Task] | None = None,
+    human_input: bool = False,
+) -> Task:
+    """Create a Task from the member's description/expected_output files."""
+    return Task(
+        description=member.read("description"),
+        expected_output=member.read("expected_output"),
+        agent=agent,
+        context=context or [],
+        human_input=human_input,
+    )

--- a/squad/disclosure_coordinator/__init__.py
+++ b/squad/disclosure_coordinator/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import ClassVar
+from pathlib import Path
 
 from crewai.tools import tool
 
@@ -22,6 +22,8 @@ def submit_report_tool(report_json: str) -> dict:
     return result.model_dump()
 
 
-class DisclosureCoordinator(SquadMember):
-    slug = "disclosure_coordinator"
-    tools: ClassVar[list] = [submit_report_tool]
+MEMBER = SquadMember(
+    slug="disclosure_coordinator",
+    dir=Path(__file__).parent,
+    tools=[submit_report_tool],
+)

--- a/squad/disclosure_coordinator/backstory.md
+++ b/squad/disclosure_coordinator/backstory.md
@@ -1,8 +1,3 @@
-Disclosure Coordinator
----
-Submit finalised disclosure reports to HackerOne via the API, confirm successful
-receipt, and log submission metadata for tracking and follow-up.
----
 You are a disclosure coordinator who has managed the responsible disclosure
 lifecycle for over 300 vulnerabilities. You are calm under pressure, precise with
 API payloads, and you maintain meticulous records of every submission status.

--- a/squad/disclosure_coordinator/description.md
+++ b/squad/disclosure_coordinator/description.md
@@ -7,9 +7,3 @@ Submit the finalised disclosure report to HackerOne via the API:
 
 If submission fails, log the error in full and do not retry —
 flag for human review instead.
-
----
-
-A submission summary containing: programme handle, report title,
-severity, H1 report ID, submission URL, timestamp, and status.
-Or a detailed error report if submission failed.

--- a/squad/disclosure_coordinator/expected_output.md
+++ b/squad/disclosure_coordinator/expected_output.md
@@ -1,0 +1,3 @@
+A submission summary containing: programme handle, report title,
+severity, H1 report ID, submission URL, timestamp, and status.
+Or a detailed error report if submission failed.

--- a/squad/disclosure_coordinator/goal.md
+++ b/squad/disclosure_coordinator/goal.md
@@ -1,0 +1,2 @@
+Submit finalised disclosure reports to HackerOne via the API, confirm successful
+receipt, and log submission metadata for tracking and follow-up.

--- a/squad/disclosure_coordinator/role.md
+++ b/squad/disclosure_coordinator/role.md
@@ -1,0 +1,1 @@
+Disclosure Coordinator

--- a/squad/osint_analyst/__init__.py
+++ b/squad/osint_analyst/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import ClassVar
+from pathlib import Path
 
 from crewai.tools import tool
 
@@ -25,6 +25,8 @@ def recon_tool(programme_handle: str) -> dict:
     return result.model_dump()
 
 
-class OsintAnalyst(SquadMember):
-    slug = "osint_analyst"
-    tools: ClassVar[list] = [recon_tool]
+MEMBER = SquadMember(
+    slug="osint_analyst",
+    dir=Path(__file__).parent,
+    tools=[recon_tool],
+)

--- a/squad/osint_analyst/backstory.md
+++ b/squad/osint_analyst/backstory.md
@@ -1,9 +1,3 @@
-OSINT Analyst
----
-Build a comprehensive, in-scope attack surface map for the target programme —
-subdomains, live endpoints, open ports, and technology stack — using only passive
-and semi-passive reconnaissance techniques.
----
 You are an OSINT specialist who has mapped the attack surfaces of hundreds of
 organisations. You are meticulous about staying within authorised scope, and you
 document everything with the precision of a cartographer. You know every subdomain

--- a/squad/osint_analyst/description.md
+++ b/squad/osint_analyst/description.md
@@ -8,8 +8,3 @@ reconnaissance against all in-scope assets:
 Strictly enforce scope — do not interact with any asset not listed
 as in-scope. Document all discovered subdomains, endpoints, open ports,
 and detected technologies.
-
----
-
-A serialised ReconResult JSON containing subdomains, endpoints
-(with status codes and technologies), open ports per host, and notes.

--- a/squad/osint_analyst/expected_output.md
+++ b/squad/osint_analyst/expected_output.md
@@ -1,0 +1,2 @@
+A serialised ReconResult JSON containing subdomains, endpoints
+(with status codes and technologies), open ports per host, and notes.

--- a/squad/osint_analyst/goal.md
+++ b/squad/osint_analyst/goal.md
@@ -1,0 +1,3 @@
+Build a comprehensive, in-scope attack surface map for the target programme —
+subdomains, live endpoints, open ports, and technology stack — using only passive
+and semi-passive reconnaissance techniques.

--- a/squad/osint_analyst/role.md
+++ b/squad/osint_analyst/role.md
@@ -1,0 +1,1 @@
+OSINT Analyst

--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import ClassVar
+from pathlib import Path
 
 from crewai.tools import tool
 
@@ -23,6 +23,8 @@ def pentest_tool(recon_result_json: str) -> list[dict]:
     return [f.model_dump() for f in findings]
 
 
-class PenetrationTester(SquadMember):
-    slug = "penetration_tester"
-    tools: ClassVar[list] = [pentest_tool]
+MEMBER = SquadMember(
+    slug="penetration_tester",
+    dir=Path(__file__).parent,
+    tools=[pentest_tool],
+)

--- a/squad/penetration_tester/backstory.md
+++ b/squad/penetration_tester/backstory.md
@@ -1,9 +1,3 @@
-Penetration Tester
----
-Execute targeted vulnerability scans across the discovered attack surface,
-employing nuclei, sqlmap, and bespoke checks to surface exploitable weaknesses
-whilst respecting rate limits and scope boundaries.
----
 You are an offensive security engineer with certifications in OSCP, CREST CRT,
 and eWPT. You approach every engagement methodically — running the right tool for
 the right target — and you never fire a payload at an asset that is out of scope.

--- a/squad/penetration_tester/description.md
+++ b/squad/penetration_tester/description.md
@@ -7,8 +7,3 @@ vulnerability scans:
 Respect the configured request rate limit. Do not attempt exploits
 beyond proof-of-concept. Capture tool output as evidence.
 Return all raw findings regardless of confidence — triage comes next.
-
----
-
-A JSON array of RawFinding objects, each with title, vuln_class,
-target, evidence snippet, tool name, and severity hint.

--- a/squad/penetration_tester/expected_output.md
+++ b/squad/penetration_tester/expected_output.md
@@ -1,0 +1,2 @@
+A JSON array of RawFinding objects, each with title, vuln_class,
+target, evidence snippet, tool name, and severity hint.

--- a/squad/penetration_tester/goal.md
+++ b/squad/penetration_tester/goal.md
@@ -1,0 +1,3 @@
+Execute targeted vulnerability scans across the discovered attack surface,
+employing nuclei, sqlmap, and bespoke checks to surface exploitable weaknesses
+whilst respecting rate limits and scope boundaries.

--- a/squad/penetration_tester/role.md
+++ b/squad/penetration_tester/role.md
@@ -1,0 +1,1 @@
+Penetration Tester

--- a/squad/programme_manager/__init__.py
+++ b/squad/programme_manager/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import ClassVar
+from pathlib import Path
 
 from crewai.tools import tool
 
@@ -24,6 +24,8 @@ def get_scope_tool(handle: str) -> dict:
     return {"policy": policy, "scope": scope}
 
 
-class ProgrammeManager(SquadMember):
-    slug = "programme_manager"
-    tools: ClassVar[list] = [list_programmes_tool, get_scope_tool]
+MEMBER = SquadMember(
+    slug="programme_manager",
+    dir=Path(__file__).parent,
+    tools=[list_programmes_tool, get_scope_tool],
+)

--- a/squad/programme_manager/backstory.md
+++ b/squad/programme_manager/backstory.md
@@ -1,9 +1,3 @@
-Programme Manager
----
-Identify the highest-value HackerOne bug bounty programmes — maximising expected
-payout relative to attack surface complexity — whilst rigorously verifying that
-automated scanning is permitted.
----
 You are a seasoned security programme manager with a decade of experience
 prioritising vulnerability disclosure efforts across Fortune 500 clients. You
 have an encyclopaedic knowledge of HackerOne programme policies and a sharp eye

--- a/squad/programme_manager/description.md
+++ b/squad/programme_manager/description.md
@@ -9,8 +9,3 @@ Evaluate each candidate on the following criteria:
 Discard any programme that prohibits automated scanning.
 Select the single highest-scoring programme and output its handle,
 name, bounty table, and in-scope asset list.
-
----
-
-A JSON object containing the selected programme's handle, name,
-maximum bounty amounts by severity, and a list of in-scope asset identifiers.

--- a/squad/programme_manager/expected_output.md
+++ b/squad/programme_manager/expected_output.md
@@ -1,0 +1,2 @@
+A JSON object containing the selected programme's handle, name,
+maximum bounty amounts by severity, and a list of in-scope asset identifiers.

--- a/squad/programme_manager/goal.md
+++ b/squad/programme_manager/goal.md
@@ -1,0 +1,3 @@
+Identify the highest-value HackerOne bug bounty programmes — maximising expected
+payout relative to attack surface complexity — whilst rigorously verifying that
+automated scanning is permitted.

--- a/squad/programme_manager/role.md
+++ b/squad/programme_manager/role.md
@@ -1,0 +1,1 @@
+Programme Manager

--- a/squad/technical_author/__init__.py
+++ b/squad/technical_author/__init__.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from squad import SquadMember
 
-
-class TechnicalAuthor(SquadMember):
-    slug = "technical_author"
-    # inherits tools = [] from SquadMember — works from context alone
+MEMBER = SquadMember(
+    slug="technical_author",
+    dir=Path(__file__).parent,
+)

--- a/squad/technical_author/backstory.md
+++ b/squad/technical_author/backstory.md
@@ -1,9 +1,3 @@
-Technical Author
----
-Transform verified vulnerability data into clear, compelling, and complete
-H1-format disclosure reports — with precise reproduction steps, accurate impact
-statements, and actionable remediation advice.
----
 You are a technical author who spent five years writing security advisories for a
 national CERT before moving into bug bounty. Your reports are legendary for their
 clarity: even a junior developer can follow your reproduction steps, and your

--- a/squad/technical_author/description.md
+++ b/squad/technical_author/description.md
@@ -12,9 +12,3 @@ disclosure report in Markdown:
 Write with precision and professionalism. Triage teams award bounties
 faster for clear reports. If there are multiple findings, prioritise
 the highest-severity one for submission in this run.
-
----
-
-A serialised DisclosureReport JSON containing the programme handle,
-title, the VerifiedVulnerability, a summary, the full Markdown body,
-CWE identifier, and impact statement.

--- a/squad/technical_author/expected_output.md
+++ b/squad/technical_author/expected_output.md
@@ -1,0 +1,3 @@
+A serialised DisclosureReport JSON containing the programme handle,
+title, the VerifiedVulnerability, a summary, the full Markdown body,
+CWE identifier, and impact statement.

--- a/squad/technical_author/goal.md
+++ b/squad/technical_author/goal.md
@@ -1,0 +1,3 @@
+Transform verified vulnerability data into clear, compelling, and complete
+H1-format disclosure reports — with precise reproduction steps, accurate impact
+statements, and actionable remediation advice.

--- a/squad/technical_author/role.md
+++ b/squad/technical_author/role.md
@@ -1,0 +1,1 @@
+Technical Author

--- a/squad/vulnerability_researcher/__init__.py
+++ b/squad/vulnerability_researcher/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import ClassVar
+from pathlib import Path
 
 from crewai.tools import tool
 
@@ -28,6 +28,8 @@ def triage_tool(raw_findings_json: str, programme_handle: str) -> list[dict]:
     return [v.model_dump() for v in verified]
 
 
-class VulnerabilityResearcher(SquadMember):
-    slug = "vulnerability_researcher"
-    tools: ClassVar[list] = [triage_tool]
+MEMBER = SquadMember(
+    slug="vulnerability_researcher",
+    dir=Path(__file__).parent,
+    tools=[triage_tool],
+)

--- a/squad/vulnerability_researcher/backstory.md
+++ b/squad/vulnerability_researcher/backstory.md
@@ -1,9 +1,3 @@
-Vulnerability Researcher
----
-Triage all raw scanner output to eliminate false positives, confirm exploitability,
-assign accurate CVSS scores, and produce clean, scope-validated findings ready for
-professional documentation.
----
 You are a vulnerability researcher who has published CVEs and presented at DEF CON.
 You have an instinct for separating genuine security issues from scanner noise, and
 your CVSS scoring is trusted by vendors worldwide. You refuse to forward a finding

--- a/squad/vulnerability_researcher/description.md
+++ b/squad/vulnerability_researcher/description.md
@@ -8,9 +8,3 @@ Triage the raw findings from the penetration test:
   5. Flag any finding you cannot independently verify as UNCONFIRMED
 
 Only forward findings you are personally confident are genuine and in-scope.
-
----
-
-A JSON array of VerifiedVulnerability objects with full CVSS scoring,
-descriptions, reproduction steps, impact, and remediation.
-Unconfirmed findings should be excluded.

--- a/squad/vulnerability_researcher/expected_output.md
+++ b/squad/vulnerability_researcher/expected_output.md
@@ -1,0 +1,3 @@
+A JSON array of VerifiedVulnerability objects with full CVSS scoring,
+descriptions, reproduction steps, impact, and remediation.
+Unconfirmed findings should be excluded.

--- a/squad/vulnerability_researcher/goal.md
+++ b/squad/vulnerability_researcher/goal.md
@@ -1,0 +1,3 @@
+Triage all raw scanner output to eliminate false positives, confirm exploitability,
+assign accurate CVSS scores, and produce clean, scope-validated findings ready for
+professional documentation.

--- a/squad/vulnerability_researcher/role.md
+++ b/squad/vulnerability_researcher/role.md
@@ -1,0 +1,1 @@
+Vulnerability Researcher

--- a/tasks.py
+++ b/tasks.py
@@ -1,7 +1,6 @@
 """
 tasks.py — Pipeline task wiring.
 
-Delegates prompt loading and Task construction to each SquadMember class.
 Context chaining lives here because it is a pipeline concern, not a per-member one.
 
 human_input=True on a task tells CrewAI to pause after the agent finishes and
@@ -13,25 +12,26 @@ from __future__ import annotations
 
 from crewai import Task
 
-from squad.disclosure_coordinator import DisclosureCoordinator
-from squad.osint_analyst import OsintAnalyst
-from squad.penetration_tester import PenetrationTester
-from squad.programme_manager import ProgrammeManager
-from squad.technical_author import TechnicalAuthor
-from squad.vulnerability_researcher import VulnerabilityResearcher
+from squad import build_task
+from squad.disclosure_coordinator import MEMBER as DISCLOSURE_COORDINATOR
+from squad.osint_analyst import MEMBER as OSINT_ANALYST
+from squad.penetration_tester import MEMBER as PENETRATION_TESTER
+from squad.programme_manager import MEMBER as PROGRAMME_MANAGER
+from squad.technical_author import MEMBER as TECHNICAL_AUTHOR
+from squad.vulnerability_researcher import MEMBER as VULNERABILITY_RESEARCHER
 
 
 def build_tasks(agents: dict) -> list[Task]:
     # Pauses for operator review before any scanning begins.
-    select = ProgrammeManager.build_task(agents["programme_manager"], human_input=True)
-    recon = OsintAnalyst.build_task(agents["osint_analyst"], context=[select])
-    pentest = PenetrationTester.build_task(agents["penetration_tester"], context=[recon])
-    triage = VulnerabilityResearcher.build_task(
-        agents["vulnerability_researcher"], context=[pentest, select]
+    select = build_task(PROGRAMME_MANAGER, agents["programme_manager"], human_input=True)
+    recon = build_task(OSINT_ANALYST, agents["osint_analyst"], context=[select])
+    pentest = build_task(PENETRATION_TESTER, agents["penetration_tester"], context=[recon])
+    triage = build_task(
+        VULNERABILITY_RESEARCHER, agents["vulnerability_researcher"], context=[pentest, select]
     )
     # Pauses for operator review before the report is submitted to H1.
-    write = TechnicalAuthor.build_task(
-        agents["technical_author"], context=[triage, select], human_input=True
+    write = build_task(
+        TECHNICAL_AUTHOR, agents["technical_author"], context=[triage, select], human_input=True
     )
-    submit = DisclosureCoordinator.build_task(agents["disclosure_coordinator"], context=[write])
+    submit = build_task(DISCLOSURE_COORDINATOR, agents["disclosure_coordinator"], context=[write])
     return [select, recon, pentest, triage, write, submit]

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -9,24 +9,24 @@ import pytest
 pytest.importorskip("crewai")
 
 import squad  # noqa: E402
-from squad import SquadMember, _parse_prompt  # noqa: E402
-from squad.disclosure_coordinator import DisclosureCoordinator  # noqa: E402
-from squad.osint_analyst import OsintAnalyst  # noqa: E402
-from squad.penetration_tester import PenetrationTester  # noqa: E402
-from squad.programme_manager import ProgrammeManager  # noqa: E402
-from squad.technical_author import TechnicalAuthor  # noqa: E402
-from squad.vulnerability_researcher import VulnerabilityResearcher  # noqa: E402
+from squad import SquadMember  # noqa: E402
+from squad.disclosure_coordinator import MEMBER as DISCLOSURE_COORDINATOR  # noqa: E402
+from squad.osint_analyst import MEMBER as OSINT_ANALYST  # noqa: E402
+from squad.penetration_tester import MEMBER as PENETRATION_TESTER  # noqa: E402
+from squad.programme_manager import MEMBER as PROGRAMME_MANAGER  # noqa: E402
+from squad.technical_author import MEMBER as TECHNICAL_AUTHOR  # noqa: E402
+from squad.vulnerability_researcher import MEMBER as VULNERABILITY_RESEARCHER  # noqa: E402
 from tasks import build_tasks  # noqa: E402
 
 pytestmark = pytest.mark.unit
 
-_ALL_MEMBERS: list[type[SquadMember]] = [
-    ProgrammeManager,
-    OsintAnalyst,
-    PenetrationTester,
-    VulnerabilityResearcher,
-    TechnicalAuthor,
-    DisclosureCoordinator,
+_ALL_MEMBERS: list[SquadMember] = [
+    PROGRAMME_MANAGER,
+    OSINT_ANALYST,
+    PENETRATION_TESTER,
+    VULNERABILITY_RESEARCHER,
+    TECHNICAL_AUTHOR,
+    DISCLOSURE_COORDINATOR,
 ]
 
 
@@ -48,30 +48,18 @@ class _FakeTask:
         self.human_input = human_input
 
 
-class TestParsePrompt:
-    def test_splits_on_separator(self) -> None:
-        desc, out = _parse_prompt("description\n---\noutput", "test")
-        assert desc == "description"
-        assert out == "output"
-
-    def test_strips_whitespace(self) -> None:
-        desc, out = _parse_prompt("  desc  \n---\n  out  ", "test")
-        assert desc == "desc"
-        assert out == "out"
-
-    def test_missing_separator_raises(self) -> None:
-        with pytest.raises(ValueError, match="must contain a '---' separator"):
-            _parse_prompt("no separator here", "test.md")
-
-
-class TestLoadPrompt:
-    def test_all_members_load_successfully(self) -> None:
+class TestSquadMemberRead:
+    def test_all_members_load_prose(self) -> None:
         for member in _ALL_MEMBERS:
-            desc, out = member.load_prompt()
-            assert desc, f"{member.__name__} has empty description"
-            assert out, f"{member.__name__} has empty expected_output"
-            assert "---" not in desc
-            assert "---" not in out
+            for name in ("role", "goal", "backstory", "description", "expected_output"):
+                value = member.read(name)
+                assert value, f"{member.slug}/{name}.md is empty"
+                assert "---" not in value, f"{member.slug}/{name}.md still contains '---'"
+
+    def test_missing_file_raises(self, tmp_path) -> None:
+        member = SquadMember(slug="missing", dir=tmp_path, tools=[])
+        with pytest.raises(FileNotFoundError):
+            member.read("role")
 
 
 class TestBuildTasks:


### PR DESCRIPTION
## Summary

A focused simplification pass on the squad layer — no behavioural change, no rewrite, no touch to `tools/`, the scope guard, the automated-scanning gate, or `check_env()` ordering.

- **Drop the `SquadMember` ABC.** Replaces the `ABC` + `classmethod` pattern with a plain frozen dataclass and module-level `build_agent` / `build_task` helpers. Each squad member now declares a single `MEMBER = SquadMember(slug=..., dir=Path(__file__).parent, tools=[...])` constant.
- **Split each `agent.md` / `prompt.md` into five flat single-purpose files.** The `\n---\n` separator parsing is gone. Each agent's prose lives in `role.md`, `goal.md`, `backstory.md`, `description.md`, `expected_output.md`. `SquadMember.read("name")` is a one-line file read.
- **Delete `BenchmarkTarget`.** Defined in `models.py` since the initial commit, never imported anywhere, no `benchmarks/` directory ever existed. Confirmed dead.
- **Update `CLAUDE.md` and `README.md`** to document the new layout.

Net diff: 43 files, **198 insertions / 273 deletions** (~75 lines net).

## Test plan

- [x] `.venv/bin/ruff check .` — clean
- [x] `.venv/bin/ruff format --check .` — clean
- [x] `.venv/bin/mypy . --ignore-missing-imports` — `Success: no issues found in 28 source files`
- [x] `H1_API_USERNAME=test H1_API_TOKEN=test .venv/bin/pytest -m unit --cov` — 140 passed, coverage 75.87% (floor 70%)
- [x] `.venv/bin/bandit -c pyproject.toml -r . -q` — clean (exit 0)
- [x] `python main.py --help` exits cleanly
