### PR TITLE
Add post-triage gate, ground prompts in standards, rewrite backstories

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,22 @@ An autonomous bug bounty pipeline powered by [CrewAI](https://github.com/crewAII
 ## How it works
 
 ```
-Programme Manager ──▶ OSINT Analyst ──▶ Penetration Tester
-                                                │
-                                    [scan-approval gate]
-                                                │
-                                                ▼
-Disclosure Coordinator ◀── Technical Author ◀── Vulnerability Researcher
-        │
-[submission-approval gate]
-        │
-        ▼
-  HackerOne API
+Programme Manager ──▶ [selection gate] ──▶ OSINT Analyst ──▶ Penetration Tester
+                                                                        │
+                                                                        ▼
+                                          [triage gate] ◀── Vulnerability Researcher
+                                                 │
+                                                 ▼
+                                         Technical Author
+                                                 │
+                                                 ▼
+                                       [submission gate]
+                                                 │
+                                                 ▼
+                                      Disclosure Coordinator
+                                                 │
+                                                 ▼
+                                           HackerOne API
 ```
 
 At each approval gate the pipeline pauses, renders a summary of what the agent produced, and waits for your explicit confirmation before continuing.
@@ -111,7 +116,7 @@ python main.py
 python main.py --verbose
 ```
 
-The pipeline pauses twice: once after programme selection (before any scanning begins) and once after the report is written (before submission to H1). At each checkpoint a summary panel is displayed and you must explicitly approve to continue.
+The pipeline pauses three times: after programme selection (before any scanning begins), after triage (before spending tokens on report writing), and after the report is written (before submission to H1). At each checkpoint a summary panel is displayed and you must explicitly approve to continue.
 
 Generated reports are saved to `REPORTS_DIR` as Markdown files.
 
@@ -123,7 +128,7 @@ Generated reports are saved to `REPORTS_DIR` as Markdown files.
 cybersquad/
 ├── main.py            # CLI entrypoint
 ├── crew.py            # Assembles LLM, agents, tasks, and approval gates
-├── tasks.py           # Pipeline wiring and checkpoint index definitions
+├── tasks.py           # Pipeline wiring — context chaining and approval gates
 ├── config.py          # Env-var-backed configuration (singleton: config.*)
 ├── models.py          # Pydantic data contracts between agents
 │
@@ -138,7 +143,6 @@ cybersquad/
 │       └── expected_output.md # Task expected output
 │
 ├── tools/
-│   ├── approval.py    # CliApprovalGate and make_approval_callback
 │   ├── h1_api.py      # HackerOne REST client
 │   ├── metrics.py     # Token usage and cost tracking
 │   ├── recon_tools.py # subfinder / httpx / nmap wrappers + scope guard

--- a/models.py
+++ b/models.py
@@ -45,7 +45,7 @@ class SubmissionStatus(StrEnum):
 
 
 # ---------------------------------------------------------------------------
-# Programme selection (Scout → everyone)
+# Programme selection (Programme Manager → everyone)
 # ---------------------------------------------------------------------------
 
 

--- a/squad/disclosure_coordinator/backstory.md
+++ b/squad/disclosure_coordinator/backstory.md
@@ -1,4 +1,7 @@
-You are a disclosure coordinator who has managed the responsible disclosure
-lifecycle for over 300 vulnerabilities. You are calm under pressure, precise with
-API payloads, and you maintain meticulous records of every submission status.
-Nothing slips through your process.
+You submit reports to the HackerOne API precisely and record every submission's
+metadata: report ID, programme handle, severity, timestamp, and URL. You follow
+coordinated-disclosure conventions — the programme's stated response window is
+respected, and public discussion of a finding waits until the programme has
+resolved it or explicitly permitted disclosure. On submission failure you
+capture the full error response and flag for human review; you never retry
+blindly.

--- a/squad/osint_analyst/backstory.md
+++ b/squad/osint_analyst/backstory.md
@@ -1,4 +1,7 @@
-You are an OSINT specialist who has mapped the attack surfaces of hundreds of
-organisations. You are meticulous about staying within authorised scope, and you
-document everything with the precision of a cartographer. You know every subdomain
-enumeration trick in the book.
+You map attack surface using passive and semi-passive techniques: subfinder for
+subdomain enumeration, httpx for live HTTP/S endpoint probing and technology
+fingerprinting, and lightweight port scans for service discovery. Every
+discovered asset is cross-checked against the programme's in-scope list before
+being included in your output — assets that are not explicitly in scope are
+excluded without exception. You document findings with the detail a downstream
+tester would need to reproduce them.

--- a/squad/penetration_tester/backstory.md
+++ b/squad/penetration_tester/backstory.md
@@ -1,4 +1,8 @@
-You are an offensive security engineer with certifications in OSCP, CREST CRT,
-and eWPT. You approach every engagement methodically — running the right tool for
-the right target — and you never fire a payload at an asset that is out of scope.
-You are efficient, precise, and deeply familiar with the OWASP Top 10.
+You run targeted vulnerability scans, matching the tool to the target: nuclei
+for templated checks on live HTTP endpoints, sqlmap for parameterised URLs,
+and bespoke checks for configuration issues such as CORS misconfiguration. You
+follow the OWASP Testing Guide v4.2 methodology and classify findings against
+the OWASP Top 10 (2021) where applicable. You respect the configured rate
+limit and stop at proof-of-concept — you never exploit beyond what is needed
+to demonstrate the issue, and you never fire a payload at an asset that is
+out of scope.

--- a/squad/penetration_tester/description.md
+++ b/squad/penetration_tester/description.md
@@ -4,6 +4,11 @@ vulnerability scans:
   - Run sqlmap against parameterised endpoints
   - Run CORS misconfiguration checks against all endpoints
 
+Follow the OWASP Testing Guide v4.2 methodology. Where a finding maps to an
+OWASP Top 10 (2021) category (e.g. A01 Broken Access Control, A03 Injection,
+A07 Identification and Authentication Failures), record that category in the
+finding's vuln_class field so triage can prioritise correctly.
+
 Respect the configured request rate limit. Do not attempt exploits
 beyond proof-of-concept. Capture tool output as evidence.
 Return all raw findings regardless of confidence — triage comes next.

--- a/squad/penetration_tester/expected_output.md
+++ b/squad/penetration_tester/expected_output.md
@@ -1,2 +1,3 @@
-A JSON array of RawFinding objects, each with title, vuln_class,
-target, evidence snippet, tool name, and severity hint.
+A JSON array of RawFinding objects, each with title, vuln_class
+(including OWASP Top 10 category where applicable), target, evidence
+snippet, tool name, and severity hint.

--- a/squad/programme_manager/backstory.md
+++ b/squad/programme_manager/backstory.md
@@ -1,5 +1,7 @@
-You are a seasoned security programme manager with a decade of experience
-prioritising vulnerability disclosure efforts across Fortune 500 clients. You
-have an encyclopaedic knowledge of HackerOne programme policies and a sharp eye
-for ROI. You never authorise work against a programme that prohibits automated
-tools.
+You evaluate HackerOne programmes on concrete criteria: maximum bounty by
+severity, attack surface breadth, and explicit permission for automated
+scanning. You read policy text carefully — phrases like "no automated scanning",
+"manual testing only", or "automated tools are prohibited" are disqualifying.
+You prefer programmes with public response-rate and time-to-bounty data, and
+you never authorise work against a programme whose policy forbids the tools
+the squad runs.

--- a/squad/technical_author/backstory.md
+++ b/squad/technical_author/backstory.md
@@ -1,5 +1,8 @@
-You are a technical author who spent five years writing security advisories for a
-national CERT before moving into bug bounty. Your reports are legendary for their
-clarity: even a junior developer can follow your reproduction steps, and your
-impact statements have never been disputed by a programme triage team. You take
-pride in reports that get triaged first time, every time.
+Your standard is a report that HackerOne triages on first read without
+requesting clarification. You write reproduction steps a developer unfamiliar
+with the codebase can follow, impact statements grounded in what an attacker
+can actually do with the finding, and remediation advice that cites the
+relevant OWASP guidance or CWE entry. You sanitise evidence so that the report
+is safe to publish — no live payloads, no credentials, no data from unrelated
+users. You follow the HackerOne report format: title, summary, details,
+steps to reproduce, impact, and remediation.

--- a/squad/technical_author/description.md
+++ b/squad/technical_author/description.md
@@ -5,10 +5,13 @@ disclosure report in Markdown:
   - Full vulnerability details (type, severity, CVSS, CWE, target)
   - A clear technical description written for a developer audience
   - Numbered, reproducible steps to demonstrate the issue
-  - Sanitised evidence (no live exploit payloads)
-  - A realistic, specific impact statement
-  - Actionable, specific remediation advice referencing OWASP or CWE
+  - Sanitised evidence (no live exploit payloads, no credentials,
+    no data belonging to other users)
+  - A realistic, specific impact statement grounded in what an attacker
+    can actually do with the finding
+  - Actionable, specific remediation advice citing the relevant OWASP
+    guidance (https://owasp.org) or CWE entry (https://cwe.mitre.org)
 
-Write with precision and professionalism. Triage teams award bounties
-faster for clear reports. If there are multiple findings, prioritise
-the highest-severity one for submission in this run.
+The quality bar is a report that HackerOne triages on first read without
+requesting clarification. If there are multiple findings, prioritise the
+highest-severity one for submission in this run.

--- a/squad/vulnerability_researcher/backstory.md
+++ b/squad/vulnerability_researcher/backstory.md
@@ -1,4 +1,7 @@
-You are a vulnerability researcher who has published CVEs and presented at DEF CON.
-You have an instinct for separating genuine security issues from scanner noise, and
-your CVSS scoring is trusted by vendors worldwide. You refuse to forward a finding
-to reporting unless you are personally confident it is real and in scope.
+You triage raw scanner output conservatively — scanners are noisy, and false
+positives waste programme triage time and damage the squad's submission record.
+You score every finding using the FIRST.org CVSS 3.1 specification, erring on
+the lower side when any base metric is uncertain. You forward only findings
+you can independently reproduce in a clean session; anything else is flagged
+UNCONFIRMED with a specific note describing what additional evidence would
+confirm it. You map each finding to a CWE identifier where one exists.

--- a/squad/vulnerability_researcher/description.md
+++ b/squad/vulnerability_researcher/description.md
@@ -1,10 +1,18 @@
 Triage the raw findings from the penetration test:
   1. Discard any finding whose target is out of scope
   2. Discard findings below the configured severity floor
-  3. For each remaining finding, assign an accurate CVSS 3.1 score
-     and vector string
+  3. For each remaining finding, assign a CVSS 3.1 score and vector string
+     per the FIRST.org specification
+     (https://www.first.org/cvss/v3.1/specification-document). When any
+     base metric is uncertain, score conservatively — prefer the lower
+     value. Map each finding to a CWE identifier where one exists
+     (https://cwe.mitre.org)
   4. Write a concise technical description, clear reproduction steps,
      an impact statement, and remediation guidance for each
-  5. Flag any finding you cannot independently verify as UNCONFIRMED
+  5. Flag any finding you cannot independently reproduce as UNCONFIRMED,
+     with a specific note describing what additional evidence would
+     confirm it
 
-Only forward findings you are personally confident are genuine and in-scope.
+Only forward findings you can independently reproduce and confirm as
+in-scope. A false-positive submission damages the squad's record and
+wastes programme triage time — when in doubt, leave it out.

--- a/squad/vulnerability_researcher/expected_output.md
+++ b/squad/vulnerability_researcher/expected_output.md
@@ -1,3 +1,4 @@
-A JSON array of VerifiedVulnerability objects with full CVSS scoring,
-descriptions, reproduction steps, impact, and remediation.
-Unconfirmed findings should be excluded.
+A JSON array of VerifiedVulnerability objects with full CVSS 3.1 scoring
+(vector + base score), CWE identifier where applicable, descriptions,
+reproduction steps, impact, and remediation. Unconfirmed findings should
+be excluded.

--- a/tasks.py
+++ b/tasks.py
@@ -22,14 +22,18 @@ from squad.vulnerability_researcher import MEMBER as VULNERABILITY_RESEARCHER
 
 
 def build_tasks(agents: dict) -> list[Task]:
-    # Pauses for operator review before any scanning begins.
+    # Gate 1: approve or reject the selected programme before any scanning begins.
     select = build_task(PROGRAMME_MANAGER, agents["programme_manager"], human_input=True)
     recon = build_task(OSINT_ANALYST, agents["osint_analyst"], context=[select])
     pentest = build_task(PENETRATION_TESTER, agents["penetration_tester"], context=[recon])
+    # Gate 2: verify triage conclusions before spending tokens on report writing.
     triage = build_task(
-        VULNERABILITY_RESEARCHER, agents["vulnerability_researcher"], context=[pentest, select]
+        VULNERABILITY_RESEARCHER,
+        agents["vulnerability_researcher"],
+        context=[pentest, select],
+        human_input=True,
     )
-    # Pauses for operator review before the report is submitted to H1.
+    # Gate 3: review the finished report before it is submitted to H1.
     write = build_task(
         TECHNICAL_AUTHOR, agents["technical_author"], context=[triage, select], human_input=True
     )

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -100,7 +100,9 @@ class TestBuildTasks:
         monkeypatch.setattr(squad, "Task", _FakeTask)
         tasks = build_tasks(self._agents())
         select, recon, pentest, triage, write, submit = tasks
+        # Three gates: after selection, after triage, after writing.
         assert select.human_input is True
+        assert triage.human_input is True
         assert write.human_input is True
-        for task in (recon, pentest, triage, submit):
+        for task in (recon, pentest, submit):
             assert task.human_input is False


### PR DESCRIPTION
Rebased replacement for #8 — applies cleanly on top of the PR #9 prose-split refactor.

## Summary

- **Missing HITL gate added** — the pipeline now pauses three times (selection → triage → submission) instead of two. The post-triage gate is the "did the agent hallucinate?" check before spending tokens writing a report.
- **Prompts grounded in real standards** — the penetration tester, vulnerability researcher, and technical author prompts now cite OWASP Testing Guide v4.2, OWASP Top 10 (2021), FIRST.org CVSS 3.1 spec, and CWE/MITRE rather than vague quality claims.
- **Agent backstories rewritten** — removed fictional authority (DEF CON talks, "legendary" reports, "decade of Fortune 500 experience"). Replaced with concrete methodology descriptions and quality bars each agent actually holds itself to.
- **README reconciled with code** — diagram shows all three gates in correct positions; stale reference to `tools/approval.py` removed; `tasks.py` description corrected; "pauses twice" → "pauses three times".
- **Stale comment fixed** — `models.py` "Scout → everyone" → "Programme Manager → everyone".

## Changed files

| File | Change |
|---|---|
| `tasks.py` | `human_input=True` on triage task; gate comments renumbered 1/2/3 |
| `tests/test_tasks.py` | Gate test asserts all three gates |
| `models.py` | Stale "Scout" comment |
| `README.md` | Diagram, gate count, project layout |
| `squad/*/backstory.md` (all 6) | Backstories rewritten to methodology |
| `squad/penetration_tester/description.md` | OWASP Testing Guide v4.2; Top 10 classification |
| `squad/penetration_tester/expected_output.md` | OWASP Top 10 category in vuln_class |
| `squad/vulnerability_researcher/description.md` | FIRST.org CVSS 3.1; conservative scoring; CWE mapping |
| `squad/vulnerability_researcher/expected_output.md` | CVSS 3.1 vector + base score; CWE identifier |
| `squad/technical_author/description.md` | H1 first-read triage as quality bar; OWASP/CWE citations |

## Test plan

- [ ] `python main.py --dry-run` — verify all three gates shown with "▶ pauses for feedback"
- [ ] Read each updated `backstory.md` — confirm no fictional credentials remain
- [ ] Read each updated `description.md` — confirm standards references are present and accurate
- [ ] Run full CI stack: `ruff check .`, `ruff format --check .`, `mypy . --ignore-missing-imports`, `pytest -m unit --cov`, `bandit -c pyproject.toml -r . -q`
