### PR TITLE
feat: CYBERSQUAD_HUMAN_INPUT controls all human_input gates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,5 +21,8 @@ NUCLEI_RATE_LIMIT=10
 SQLMAP_OUTPUT_DIR=/tmp/sqlmap-output
 
 
+# ── Human-in-the-loop ────────────────────────────────────────
+CYBERSQUAD_HUMAN_INPUT=true  # set false to run fully automated (e.g. in a container)
+
 # ── Debug ────────────────────────────────────────────────────
 VERBOSE=false

--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,7 @@ NUCLEI_RATE_LIMIT=10
 SQLMAP_OUTPUT_DIR=/tmp/sqlmap-output
 
 
-CYBERSQUAD_HUMAN_INPUT=true  # set false to run fully automated (e.g. in a container)
+CYBERSQUAD_HUMAN_INPUT=true  # set false for unattended runs
 
 # -- Debug ----------------------------------------------------
 VERBOSE=false

--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,6 @@ NUCLEI_RATE_LIMIT=10
 SQLMAP_OUTPUT_DIR=/tmp/sqlmap-output
 
 
-# ── Human-in-the-loop ────────────────────────────────────────
 CYBERSQUAD_HUMAN_INPUT=true  # set false to run fully automated (e.g. in a container)
 
 # ── Debug ────────────────────────────────────────────────────

--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,19 @@
-# ── HackerOne API ────────────────────────────────────────────
+# -- HackerOne API --------------------------------------------
 H1_API_USERNAME=your_h1_username
 H1_API_TOKEN=your_h1_api_token
 
-# ── LLM ──────────────────────────────────────────────────────
+# -- LLM ------------------------------------------------------
 ANTHROPIC_API_KEY=your_anthropic_api_key
 CREWAI_MODEL=claude-sonnet-4-20250514
 CREWAI_TEMPERATURE=0.2
 
-# ── Pipeline tuning ──────────────────────────────────────────
+# -- Pipeline tuning ------------------------------------------
 H1_MIN_BOUNTY=500        # ignore programmes paying less than this (USD)
 H1_MAX_PROGRAMMES=10     # how many programmes to evaluate per run
 MIN_SEVERITY=medium      # low | medium | high | critical
 SCAN_DELAY=0.5           # seconds between requests
 
-# ── Paths ────────────────────────────────────────────────────
+# -- Paths ----------------------------------------------------
 REPORTS_DIR=./reports
 NUCLEI_TEMPLATES=~/.local/nuclei-templates
 RECON_WORDLIST=/usr/share/seclists/Discovery/DNS/subdomains-top1million-5000.txt
@@ -23,5 +23,5 @@ SQLMAP_OUTPUT_DIR=/tmp/sqlmap-output
 
 CYBERSQUAD_HUMAN_INPUT=true  # set false to run fully automated (e.g. in a container)
 
-# ── Debug ────────────────────────────────────────────────────
+# -- Debug ----------------------------------------------------
 VERBOSE=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Install dev dependencies
         run: pip install -e ".[dev]"
 
-      - name: ruff — lint
+      - name: ruff - lint
         run: ruff check .
 
-      - name: ruff — format check
+      - name: ruff - format check
         run: ruff format --check .
 
-      - name: mypy — type check
+      - name: mypy - type check
         run: mypy . --ignore-missing-imports
 
   test:
@@ -69,10 +69,10 @@ jobs:
       - name: Install SAST tools
         run: pip install bandit[toml] semgrep
 
-      - name: bandit — security lint
+      - name: bandit - security lint
         run: bandit -c pyproject.toml -r . -q
 
-      - name: semgrep — SAST scan
+      - name: semgrep - SAST scan
         run: >
           semgrep scan
           --config=p/python

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ build/
 venv/
 env/
 
-# Reports output (contain vuln data — never commit)
+# Reports output (contain vuln data - never commit)
 reports/
 
 # Tool artefacts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Bounty Squad — AI Contributor Guide
+# Bounty Squad - AI Contributor Guide
 
 This file is for AI assistants working on this codebase. It covers the architecture, conventions, safety invariants, and the things most likely to trip you up.
 
@@ -6,7 +6,7 @@ This file is for AI assistants working on this codebase. It covers the architect
 
 ---
 
-## Before you push — non-negotiable
+## Before you push - non-negotiable
 
 1. **Work inside a virtualenv with the full dev deps installed.**
 
@@ -15,7 +15,7 @@ This file is for AI assistants working on this codebase. It covers the architect
    .venv/bin/pip install -e ".[dev]"
    ```
 
-   If you skip this, `mypy` will silently pass locally because it can't resolve `crewai`, `crewai.tools`, or `langchain_anthropic` — and CI will then fail on type errors you never saw. Every other tool is similarly affected. **No venv, no valid local signal.**
+   If you skip this, `mypy` will silently pass locally because it can't resolve `crewai`, `crewai.tools`, or `langchain_anthropic` - and CI will then fail on type errors you never saw. Every other tool is similarly affected. **No venv, no valid local signal.**
 
 2. **Run the entire CI stack locally, in order, before every push.** A ruff pass alone is not enough. The full set:
 
@@ -27,7 +27,7 @@ This file is for AI assistants working on this codebase. It covers the architect
    .venv/bin/bandit -c pyproject.toml -r . -q
    ```
 
-   All five must pass. If any fail, fix before pushing — never "push and let CI tell me".
+   All five must pass. If any fail, fix before pushing - never "push and let CI tell me".
 
 3. **Never push a change you haven't actually executed.** A passing mypy run after a `type: ignore` removal means nothing if the file wasn't reachable. Run the tests.
 
@@ -43,11 +43,11 @@ Bounty Squad is a six-agent CrewAI pipeline that autonomously selects HackerOne 
 
 | File | Purpose |
 |---|---|
-| `main.py` | CLI entrypoint. Calls `check_env()` before importing crew — keep it that way. |
+| `main.py` | CLI entrypoint. Calls `check_env()` before importing crew - keep it that way. |
 | `config.py` | All env-var reading lives here. Singleton: `from config import config`. |
-| `models.py` | Pydantic contracts between agents. Change these carefully — they cross agent boundaries. |
+| `models.py` | Pydantic contracts between agents. Change these carefully - they cross agent boundaries. |
 | `crew.py` | Assembles the `Crew`: builds LLM, agents, tasks. No module-level side effects. |
-| `tasks.py` | Pipeline wiring — context dependencies and `human_input` gates. Thin — keep it that way. |
+| `tasks.py` | Pipeline wiring - context dependencies and `human_input` gates. Thin - keep it that way. |
 | `squad/__init__.py` | `SquadMember` dataclass + `build_agent()` / `build_task()` helpers. Each helper reads prose from a single-purpose `.md` file. |
 | `squad/<member>/{role,goal,backstory}.md` | Three single-purpose files driving the CrewAI Agent. Edit to tune agent behaviour. |
 | `squad/<member>/{description,expected_output}.md` | Two single-purpose files driving the Task description and expected output. |
@@ -61,21 +61,25 @@ Bounty Squad is a six-agent CrewAI pipeline that autonomously selects HackerOne 
 
 ## Conventions
 
+### ASCII only
+
+All source files, comments, docstrings, and prose (.md) files must use plain ASCII. No Unicode decorative characters: no em dashes, en dashes, curly quotes, box-drawing characters, arrows, bullets, or emoji. Use `-` not `--` or `-`, `->` not `->`, `|` not `|`. This is not a style preference - Unicode in source files inflates token counts for every AI tool that reads this codebase, wasting money and energy. Violations will be caught in code review.
+
 ### Config
 
-All environment variables are read in `config.py` using `field(default_factory=lambda: ...)`. This is intentional — it means values are read at instantiation time, not at class-definition time, which lets `monkeypatch.setenv()` work correctly in tests. Do not change field defaults to bare expressions.
+All environment variables are read in `config.py` using `field(default_factory=lambda: ...)`. This is intentional - it means values are read at instantiation time, not at class-definition time, which lets `monkeypatch.setenv()` work correctly in tests. Do not change field defaults to bare expressions.
 
 ```python
 # correct
 max_programmes: int = field(default_factory=lambda: int(os.getenv("H1_MAX_PROGRAMMES", "10")))
 
-# wrong — evaluated once at import time, monkeypatch has no effect
+# wrong - evaluated once at import time, monkeypatch has no effect
 max_programmes: int = int(os.getenv("H1_MAX_PROGRAMMES", "10"))
 ```
 
 ### Models
 
-Use `StrEnum` (not `(str, Enum)`) for string enumerations — ruff rule UP042 enforces this. Use `X | None` not `Optional[X]`. Use `model_copy(update={...})` in tests to create variants.
+Use `StrEnum` (not `(str, Enum)`) for string enumerations - ruff rule UP042 enforces this. Use `X | None` not `Optional[X]`. Use `model_copy(update={...})` in tests to create variants.
 
 ### Agents
 
@@ -96,9 +100,9 @@ Each agent's prose lives in five single-purpose markdown files inside its packag
 
 ---
 
-## Safety invariants — do not break these
+## Safety invariants - do not break these
 
-**Scope enforcement** — `filter_in_scope()` in `recon_tools.py` uses an exact-match or dot-boundary check:
+**Scope enforcement** - `filter_in_scope()` in `recon_tools.py` uses an exact-match or dot-boundary check:
 
 ```python
 if host == pattern or host.endswith("." + pattern):
@@ -106,11 +110,11 @@ if host == pattern or host.endswith("." + pattern):
 
 A bare `host.endswith(pattern)` would allow `evil.notexample.com` to match `example.com`. Do not simplify this.
 
-**Automated-scanning gate** — `parse_programme()` in `h1_api.py` sets `allows_automated_scanning=False` when the policy text contains keywords like "no automated" or "automated scanning prohibited". The Programme Manager is instructed to discard such programmes. Do not remove or weaken this check.
+**Automated-scanning gate** - `parse_programme()` in `h1_api.py` sets `allows_automated_scanning=False` when the policy text contains keywords like "no automated" or "automated scanning prohibited". The Programme Manager is instructed to discard such programmes. Do not remove or weaken this check.
 
-**Import order in `main.py`** — `check_env()` must run before `build_crew()` is imported or called. The crew import triggers `crew.py`, which imports `config`, which reads env vars. If credentials are missing, `check_env()` should exit cleanly before that happens.
+**Import order in `main.py`** - `check_env()` must run before `build_crew()` is imported or called. The crew import triggers `crew.py`, which imports `config`, which reads env vars. If credentials are missing, `check_env()` should exit cleanly before that happens.
 
-**No module-level side effects in `crew.py`** — the old `crew = build_crew()` at module level has been deliberately removed. Do not re-introduce it.
+**No module-level side effects in `crew.py`** - the old `crew = build_crew()` at module level has been deliberately removed. Do not re-introduce it.
 
 ---
 
@@ -122,7 +126,7 @@ All tests are marked `@pytest.mark.unit` and must run without network access, re
 H1_API_USERNAME=test H1_API_TOKEN=test pytest -m unit
 ```
 
-Tests that reload modules for config isolation use `importlib.reload()` — this is the correct pattern for testing env-var-backed dataclasses.
+Tests that reload modules for config isolation use `importlib.reload()` - this is the correct pattern for testing env-var-backed dataclasses.
 
 Coverage floor is 70%. Every new public function in `tools/` needs a test. Every bug fix needs a regression test.
 
@@ -131,9 +135,9 @@ Coverage floor is 70%. Every new public function in `tools/` needs a test. Every
 ## Adding a new agent
 
 1. Create `squad/<role-name>/` with:
-   - `__init__.py` — `@tool` functions + `MEMBER = SquadMember(slug=..., dir=Path(__file__).parent, tools=[...])`
-   - `role.md`, `goal.md`, `backstory.md` — drive the CrewAI Agent
-   - `description.md`, `expected_output.md` — drive the Task
+   - `__init__.py` - `@tool` functions + `MEMBER = SquadMember(slug=..., dir=Path(__file__).parent, tools=[...])`
+   - `role.md`, `goal.md`, `backstory.md` - drive the CrewAI Agent
+   - `description.md`, `expected_output.md` - drive the Task
 2. Import the new `MEMBER` into `_SQUAD` in `crew.py`.
 3. Wire its task into `build_tasks()` in `tasks.py` with correct `context` dependencies.
 4. Add unit tests covering the new tool's logic.
@@ -144,28 +148,28 @@ Coverage floor is 70%. Every new public function in `tools/` needs a test. Every
 
 1. Add a field to the appropriate dataclass in `config.py` using `default_factory=lambda: os.getenv(...)`.
 2. Document it in `.env.example` with a comment explaining valid values.
-3. If the value is used in a tool, thread it through via `config.<section>.<field>` — do not hardcode fallback values in the tool.
+3. If the value is used in a tool, thread it through via `config.<section>.<field>` - do not hardcode fallback values in the tool.
 
 ---
 
 ## CI
 
-Three jobs run on every push: `lint` (ruff + mypy), `test` (pytest, 70% coverage floor), and `sast` (bandit + semgrep). The local commands in the "Before you push" section above mirror them exactly — use those.
+Three jobs run on every push: `lint` (ruff + mypy), `test` (pytest, 70% coverage floor), and `sast` (bandit + semgrep). The local commands in the "Before you push" section above mirror them exactly - use those.
 
 Notes on fixing findings:
 
-- **ruff** — `ruff check --fix` and `ruff format` resolve most issues automatically.
-- **mypy** — ensure all public functions have annotated parameters and return types. If a real dep (crewai, pydantic) has incomplete stubs and you need to suppress a false positive, use a targeted `# type: ignore[<code>]` rather than a blanket ignore.
-- **bandit** — suppress with `# nosec B<code>` (bandit's own directive, *not* `# noqa`). Keep the accompanying `# noqa: S<code>` for ruff — both are needed:
+- **ruff** - `ruff check --fix` and `ruff format` resolve most issues automatically.
+- **mypy** - ensure all public functions have annotated parameters and return types. If a real dep (crewai, pydantic) has incomplete stubs and you need to suppress a false positive, use a targeted `# type: ignore[<code>]` rather than a blanket ignore.
+- **bandit** - suppress with `# nosec B<code>` (bandit's own directive, *not* `# noqa`). Keep the accompanying `# noqa: S<code>` for ruff - both are needed:
 
   ```python
   os.getenv("FOO", "/tmp/bar")  # nosec B108  # noqa: S108
   ```
 
-- **GitHub Actions pins** — every action must be pinned to a full-length commit SHA, not a tag. Branch protection enforces this. Add the version as a trailing comment for readability:
+- **GitHub Actions pins** - every action must be pinned to a full-length commit SHA, not a tag. Branch protection enforces this. Add the version as a trailing comment for readability:
 
   ```yaml
   - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
   ```
 
-- **upload-artifact v4 and hidden files** — `.coverage` and other dotfiles are skipped by default. Set `include-hidden-files: true` on the step.
+- **upload-artifact v4 and hidden files** - `.coverage` and other dotfiles are skipped by default. Set `include-hidden-files: true` on the step.

--- a/README.md
+++ b/README.md
@@ -9,22 +9,7 @@ An autonomous bug bounty pipeline powered by [CrewAI](https://github.com/crewAII
 ## How it works
 
 ```
-Programme Manager ──▶ [selection gate] ──▶ OSINT Analyst ──▶ Penetration Tester
-                                                                        │
-                                                                        ▼
-                                          [triage gate] ◀── Vulnerability Researcher
-                                                 │
-                                                 ▼
-                                         Technical Author
-                                                 │
-                                                 ▼
-                                       [submission gate]
-                                                 │
-                                                 ▼
-                                      Disclosure Coordinator
-                                                 │
-                                                 ▼
-                                           HackerOne API
+Programme Manager ──▶ OSINT Analyst ──▶ Penetration Tester ──▶ Vulnerability Researcher ──▶ Technical Author ──▶ Disclosure Coordinator ──▶ HackerOne API
 ```
 
 With `CYBERSQUAD_HUMAN_INPUT=true` (the default) the pipeline pauses after programme selection, triage, and report writing, and waits for your confirmation before continuing. Set it to `false` for fully automated runs (e.g. in a container).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An autonomous bug bounty pipeline powered by [CrewAI](https://github.com/crewAII
 Programme Manager --> OSINT Analyst --> Penetration Tester --> Vulnerability Researcher --> Technical Author --> Disclosure Coordinator --> HackerOne API
 ```
 
-With `CYBERSQUAD_HUMAN_INPUT=true` (the default) the pipeline pauses after programme selection, triage, and report writing, and waits for your confirmation before continuing. Set it to `false` for fully automated runs (e.g. in a container).
+With `CYBERSQUAD_HUMAN_INPUT=true` (the default) the pipeline pauses after programme selection, triage, and report writing, and waits for your confirmation before continuing. Set it to `false` for unattended runs.
 
 | Agent | Responsibility | Tools |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cybersquad
 
-An autonomous bug bounty pipeline powered by [CrewAI](https://github.com/crewAIInc/crewAI) and Claude. Six AI agents model a full-stack security team: they select HackerOne programmes, map attack surface, run vulnerability scans, triage findings, write professional disclosure reports, and submit them — all in a sequential, auditable pipeline with human approval gates.
+An autonomous bug bounty pipeline powered by [CrewAI](https://github.com/crewAIInc/crewAI) and Claude. Six AI agents model a full-stack security team: they select HackerOne programmes, map attack surface, run vulnerability scans, triage findings, write professional disclosure reports, and submit them — all in a sequential, auditable pipeline.
 
 > **Legal notice** — You are solely responsible for ensuring every target is in scope, every scan is authorised, and every submission is accurate. Never disable or bypass the approval checkpoints.
 
@@ -27,7 +27,7 @@ Programme Manager ──▶ [selection gate] ──▶ OSINT Analyst ──▶ P
                                            HackerOne API
 ```
 
-At each approval gate the pipeline pauses, renders a summary of what the agent produced, and waits for your explicit confirmation before continuing.
+With `CYBERSQUAD_HUMAN_INPUT=true` (the default) the pipeline pauses after programme selection, triage, and report writing, and waits for your confirmation before continuing. Set it to `false` for fully automated runs (e.g. in a container).
 
 | Agent | Responsibility | Tools |
 |---|---|---|
@@ -100,6 +100,7 @@ ANTHROPIC_API_KEY=your-anthropic-key
 | `SCAN_DELAY` | `0.5` | Seconds between scan requests |
 | `NUCLEI_RATE_LIMIT` | `10` | Nuclei requests per second |
 | `REPORTS_DIR` | `./reports` | Directory for generated report files |
+| `CYBERSQUAD_HUMAN_INPUT` | `true` | Pause for operator approval between stages; set `false` for automated runs |
 
 ---
 
@@ -109,14 +110,15 @@ ANTHROPIC_API_KEY=your-anthropic-key
 # Preview agents, tools, and pipeline order — no execution, no API calls
 python main.py --dry-run
 
-# Full run with interactive approval checkpoints
+# Full run (pauses for human approval at each stage by default)
 python main.py
+
+# Fully automated — no pauses
+CYBERSQUAD_HUMAN_INPUT=false python main.py
 
 # Verbose LLM output
 python main.py --verbose
 ```
-
-The pipeline pauses three times: after programme selection (before any scanning begins), after triage (before spending tokens on report writing), and after the report is written (before submission to H1). At each checkpoint a summary panel is displayed and you must explicitly approve to continue.
 
 Generated reports are saved to `REPORTS_DIR` as Markdown files.
 
@@ -217,7 +219,7 @@ Edit any of the five prose files in `squad/<member>/`: `role.md`, `goal.md`, `ba
 
 - **Only scan authorised targets.** The Programme Manager filters for programmes that explicitly permit automated scanning. Do not remove or weaken this check.
 - **Respect rate limits.** `SCAN_DELAY` and `NUCLEI_RATE_LIMIT` exist for a reason. Aggressive scanning can violate programme terms and get you banned.
-- **Read before you approve.** The approval checkpoints are not decorative. Review the programme selection and the report carefully before confirming each gate.
+- **Read before you approve.** When running with `CYBERSQUAD_HUMAN_INPUT=true`, review the programme selection and the report carefully before confirming each pause.
 - **Check for duplicates.** Submitting a known duplicate wastes triage time and reflects poorly on the submission record.
 - **Handle reports carefully.** The `reports/` directory contains vulnerability details and evidence. It is gitignored — do not commit or share its contents.
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # cybersquad
 
-An autonomous bug bounty pipeline powered by [CrewAI](https://github.com/crewAIInc/crewAI) and Claude. Six AI agents model a full-stack security team: they select HackerOne programmes, map attack surface, run vulnerability scans, triage findings, write professional disclosure reports, and submit them — all in a sequential, auditable pipeline.
+An autonomous bug bounty pipeline powered by [CrewAI](https://github.com/crewAIInc/crewAI) and Claude. Six AI agents model a full-stack security team: they select HackerOne programmes, map attack surface, run vulnerability scans, triage findings, write professional disclosure reports, and submit them - all in a sequential, auditable pipeline.
 
-> **Legal notice** — You are solely responsible for ensuring every target is in scope, every scan is authorised, and every submission is accurate. Never disable or bypass the approval checkpoints.
+> **Legal notice** - You are solely responsible for ensuring every target is in scope, every scan is authorised, and every submission is accurate. Never disable or bypass the approval checkpoints.
 
 ---
 
 ## How it works
 
 ```
-Programme Manager ──▶ OSINT Analyst ──▶ Penetration Tester ──▶ Vulnerability Researcher ──▶ Technical Author ──▶ Disclosure Coordinator ──▶ HackerOne API
+Programme Manager --> OSINT Analyst --> Penetration Tester --> Vulnerability Researcher --> Technical Author --> Disclosure Coordinator --> HackerOne API
 ```
 
 With `CYBERSQUAD_HUMAN_INPUT=true` (the default) the pipeline pauses after programme selection, triage, and report writing, and waits for your confirmation before continuing. Set it to `false` for fully automated runs (e.g. in a container).
@@ -19,8 +19,8 @@ With `CYBERSQUAD_HUMAN_INPUT=true` (the default) the pipeline pauses after progr
 | Programme Manager | Ranks H1 programmes by bounty value; verifies automated scanning is permitted | HackerOne API |
 | OSINT Analyst | Enumerates subdomains, live endpoints, and open ports | subfinder, httpx, nmap |
 | Penetration Tester | Runs templated and targeted scans against discovered surface | nuclei, sqlmap |
-| Vulnerability Researcher | Triages raw findings, assigns CVSS 3.1 scores, validates scope | — |
-| Technical Author | Renders complete HackerOne-format Markdown disclosure reports | — |
+| Vulnerability Researcher | Triages raw findings, assigns CVSS 3.1 scores, validates scope | - |
+| Technical Author | Renders complete HackerOne-format Markdown disclosure reports | - |
 | Disclosure Coordinator | Submits reports via H1 API and records submission metadata | HackerOne API |
 
 ---
@@ -29,7 +29,7 @@ With `CYBERSQUAD_HUMAN_INPUT=true` (the default) the pipeline pauses after progr
 
 **Python 3.12+**
 
-**External binaries** — install and ensure each is on your `PATH`:
+**External binaries** - install and ensure each is on your `PATH`:
 
 | Binary | Purpose |
 |---|---|
@@ -74,7 +74,7 @@ H1_API_TOKEN=your-h1-api-token
 ANTHROPIC_API_KEY=your-anthropic-key
 ```
 
-**Key tunables** (all have sensible defaults — see `.env.example` for the full list):
+**Key tunables** (all have sensible defaults - see `.env.example` for the full list):
 
 | Variable | Default | Purpose |
 |---|---|---|
@@ -92,13 +92,13 @@ ANTHROPIC_API_KEY=your-anthropic-key
 ## Running the pipeline
 
 ```bash
-# Preview agents, tools, and pipeline order — no execution, no API calls
+# Preview agents, tools, and pipeline order - no execution, no API calls
 python main.py --dry-run
 
 # Full run (pauses for human approval at each stage by default)
 python main.py
 
-# Fully automated — no pauses
+# Fully automated - no pauses
 CYBERSQUAD_HUMAN_INPUT=false python main.py
 
 # Verbose LLM output
@@ -113,33 +113,33 @@ Generated reports are saved to `REPORTS_DIR` as Markdown files.
 
 ```
 cybersquad/
-├── main.py            # CLI entrypoint
-├── crew.py            # Assembles LLM, agents, tasks, and approval gates
-├── tasks.py           # Pipeline wiring — context chaining and approval gates
-├── config.py          # Env-var-backed configuration (singleton: config.*)
-├── models.py          # Pydantic data contracts between agents
-│
-├── squad/             # One sub-package per agent
-│   ├── __init__.py    # SquadMember dataclass + build_agent() / build_task() helpers
-│   └── <member>/
-│       ├── __init__.py        # @tool functions + MEMBER = SquadMember(...) constant
-│       ├── role.md            # Agent role line
-│       ├── goal.md            # Agent goal (edit to tune behaviour)
-│       ├── backstory.md       # Agent backstory
-│       ├── description.md     # Task description
-│       └── expected_output.md # Task expected output
-│
-├── tools/
-│   ├── h1_api.py      # HackerOne REST client
-│   ├── metrics.py     # Token usage and cost tracking
-│   ├── recon_tools.py # subfinder / httpx / nmap wrappers + scope guard
-│   ├── report_tools.py# Markdown report renderer and file writer
-│   └── vuln_tools.py  # nuclei / sqlmap / custom check wrappers
-│
-├── tests/             # pytest unit tests (@pytest.mark.unit)
-├── proposals/         # Design proposals for upcoming features
-├── pyproject.toml
-└── .env.example
++-- main.py            # CLI entrypoint
++-- crew.py            # Assembles LLM, agents, tasks, and approval gates
++-- tasks.py           # Pipeline wiring - context chaining and approval gates
++-- config.py          # Env-var-backed configuration (singleton: config.*)
++-- models.py          # Pydantic data contracts between agents
+|
++-- squad/             # One sub-package per agent
+|   +-- __init__.py    # SquadMember dataclass + build_agent() / build_task() helpers
+|   +-- <member>/
+|       +-- __init__.py        # @tool functions + MEMBER = SquadMember(...) constant
+|       +-- role.md            # Agent role line
+|       +-- goal.md            # Agent goal (edit to tune behaviour)
+|       +-- backstory.md       # Agent backstory
+|       +-- description.md     # Task description
+|       +-- expected_output.md # Task expected output
+|
++-- tools/
+|   +-- h1_api.py      # HackerOne REST client
+|   +-- metrics.py     # Token usage and cost tracking
+|   +-- recon_tools.py # subfinder / httpx / nmap wrappers + scope guard
+|   +-- report_tools.py# Markdown report renderer and file writer
+|   +-- vuln_tools.py  # nuclei / sqlmap / custom check wrappers
+|
++-- tests/             # pytest unit tests (@pytest.mark.unit)
++-- proposals/         # Design proposals for upcoming features
++-- pyproject.toml
++-- .env.example
 ```
 
 ---
@@ -149,7 +149,7 @@ cybersquad/
 ### Tests
 
 ```bash
-# Unit tests — no network, no binaries, all mocked
+# Unit tests - no network, no binaries, all mocked
 H1_API_USERNAME=test H1_API_TOKEN=test pytest -m unit
 
 # With coverage
@@ -185,10 +185,10 @@ Edit any of the five prose files in `squad/<member>/`: `role.md`, `goal.md`, `ba
 
 ## Contributing
 
-- **Branch naming** — `feat/`, `fix/`, `chore/`, or `docs/` prefixes.
-- **One concern per PR** — a new agent, a new tool, a config change — not all three.
-- **No secrets in code** — credentials belong in `.env` (gitignored). New config fields go in `config.py` and must be documented in `.env.example`.
-- **Scope and safety** — changes to scanning behaviour must preserve rate-limiting and the scope guard in `recon_tools.py`. `filter_in_scope()` is a hard safety boundary; do not weaken it.
+- **Branch naming** - `feat/`, `fix/`, `chore/`, or `docs/` prefixes.
+- **One concern per PR** - a new agent, a new tool, a config change - not all three.
+- **No secrets in code** - credentials belong in `.env` (gitignored). New config fields go in `config.py` and must be documented in `.env.example`.
+- **Scope and safety** - changes to scanning behaviour must preserve rate-limiting and the scope guard in `recon_tools.py`. `filter_in_scope()` is a hard safety boundary; do not weaken it.
 
 ### CI jobs
 
@@ -206,10 +206,10 @@ Edit any of the five prose files in `squad/<member>/`: `role.md`, `goal.md`, `ba
 - **Respect rate limits.** `SCAN_DELAY` and `NUCLEI_RATE_LIMIT` exist for a reason. Aggressive scanning can violate programme terms and get you banned.
 - **Read before you approve.** When running with `CYBERSQUAD_HUMAN_INPUT=true`, review the programme selection and the report carefully before confirming each pause.
 - **Check for duplicates.** Submitting a known duplicate wastes triage time and reflects poorly on the submission record.
-- **Handle reports carefully.** The `reports/` directory contains vulnerability details and evidence. It is gitignored — do not commit or share its contents.
+- **Handle reports carefully.** The `reports/` directory contains vulnerability details and evidence. It is gitignored - do not commit or share its contents.
 
 ---
 
 ## Licence
 
-MIT — see `LICENSE`.
+MIT - see `LICENSE`.

--- a/config.py
+++ b/config.py
@@ -1,5 +1,5 @@
 """
-config.py — Central configuration for the Bounty Squad pipeline.
+config.py - Central configuration for the Bounty Squad pipeline.
 Load secrets from environment variables; never hardcode credentials.
 """
 
@@ -15,7 +15,7 @@ class H1Config:
     api_token: str = field(default_factory=lambda: os.environ["H1_API_TOKEN"])
     base_url: str = "https://api.hackerone.com/v1"
     # FIX: use default_factory so os.getenv is called at instantiation time,
-    # not at class-definition time — allows monkeypatch to work in tests
+    # not at class-definition time - allows monkeypatch to work in tests
     min_bounty_threshold: int = field(
         default_factory=lambda: int(os.getenv("H1_MIN_BOUNTY", "500"))
     )
@@ -73,7 +73,7 @@ class ScanConfig:
 
 @dataclass
 class AppConfig:
-    """Top-level application config — compose all sub-configs here."""
+    """Top-level application config - compose all sub-configs here."""
 
     h1: H1Config = field(default_factory=H1Config)
     llm: LLMConfig = field(default_factory=LLMConfig)
@@ -86,5 +86,5 @@ class AppConfig:
     )
 
 
-# Singleton — import this everywhere rather than re-instantiating
+# Singleton - import this everywhere rather than re-instantiating
 config = AppConfig()

--- a/config.py
+++ b/config.py
@@ -81,6 +81,9 @@ class AppConfig:
     scan: ScanConfig = field(default_factory=ScanConfig)
     reports_dir: str = field(default_factory=lambda: os.getenv("REPORTS_DIR", "./reports"))
     verbose: bool = field(default_factory=lambda: os.getenv("VERBOSE", "false").lower() == "true")
+    human_input: bool = field(
+        default_factory=lambda: os.getenv("CYBERSQUAD_HUMAN_INPUT", "true").lower() == "true"
+    )
 
 
 # Singleton — import this everywhere rather than re-instantiating

--- a/crew.py
+++ b/crew.py
@@ -1,5 +1,5 @@
 """
-crew.py — Assembles the Bounty Squad into a CrewAI Pipeline.
+crew.py - Assembles the Bounty Squad into a CrewAI Pipeline.
 
 Call build_crew() to get a fully wired crew, then crew.kickoff() to run it.
 """

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 """
-main.py — Bounty Squad pipeline entrypoint.
+main.py - Bounty Squad pipeline entrypoint.
 
 Usage:
     python main.py             # single run, settings from .env / env vars
@@ -51,7 +51,7 @@ logger = logging.getLogger("bounty_squad")
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Bounty Squad — autonomous bug bounty pipeline",
+        description="Bounty Squad - autonomous bug bounty pipeline",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
     )
@@ -71,7 +71,7 @@ def check_env() -> None:
 
 def dry_run_summary(crew: Any) -> None:  # noqa: ANN401
     """Render the crew layout as rich tables without executing."""
-    console.rule("[bold cyan]BOUNTY SQUAD — DRY RUN[/bold cyan]")
+    console.rule("[bold cyan]BOUNTY SQUAD - DRY RUN[/bold cyan]")
     console.print()
 
     agents_table = Table(show_header=True, header_style="bold", box=None, padding=(0, 2))
@@ -90,11 +90,11 @@ def dry_run_summary(crew: Any) -> None:  # noqa: ANN401
     tasks_table.add_column("Task")
     tasks_table.add_column("Human review")
     for i, task in enumerate(crew.tasks):
-        review_cell = "[yellow]▶ pauses for feedback[/yellow]" if task.human_input else ""
+        review_cell = "[yellow]> pauses for feedback[/yellow]" if task.human_input else ""
         tasks_table.add_row(
             str(i + 1),
             task.agent.role,
-            task.description[:72].strip() + "…",
+            task.description[:72].strip() + "...",
             review_cell,
         )
     console.print(Panel(tasks_table, title="Pipeline  [dim](sequential)[/dim]"))

--- a/models.py
+++ b/models.py
@@ -11,9 +11,7 @@ from enum import StrEnum
 
 from pydantic import BaseModel, Field
 
-# ---------------------------------------------------------------------------
 # Enumerations
-# ---------------------------------------------------------------------------
 
 
 class Severity(StrEnum):
@@ -44,9 +42,7 @@ class SubmissionStatus(StrEnum):
     INFORMATIVE = "informative"
 
 
-# ---------------------------------------------------------------------------
 # Programme selection (Programme Manager -> everyone)
-# ---------------------------------------------------------------------------
 
 
 class ScopeItem(BaseModel):
@@ -72,9 +68,7 @@ class Programme(BaseModel):
     selected_at: datetime = Field(default_factory=datetime.utcnow)
 
 
-# ---------------------------------------------------------------------------
 # Recon (OSINT Analyst -> Penetration Tester)
-# ---------------------------------------------------------------------------
 
 
 class Endpoint(BaseModel):
@@ -98,9 +92,7 @@ class ReconResult(BaseModel):
     completed_at: datetime = Field(default_factory=datetime.utcnow)
 
 
-# ---------------------------------------------------------------------------
 # Vulnerability findings (Penetration Tester -> Vulnerability Researcher)
-# ---------------------------------------------------------------------------
 
 
 class RawFinding(BaseModel):
@@ -132,9 +124,7 @@ class VerifiedVulnerability(BaseModel):
     confirmed_at: datetime = Field(default_factory=datetime.utcnow)
 
 
-# ---------------------------------------------------------------------------
 # Report (Technical Author -> Disclosure Coordinator)
-# ---------------------------------------------------------------------------
 
 
 class DisclosureReport(BaseModel):
@@ -152,9 +142,7 @@ class DisclosureReport(BaseModel):
     authored_at: datetime = Field(default_factory=datetime.utcnow)
 
 
-# ---------------------------------------------------------------------------
 # Submission (Disclosure Coordinator)
-# ---------------------------------------------------------------------------
 
 
 class SubmissionResult(BaseModel):
@@ -167,9 +155,7 @@ class SubmissionResult(BaseModel):
     error: str | None = None
 
 
-# ---------------------------------------------------------------------------
 # Operational metrics (emitted after every pipeline run)
-# ---------------------------------------------------------------------------
 
 
 class RunMetrics(BaseModel):

--- a/models.py
+++ b/models.py
@@ -1,5 +1,5 @@
 """
-models.py — Pydantic data models shared across the entire pipeline.
+models.py - Pydantic data models shared across the entire pipeline.
 
 Each model represents a discrete artefact that agents pass to one another.
 """
@@ -45,7 +45,7 @@ class SubmissionStatus(StrEnum):
 
 
 # ---------------------------------------------------------------------------
-# Programme selection (Programme Manager → everyone)
+# Programme selection (Programme Manager -> everyone)
 # ---------------------------------------------------------------------------
 
 
@@ -73,7 +73,7 @@ class Programme(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# Recon (OSINT Analyst → Penetration Tester)
+# Recon (OSINT Analyst -> Penetration Tester)
 # ---------------------------------------------------------------------------
 
 
@@ -99,7 +99,7 @@ class ReconResult(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# Vulnerability findings (Penetration Tester → Vulnerability Researcher)
+# Vulnerability findings (Penetration Tester -> Vulnerability Researcher)
 # ---------------------------------------------------------------------------
 
 
@@ -133,7 +133,7 @@ class VerifiedVulnerability(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# Report (Technical Author → Disclosure Coordinator)
+# Report (Technical Author -> Disclosure Coordinator)
 # ---------------------------------------------------------------------------
 
 

--- a/proposals/dockerised-infra.md
+++ b/proposals/dockerised-infra.md
@@ -5,15 +5,15 @@
 The scan tools (subfinder, httpx, nmap, nuclei, sqlmap) are currently assumed
 to be on `PATH`. This has several failure modes:
 
-- **Version drift** — different machines run different tool versions, producing
+- **Version drift** - different machines run different tool versions, producing
   inconsistent results and CI failures
-- **Blast radius** — a misconfigured scan tool running on the host has access
+- **Blast radius** - a misconfigured scan tool running on the host has access
   to the operator's entire network namespace
-- **No resource limits** — a runaway nuclei or sqlmap job can saturate the
+- **No resource limits** - a runaway nuclei or sqlmap job can saturate the
   host's CPU/network indefinitely
-- **No audit trail** — tool invocations are not captured anywhere beyond
+- **No audit trail** - tool invocations are not captured anywhere beyond
   application logs
-- **Observability gap** — token cost and HTTP metrics are tracked in
+- **Observability gap** - token cost and HTTP metrics are tracked in
   `tools/metrics.py`, but scan volume, tool runtimes, and per-programme cost
   are invisible
 
@@ -22,22 +22,22 @@ to be on `PATH`. This has several failure modes:
 ## Proposed architecture
 
 ```
-┌──────────────────────────────────────────────────────────────────────────┐
-│  docker-compose.yml                                                      │
-│                                                                          │
-│  ┌──────────────┐   ┌──────────────┐   ┌──────────────────────────────┐ │
-│  │  bounty-squad │   │  scan-runner │   │  observability               │ │
-│  │  (Python app) │──▶│  (tools only)│   │  ┌──────────┐  ┌──────────┐ │ │
-│  │               │   │              │   │  │Prometheus│  │ Langfuse │ │ │
-│  │  Port: none   │   │  subfinder   │   │  └────┬─────┘  │ Port:3000│ │ │
-│  │  Net: internal│   │  httpx       │   │       │         └────┬─────┘ │ │
-│  └──────────────┘   │  nmap        │   │  ┌────▼─────┐        │       │ │
-│                      │  nuclei      │   │  │ Grafana  │   ┌────▼─────┐ │ │
-│                      │  sqlmap      │   │  │ Port:3001│   │Postgres  │ │ │
-│                      │              │   │  └──────────┘   └──────────┘ │ │
-│                      │  Net: scan   │   └──────────────────────────────┘ │
-│                      └──────────────┘                                    │
-└──────────────────────────────────────────────────────────────────────────┘
++--------------------------------------------------------------------------+
+|  docker-compose.yml                                                      |
+|                                                                          |
+|  +--------------+   +--------------+   +------------------------------+ |
+|  |  bounty-squad |   |  scan-runner |   |  observability               | |
+|  |  (Python app) |-->|  (tools only)|   |  +----------+  +----------+ | |
+|  |               |   |              |   |  |Prometheus|  | Langfuse | | |
+|  |  Port: none   |   |  subfinder   |   |  +----+-----+  | Port:3000| | |
+|  |  Net: internal|   |  httpx       |   |       |         +----+-----+ | |
+|  +--------------+   |  nmap        |   |  +----▼-----+        |       | |
+|                      |  nuclei      |   |  | Grafana  |   +----▼-----+ | |
+|                      |  sqlmap      |   |  | Port:3001|   |Postgres  | | |
+|                      |              |   |  +----------+   +----------+ | |
+|                      |  Net: scan   |   +------------------------------+ |
+|                      +--------------+                                    |
++--------------------------------------------------------------------------+
 ```
 
 ### Networks
@@ -45,10 +45,10 @@ to be on `PATH`. This has several failure modes:
 | Network | Purpose |
 |---|---|
 | `internal` | App ↔ scan-runner communication only. No internet access. |
-| `scan` | scan-runner → target hosts. Egress only, no inbound. |
-| `observability` | App + scan-runner → Prometheus push gateway. Isolated. |
+| `scan` | scan-runner -> target hosts. Egress only, no inbound. |
+| `observability` | App + scan-runner -> Prometheus push gateway. Isolated. |
 
-The application container has **no direct internet access** — all outbound
+The application container has **no direct internet access** - all outbound
 traffic goes through the scan-runner. This means a prompt-injection attack that
 tricks an agent into making an arbitrary HTTP call is blocked at the network
 layer.
@@ -80,7 +80,7 @@ POST /scan/sqlmap      {"url": "...", "params": [...], ...}
 
 Each endpoint:
 1. Validates the request against the scope guard (same `filter_in_scope` logic,
-   but enforced server-side — belt and braces)
+   but enforced server-side - belt and braces)
 2. Runs the tool with pre-pinned binary versions
 3. Streams stdout/stderr to structured logs
 4. Returns parsed JSON output
@@ -93,7 +93,7 @@ downloads, not `apt install`. This guarantees reproducibility.
 
 Standard `prom/prometheus` and `grafana/grafana` images, version-pinned.
 Grafana on port 3001 (Langfuse takes 3000). Datasource and dashboards
-provisioned via config files — no manual setup.
+provisioned via config files - no manual setup.
 
 | Dashboard | Key panels |
 |---|---|
@@ -102,11 +102,11 @@ provisioned via config files — no manual setup.
 | **Programme ROI** | Estimated bounty / actual cost ratio per programme |
 | **Rate limiting** | Requests/sec vs configured `SCAN_DELAY`, 429 count |
 
-### `langfuse` + `postgres` — LLM observability
+### `langfuse` + `postgres` - LLM observability
 
 [Langfuse](https://langfuse.com) is self-hosted, open-source, and provides
 per-run traces of every LLM call: prompt sent, tool calls made, response
-received, token counts, latency. This is the layer Prometheus can't give you —
+received, token counts, latency. This is the layer Prometheus can't give you -
 *why* the agent made a decision, not just *that* it did.
 
 **Service setup:**
@@ -131,11 +131,11 @@ postgres:
   volumes: ["postgres_data:/var/lib/postgresql/data"]
 ```
 
-**Python integration** — add `langfuse` to dependencies and configure the
+**Python integration** - add `langfuse` to dependencies and configure the
 LangChain callback (zero application code changes required):
 
 ```python
-# crew.py — one addition to build_crew()
+# crew.py - one addition to build_crew()
 from langfuse.callback import CallbackHandler
 
 langfuse_handler = CallbackHandler()   # reads LANGFUSE_* env vars
@@ -143,7 +143,7 @@ return Crew(..., callbacks=[langfuse_handler])
 ```
 
 Each pipeline run then appears in the Langfuse UI as a trace tree:
-`build_crew → ProgrammeManager → [tool: list_programmes] → ...`
+`build_crew -> ProgrammeManager -> [tool: list_programmes] -> ...`
 
 **New env vars:**
 
@@ -171,13 +171,13 @@ entrypoint, then drops to a non-root user.
 
 ## Changes required in the Python codebase
 
-1. `tools/recon_tools.py` — replace `subprocess.run(["subfinder", ...])` etc.
+1. `tools/recon_tools.py` - replace `subprocess.run(["subfinder", ...])` etc.
    with `httpx.post(f"{config.scan_runner_url}/scan/subfinder", ...)`. The
    scope guard moves to the scan-runner, but keep a client-side check too.
-2. `tools/vuln_tools.py` — same pattern for nuclei and sqlmap.
-3. `config.py` — add `scan_runner_url: str` field.
-4. `tools/metrics.py` — add Prometheus push client for scan metrics.
-5. Tests — `scan_runner_url` defaults to a mock server in unit tests (no change
+2. `tools/vuln_tools.py` - same pattern for nuclei and sqlmap.
+3. `config.py` - add `scan_runner_url: str` field.
+4. `tools/metrics.py` - add Prometheus push client for scan metrics.
+5. Tests - `scan_runner_url` defaults to a mock server in unit tests (no change
    to existing test structure needed; just add `conftest.py` fixture for the
    mock server URL).
 
@@ -212,7 +212,7 @@ observability/
 - Scan-runner runs as UID 1000, no `CAP_NET_ADMIN` except for the `iptables`
   setup step (which runs as root then drops privileges)
 - All tool binaries are verified by SHA-256 at image build time
-- The scan-runner API has no authentication (internal network only) — add mTLS
+- The scan-runner API has no authentication (internal network only) - add mTLS
   if the deployment moves to a multi-tenant environment
 - `sqlmap` is explicitly rate-limited server-side regardless of client config
   (`--delay` enforced, `--risk` capped at 1 by the server)

--- a/proposals/pr-agent-and-disclosure.md
+++ b/proposals/pr-agent-and-disclosure.md
@@ -3,7 +3,7 @@
 ## Problem
 
 The squad currently discloses silently. There is no mechanism to leverage
-successful disclosures for reputation, audience-building, or revenue — all of
+successful disclosures for reputation, audience-building, or revenue - all of
 which feed back into programme selection quality and operator trust.
 
 Separately, the DisclosureCoordinator has no structured hand-off protocol: it
@@ -14,18 +14,18 @@ coordinated-disclosure windows, or public announcement triggers.
 
 ## Proposed additions
 
-### 1. DisclosureCoordinator — extended responsibilities
+### 1. DisclosureCoordinator - extended responsibilities
 
 Extend (not replace) the existing agent with:
 
-- **Patch-tracking loop** — after submission, poll H1 API for report state
-  transitions (`triaged` → `resolved`). Store state in a lightweight JSON
+- **Patch-tracking loop** - after submission, poll H1 API for report state
+  transitions (`triaged` -> `resolved`). Store state in a lightweight JSON
   sidecar alongside the report file.
-- **Disclosure window management** — record submission date, programme's stated
+- **Disclosure window management** - record submission date, programme's stated
   disclosure window (default 90 days), and whether the programme permits public
   disclosure at all. Surface a `disclosure_eligible: bool` flag when the window
   expires or the programme explicitly grants disclosure.
-- **Structured hand-off** — when `disclosure_eligible=True`, emit a
+- **Structured hand-off** - when `disclosure_eligible=True`, emit a
   `DisclosureAnnouncement` model (see below) and pass it to the PR Agent as
   context.
 
@@ -49,14 +49,14 @@ class DisclosureAnnouncement:
 
 ---
 
-### 2. PublicRelationsAgent — new squad member
+### 2. PublicRelationsAgent - new squad member
 
 **Role:** tweet about resolved disclosures in a way that builds the squad's
 reputation and, over time, audience.
 
 **Revenue model:** a public track record of quality disclosures:
 - Attracts higher-paying programmes to engage the squad directly
-- Drives followers who share write-ups (social proof → more H1 upvotes)
+- Drives followers who share write-ups (social proof -> more H1 upvotes)
 - Potential sponsored content from security tooling vendors (longer-term)
 
 **Tools:**
@@ -64,7 +64,7 @@ reputation and, over time, audience.
 | Tool | Purpose |
 |---|---|
 | `post_tweet_tool` | Posts to X/Twitter via API v2. Requires `TWITTER_BEARER_TOKEN`, `TWITTER_ACCESS_TOKEN`, `TWITTER_ACCESS_SECRET`. |
-| `draft_tweet_tool` | Generates tweet text from `DisclosureAnnouncement` without posting — for dry-run / review. |
+| `draft_tweet_tool` | Generates tweet text from `DisclosureAnnouncement` without posting - for dry-run / review. |
 | `get_tweet_metrics_tool` | Fetches impressions, likes, retweets for previously posted tweets. Feeds into future programme selection scoring. |
 
 **Tweet strategy constraints (baked into prompt):**
@@ -72,11 +72,11 @@ reputation and, over time, audience.
 - Never include reproduction steps, payloads, or PoC links
 - Always include CVE ID if assigned
 - Tag the programme if they have a public X handle (field on `Programme` model)
-- Keep technical detail high, hype low — target a security-practitioner audience
+- Keep technical detail high, hype low - target a security-practitioner audience
 
 **Example tweet format:**
 ```
-Resolved: Stored XSS in [programme] search endpoint — CVSS 7.4
+Resolved: Stored XSS in [programme] search endpoint - CVSS 7.4
 Patch shipped 2025-03-14. Report accepted in 4 days.
 CVE-2025-XXXXX #BugBounty #XSS
 ```
@@ -86,12 +86,12 @@ CVE-2025-XXXXX #BugBounty #XSS
 ## Pipeline position
 
 ```
-... → TechnicalAuthor → [submission-approval] → DisclosureCoordinator
-        → [disclosure-approval] → PublicRelationsAgent
+... -> TechnicalAuthor -> [submission-approval] -> DisclosureCoordinator
+        -> [disclosure-approval] -> PublicRelationsAgent
 ```
 
 The PR agent sits at the end, gated by a third `ApprovalGate` checkpoint
-(`disclosure-approval`). This gate is separate from `submission-approval` —
+(`disclosure-approval`). This gate is separate from `submission-approval` -
 the operator may approve submission but want to review the tweet draft before
 it goes live.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ bounty-squad = "main:main"
 packages = ["tools"]
 py-modules = ["config", "models", "tasks", "crew", "main"]
 
-# ── pytest ────────────────────────────────────────────────────────────────────
+# -- pytest --------------------------------------------------------------------
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -55,7 +55,7 @@ markers = [
     "integration: hits real APIs or binaries (skipped in CI by default)",
 ]
 
-# ── coverage ──────────────────────────────────────────────────────────────────
+# -- coverage ------------------------------------------------------------------
 
 [tool.coverage.run]
 source = ["."]
@@ -70,7 +70,7 @@ exclude_lines = [
     "raise NotImplementedError",
 ]
 
-# ── ruff ──────────────────────────────────────────────────────────────────────
+# -- ruff ----------------------------------------------------------------------
 
 [tool.ruff]
 target-version = "py312"
@@ -85,13 +85,13 @@ select = [
     "B",    # flake8-bugbear (common footguns)
     "C4",   # flake8-comprehensions
     "UP",   # pyupgrade (modernise syntax)
-    "S",    # flake8-bandit (security — basic layer)
+    "S",    # flake8-bandit (security - basic layer)
     "ANN",  # flake8-annotations (type hints)
 ]
 ignore = [
     "S101",    # use of assert (fine in tests)
-    "S603",    # subprocess call — we call binaries intentionally
-    "S607",    # partial path in subprocess — binaries found via shutil.which
+    "S603",    # subprocess call - we call binaries intentionally
+    "S607",    # partial path in subprocess - binaries found via shutil.which
 ]
 
 [tool.ruff.lint.per-file-ignores]
@@ -101,7 +101,7 @@ ignore = [
 quote-style = "double"
 indent-style = "space"
 
-# ── mypy ──────────────────────────────────────────────────────────────────────
+# -- mypy ----------------------------------------------------------------------
 
 [tool.mypy]
 python_version = "3.12"
@@ -116,15 +116,15 @@ disallow_any_generics = false
 module = "tests.*"
 disallow_untyped_defs = false
 
-# ── bandit ────────────────────────────────────────────────────────────────────
+# -- bandit --------------------------------------------------------------------
 
 [tool.bandit]
 targets = ["."]
 exclude_dirs = ["tests", ".venv"]
 skips = [
-    "B404",  # import subprocess — we use it intentionally for binary wrappers
-    "B603",  # subprocess without shell=True — correct, we never use shell=True
-    "B607",  # partial executable path — resolved via shutil.which before call
+    "B404",  # import subprocess - we use it intentionally for binary wrappers
+    "B603",  # subprocess without shell=True - correct, we never use shell=True
+    "B607",  # partial executable path - resolved via shutil.which before call
 ]
 severity = "medium"
 confidence = "medium"

--- a/squad/__init__.py
+++ b/squad/__init__.py
@@ -1,5 +1,5 @@
 """
-squad/__init__.py — shared SquadMember dataclass + agent/task builders.
+squad/__init__.py - shared SquadMember dataclass + agent/task builders.
 
 Each sub-package declares one module-level ``MEMBER = SquadMember(...)`` constant.
 Prose lives in five single-purpose markdown files alongside it:

--- a/squad/disclosure_coordinator/__init__.py
+++ b/squad/disclosure_coordinator/__init__.py
@@ -1,4 +1,4 @@
-"""Disclosure Coordinator — submits finalised reports to HackerOne."""
+"""Disclosure Coordinator - submits finalised reports to HackerOne."""
 
 from __future__ import annotations
 

--- a/squad/disclosure_coordinator/backstory.md
+++ b/squad/disclosure_coordinator/backstory.md
@@ -1,6 +1,6 @@
 You submit reports to the HackerOne API precisely and record every submission's
 metadata: report ID, programme handle, severity, timestamp, and URL. You follow
-coordinated-disclosure conventions — the programme's stated response window is
+coordinated-disclosure conventions - the programme's stated response window is
 respected, and public discussion of a finding waits until the programme has
 resolved it or explicitly permitted disclosure. On submission failure you
 capture the full error response and flag for human review; you never retry

--- a/squad/disclosure_coordinator/description.md
+++ b/squad/disclosure_coordinator/description.md
@@ -5,5 +5,5 @@ Submit the finalised disclosure report to HackerOne via the API:
   4. Log the result: report ID, programme handle, severity,
      submission timestamp, and H1 URL
 
-If submission fails, log the error in full and do not retry —
+If submission fails, log the error in full and do not retry -
 flag for human review instead.

--- a/squad/osint_analyst/__init__.py
+++ b/squad/osint_analyst/__init__.py
@@ -1,4 +1,4 @@
-"""OSINT Analyst — maps the in-scope attack surface."""
+"""OSINT Analyst - maps the in-scope attack surface."""
 
 from __future__ import annotations
 

--- a/squad/osint_analyst/backstory.md
+++ b/squad/osint_analyst/backstory.md
@@ -2,6 +2,6 @@ You map attack surface using passive and semi-passive techniques: subfinder for
 subdomain enumeration, httpx for live HTTP/S endpoint probing and technology
 fingerprinting, and lightweight port scans for service discovery. Every
 discovered asset is cross-checked against the programme's in-scope list before
-being included in your output — assets that are not explicitly in scope are
+being included in your output - assets that are not explicitly in scope are
 excluded without exception. You document findings with the detail a downstream
 tester would need to reproduce them.

--- a/squad/osint_analyst/description.md
+++ b/squad/osint_analyst/description.md
@@ -5,6 +5,6 @@ reconnaissance against all in-scope assets:
   - Perform lightweight port scanning on live hosts
   - Identify technology stacks
 
-Strictly enforce scope — do not interact with any asset not listed
+Strictly enforce scope - do not interact with any asset not listed
 as in-scope. Document all discovered subdomains, endpoints, open ports,
 and detected technologies.

--- a/squad/osint_analyst/goal.md
+++ b/squad/osint_analyst/goal.md
@@ -1,3 +1,3 @@
-Build a comprehensive, in-scope attack surface map for the target programme —
-subdomains, live endpoints, open ports, and technology stack — using only passive
+Build a comprehensive, in-scope attack surface map for the target programme -
+subdomains, live endpoints, open ports, and technology stack - using only passive
 and semi-passive reconnaissance techniques.

--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -1,4 +1,4 @@
-"""Penetration Tester — scans discovered attack surface for vulnerabilities."""
+"""Penetration Tester - scans discovered attack surface for vulnerabilities."""
 
 from __future__ import annotations
 

--- a/squad/penetration_tester/backstory.md
+++ b/squad/penetration_tester/backstory.md
@@ -3,6 +3,6 @@ for templated checks on live HTTP endpoints, sqlmap for parameterised URLs,
 and bespoke checks for configuration issues such as CORS misconfiguration. You
 follow the OWASP Testing Guide v4.2 methodology and classify findings against
 the OWASP Top 10 (2021) where applicable. You respect the configured rate
-limit and stop at proof-of-concept — you never exploit beyond what is needed
+limit and stop at proof-of-concept - you never exploit beyond what is needed
 to demonstrate the issue, and you never fire a payload at an asset that is
 out of scope.

--- a/squad/penetration_tester/description.md
+++ b/squad/penetration_tester/description.md
@@ -11,4 +11,4 @@ finding's vuln_class field so triage can prioritise correctly.
 
 Respect the configured request rate limit. Do not attempt exploits
 beyond proof-of-concept. Capture tool output as evidence.
-Return all raw findings regardless of confidence — triage comes next.
+Return all raw findings regardless of confidence - triage comes next.

--- a/squad/programme_manager/__init__.py
+++ b/squad/programme_manager/__init__.py
@@ -1,4 +1,4 @@
-"""Programme Manager — selects the highest-value H1 programme."""
+"""Programme Manager - selects the highest-value H1 programme."""
 
 from __future__ import annotations
 

--- a/squad/programme_manager/backstory.md
+++ b/squad/programme_manager/backstory.md
@@ -1,6 +1,6 @@
 You evaluate HackerOne programmes on concrete criteria: maximum bounty by
 severity, attack surface breadth, and explicit permission for automated
-scanning. You read policy text carefully — phrases like "no automated scanning",
+scanning. You read policy text carefully - phrases like "no automated scanning",
 "manual testing only", or "automated tools are prohibited" are disqualifying.
 You prefer programmes with public response-rate and time-to-bounty data, and
 you never authorise work against a programme whose policy forbids the tools

--- a/squad/programme_manager/goal.md
+++ b/squad/programme_manager/goal.md
@@ -1,3 +1,3 @@
-Identify the highest-value HackerOne bug bounty programmes — maximising expected
-payout relative to attack surface complexity — whilst rigorously verifying that
+Identify the highest-value HackerOne bug bounty programmes - maximising expected
+payout relative to attack surface complexity - whilst rigorously verifying that
 automated scanning is permitted.

--- a/squad/technical_author/__init__.py
+++ b/squad/technical_author/__init__.py
@@ -1,4 +1,4 @@
-"""Technical Author — writes professional H1-format disclosure reports."""
+"""Technical Author - writes professional H1-format disclosure reports."""
 
 from __future__ import annotations
 

--- a/squad/technical_author/backstory.md
+++ b/squad/technical_author/backstory.md
@@ -3,6 +3,6 @@ requesting clarification. You write reproduction steps a developer unfamiliar
 with the codebase can follow, impact statements grounded in what an attacker
 can actually do with the finding, and remediation advice that cites the
 relevant OWASP guidance or CWE entry. You sanitise evidence so that the report
-is safe to publish — no live payloads, no credentials, no data from unrelated
+is safe to publish - no live payloads, no credentials, no data from unrelated
 users. You follow the HackerOne report format: title, summary, details,
 steps to reproduce, impact, and remediation.

--- a/squad/technical_author/description.md
+++ b/squad/technical_author/description.md
@@ -1,7 +1,7 @@
 For each verified vulnerability, produce a complete HackerOne-format
 disclosure report in Markdown:
   - A punchy, accurate title
-  - A 2–3 sentence executive summary
+  - A 2-3 sentence executive summary
   - Full vulnerability details (type, severity, CVSS, CWE, target)
   - A clear technical description written for a developer audience
   - Numbered, reproducible steps to demonstrate the issue

--- a/squad/technical_author/goal.md
+++ b/squad/technical_author/goal.md
@@ -1,3 +1,3 @@
 Transform verified vulnerability data into clear, compelling, and complete
-H1-format disclosure reports — with precise reproduction steps, accurate impact
+H1-format disclosure reports - with precise reproduction steps, accurate impact
 statements, and actionable remediation advice.

--- a/squad/vulnerability_researcher/__init__.py
+++ b/squad/vulnerability_researcher/__init__.py
@@ -1,4 +1,4 @@
-"""Vulnerability Researcher — triages raw findings, eliminates false positives."""
+"""Vulnerability Researcher - triages raw findings, eliminates false positives."""
 
 from __future__ import annotations
 

--- a/squad/vulnerability_researcher/backstory.md
+++ b/squad/vulnerability_researcher/backstory.md
@@ -1,4 +1,4 @@
-You triage raw scanner output conservatively — scanners are noisy, and false
+You triage raw scanner output conservatively - scanners are noisy, and false
 positives waste programme triage time and damage the squad's submission record.
 You score every finding using the FIRST.org CVSS 3.1 specification, erring on
 the lower side when any base metric is uncertain. You forward only findings

--- a/squad/vulnerability_researcher/description.md
+++ b/squad/vulnerability_researcher/description.md
@@ -4,7 +4,7 @@ Triage the raw findings from the penetration test:
   3. For each remaining finding, assign a CVSS 3.1 score and vector string
      per the FIRST.org specification
      (https://www.first.org/cvss/v3.1/specification-document). When any
-     base metric is uncertain, score conservatively — prefer the lower
+     base metric is uncertain, score conservatively - prefer the lower
      value. Map each finding to a CWE identifier where one exists
      (https://cwe.mitre.org)
   4. Write a concise technical description, clear reproduction steps,
@@ -15,4 +15,4 @@ Triage the raw findings from the penetration test:
 
 Only forward findings you can independently reproduce and confirm as
 in-scope. A false-positive submission damages the squad's record and
-wastes programme triage time — when in doubt, leave it out.
+wastes programme triage time - when in doubt, leave it out.

--- a/tasks.py
+++ b/tasks.py
@@ -1,5 +1,5 @@
 """
-tasks.py — Pipeline task wiring.
+tasks.py - Pipeline task wiring.
 
 Context chaining lives here because it is a pipeline concern, not a per-member one.
 

--- a/tasks.py
+++ b/tasks.py
@@ -7,7 +7,7 @@ human_input=True on a task tells CrewAI to pause after the agent finishes and
 prompt the operator for feedback before advancing. Empty feedback (Enter) accepts
 the result; typed feedback re-invokes the agent with that guidance.
 
-Set CYBERSQUAD_HUMAN_INPUT=false to disable all gates (e.g. for automated/container runs).
+Set CYBERSQUAD_HUMAN_INPUT=false to disable all gates for unattended runs.
 """
 
 from __future__ import annotations

--- a/tasks.py
+++ b/tasks.py
@@ -6,12 +6,15 @@ Context chaining lives here because it is a pipeline concern, not a per-member o
 human_input=True on a task tells CrewAI to pause after the agent finishes and
 prompt the operator for feedback before advancing. Empty feedback (Enter) accepts
 the result; typed feedback re-invokes the agent with that guidance.
+
+Set CYBERSQUAD_HUMAN_INPUT=false to disable all gates (e.g. for automated/container runs).
 """
 
 from __future__ import annotations
 
 from crewai import Task
 
+from config import config
 from squad import build_task
 from squad.disclosure_coordinator import MEMBER as DISCLOSURE_COORDINATOR
 from squad.osint_analyst import MEMBER as OSINT_ANALYST
@@ -22,20 +25,18 @@ from squad.vulnerability_researcher import MEMBER as VULNERABILITY_RESEARCHER
 
 
 def build_tasks(agents: dict) -> list[Task]:
-    # Gate 1: approve or reject the selected programme before any scanning begins.
-    select = build_task(PROGRAMME_MANAGER, agents["programme_manager"], human_input=True)
+    hi = config.human_input
+    select = build_task(PROGRAMME_MANAGER, agents["programme_manager"], human_input=hi)
     recon = build_task(OSINT_ANALYST, agents["osint_analyst"], context=[select])
     pentest = build_task(PENETRATION_TESTER, agents["penetration_tester"], context=[recon])
-    # Gate 2: verify triage conclusions before spending tokens on report writing.
     triage = build_task(
         VULNERABILITY_RESEARCHER,
         agents["vulnerability_researcher"],
         context=[pentest, select],
-        human_input=True,
+        human_input=hi,
     )
-    # Gate 3: review the finished report before it is submitted to H1.
     write = build_task(
-        TECHNICAL_AUTHOR, agents["technical_author"], context=[triage, select], human_input=True
+        TECHNICAL_AUTHOR, agents["technical_author"], context=[triage, select], human_input=hi
     )
     submit = build_task(DISCLOSURE_COORDINATOR, agents["disclosure_coordinator"], context=[write])
     return [select, recon, pentest, triage, write, submit]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 """
-tests/conftest.py — shared fixtures for the Bounty Squad test suite.
+tests/conftest.py - shared fixtures for the Bounty Squad test suite.
 """
 
 from __future__ import annotations
@@ -18,7 +18,7 @@ from models import (
     VerifiedVulnerability,
 )
 
-# ── Programme fixtures ────────────────────────────────────────────────────────
+# -- Programme fixtures --------------------------------------------------------
 
 
 @pytest.fixture()
@@ -57,7 +57,7 @@ def programme(scope_item_url, scope_item_wildcard) -> Programme:
     )
 
 
-# ── Recon fixtures ────────────────────────────────────────────────────────────
+# -- Recon fixtures ------------------------------------------------------------
 
 
 @pytest.fixture()
@@ -82,13 +82,13 @@ def recon_result(programme, endpoint) -> ReconResult:
     )
 
 
-# ── Vulnerability fixtures ────────────────────────────────────────────────────
+# -- Vulnerability fixtures ----------------------------------------------------
 
 
 @pytest.fixture()
 def raw_finding_high() -> RawFinding:
     return RawFinding(
-        title="SQL Injection — https://api.example.com/search",
+        title="SQL Injection - https://api.example.com/search",
         vuln_class="SQLi",
         target="https://api.example.com/search",
         evidence="sqlmap identified injection at parameter 'q'",
@@ -113,7 +113,7 @@ def raw_finding_low() -> RawFinding:
 def raw_finding_oos() -> RawFinding:
     """A finding whose target is outside programme scope."""
     return RawFinding(
-        title="XSS — https://other.com/search",
+        title="XSS - https://other.com/search",
         vuln_class="XSS",
         target="https://other.com/search",
         evidence="<script>alert(1)</script> reflected",
@@ -125,7 +125,7 @@ def raw_finding_oos() -> RawFinding:
 @pytest.fixture()
 def verified_vuln() -> VerifiedVulnerability:
     return VerifiedVulnerability(
-        title="SQL Injection — https://api.example.com/search",
+        title="SQL Injection - https://api.example.com/search",
         vuln_class="SQLi",
         target="https://api.example.com/search",
         severity=Severity.HIGH,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,9 +18,7 @@ from models import (
     VerifiedVulnerability,
 )
 
-# -- Programme fixtures --------------------------------------------------------
-
-
+# Programme fixtures
 @pytest.fixture()
 def scope_item_url() -> ScopeItem:
     return ScopeItem(
@@ -57,9 +55,7 @@ def programme(scope_item_url, scope_item_wildcard) -> Programme:
     )
 
 
-# -- Recon fixtures ------------------------------------------------------------
-
-
+# Recon fixtures
 @pytest.fixture()
 def endpoint() -> Endpoint:
     return Endpoint(
@@ -82,9 +78,7 @@ def recon_result(programme, endpoint) -> ReconResult:
     )
 
 
-# -- Vulnerability fixtures ----------------------------------------------------
-
-
+# Vulnerability fixtures
 @pytest.fixture()
 def raw_finding_high() -> RawFinding:
     return RawFinding(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from models import (
     VerifiedVulnerability,
 )
 
+
 # Programme fixtures
 @pytest.fixture()
 def scope_item_url() -> ScopeItem:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,5 @@
 """
-tests/test_config.py — unit tests for config.py
+tests/test_config.py - unit tests for config.py
 """
 
 from __future__ import annotations

--- a/tests/test_h1_api.py
+++ b/tests/test_h1_api.py
@@ -32,9 +32,7 @@ def h1_client(monkeypatch):
     return h1_module.H1Client()
 
 
-# -- parse_programme -----------------------------------------------------------
-
-
+# parse_programme
 class TestParseProgramme:
     def _raw_programme(self):
         return {
@@ -97,9 +95,7 @@ class TestParseProgramme:
         assert len(prog.out_of_scope) == 1
 
 
-# -- submit_report -------------------------------------------------------------
-
-
+# submit_report
 class TestSubmitReport:
     def test_successful_submission(self, h1_client, disclosure_report):
         mock_response = MagicMock()

--- a/tests/test_h1_api.py
+++ b/tests/test_h1_api.py
@@ -1,7 +1,7 @@
 """
-tests/test_h1_api.py — unit tests for tools/h1_api.py
+tests/test_h1_api.py - unit tests for tools/h1_api.py
 
-All HTTP calls are mocked — no real H1 API calls made.
+All HTTP calls are mocked - no real H1 API calls made.
 """
 
 from __future__ import annotations
@@ -32,7 +32,7 @@ def h1_client(monkeypatch):
     return h1_module.H1Client()
 
 
-# ── parse_programme ───────────────────────────────────────────────────────────
+# -- parse_programme -----------------------------------------------------------
 
 
 class TestParseProgramme:
@@ -97,7 +97,7 @@ class TestParseProgramme:
         assert len(prog.out_of_scope) == 1
 
 
-# ── submit_report ─────────────────────────────────────────────────────────────
+# -- submit_report -------------------------------------------------------------
 
 
 class TestSubmitReport:
@@ -115,7 +115,7 @@ class TestSubmitReport:
         assert result.submitted_at is not None
 
     def test_submission_payload_uses_id_not_attributes(self, h1_client, disclosure_report):
-        """Regression: payload previously used attributes:{handle:} → 422."""
+        """Regression: payload previously used attributes:{handle:} -> 422."""
         mock_response = MagicMock()
         mock_response.json.return_value = {"data": {"id": "999"}}
         mock_response.raise_for_status = MagicMock()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,4 +1,4 @@
-"""tests/test_metrics.py — unit tests for tools/metrics.py."""
+"""tests/test_metrics.py - unit tests for tools/metrics.py."""
 
 from __future__ import annotations
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,5 @@
 """
-tests/test_models.py — unit tests for models.py
+tests/test_models.py - unit tests for models.py
 """
 
 from __future__ import annotations

--- a/tests/test_recon_tools.py
+++ b/tests/test_recon_tools.py
@@ -1,5 +1,5 @@
 """
-tests/test_recon_tools.py — unit tests for tools/recon_tools.py
+tests/test_recon_tools.py - unit tests for tools/recon_tools.py
 
 Focuses on the scope guard (security-critical) and domain extraction.
 Subprocess calls are mocked so tests run without binaries installed.
@@ -23,7 +23,7 @@ from tools.recon_tools import (
 pytestmark = pytest.mark.unit
 
 
-# ── extract_domain ────────────────────────────────────────────────────────────
+# -- extract_domain ------------------------------------------------------------
 
 
 class TestExtractDomain:
@@ -43,12 +43,12 @@ class TestExtractDomain:
         assert extract_domain("https://example.com:8443") == "example.com"
 
 
-# ── filter_in_scope ───────────────────────────────────────────────────────────
+# -- filter_in_scope -----------------------------------------------------------
 
 
 class TestFilterInScope:
     """
-    The scope guard is security-critical — an out-of-scope false positive
+    The scope guard is security-critical - an out-of-scope false positive
     would cause us to test targets we're not authorised to touch.
     """
 
@@ -101,7 +101,7 @@ class TestFilterInScope:
         assert filter_in_scope(["example.com"], bare_programme) == []
 
 
-# ── enumerate_subdomains ──────────────────────────────────────────────────────
+# -- enumerate_subdomains ------------------------------------------------------
 
 
 class TestEnumerateSubdomains:
@@ -154,7 +154,7 @@ class TestEnumerateSubdomains:
         assert result == []
 
 
-# ── probe_endpoints ───────────────────────────────────────────────────────────
+# -- probe_endpoints -----------------------------------------------------------
 
 
 class TestProbeEndpoints:
@@ -221,7 +221,7 @@ class TestProbeEndpoints:
                 probe_endpoints(["example.com"])
 
 
-# ── port_scan ─────────────────────────────────────────────────────────────────
+# -- port_scan -----------------------------------------------------------------
 
 
 class TestPortScan:

--- a/tests/test_recon_tools.py
+++ b/tests/test_recon_tools.py
@@ -23,9 +23,7 @@ from tools.recon_tools import (
 pytestmark = pytest.mark.unit
 
 
-# -- extract_domain ------------------------------------------------------------
-
-
+# extract_domain
 class TestExtractDomain:
     def test_plain_domain(self):
         assert extract_domain("example.com") == "example.com"
@@ -43,9 +41,7 @@ class TestExtractDomain:
         assert extract_domain("https://example.com:8443") == "example.com"
 
 
-# -- filter_in_scope -----------------------------------------------------------
-
-
+# filter_in_scope
 class TestFilterInScope:
     """
     The scope guard is security-critical - an out-of-scope false positive
@@ -101,9 +97,7 @@ class TestFilterInScope:
         assert filter_in_scope(["example.com"], bare_programme) == []
 
 
-# -- enumerate_subdomains ------------------------------------------------------
-
-
+# enumerate_subdomains
 class TestEnumerateSubdomains:
     def test_returns_parsed_subdomains(self):
         mock_result = MagicMock()
@@ -154,9 +148,7 @@ class TestEnumerateSubdomains:
         assert result == []
 
 
-# -- probe_endpoints -----------------------------------------------------------
-
-
+# probe_endpoints
 class TestProbeEndpoints:
     def test_parses_httpx_json_output(self):
         import json
@@ -221,9 +213,7 @@ class TestProbeEndpoints:
                 probe_endpoints(["example.com"])
 
 
-# -- port_scan -----------------------------------------------------------------
-
-
+# port_scan
 class TestPortScan:
     def test_parses_open_ports(self):
         mock_result = MagicMock()

--- a/tests/test_report_tools.py
+++ b/tests/test_report_tools.py
@@ -1,5 +1,5 @@
 """
-tests/test_report_tools.py — unit tests for tools/report_tools.py
+tests/test_report_tools.py - unit tests for tools/report_tools.py
 """
 
 from __future__ import annotations

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,4 +1,4 @@
-"""tests/test_tasks.py — unit tests for squad assembly and task wiring."""
+"""tests/test_tasks.py - unit tests for squad assembly and task wiring."""
 
 from __future__ import annotations
 

--- a/tests/test_vuln_tools.py
+++ b/tests/test_vuln_tools.py
@@ -20,9 +20,7 @@ from tools.vuln_tools import (
 pytestmark = pytest.mark.unit
 
 
-# -- _above_floor --------------------------------------------------------------
-
-
+# _above_floor
 class TestAboveFloor:
     def test_medium_above_medium_floor(self, monkeypatch):
         monkeypatch.setenv("MIN_SEVERITY", "medium")
@@ -61,9 +59,7 @@ class TestAboveFloor:
         assert vt._above_floor(Severity.INFORMATIONAL) is False
 
 
-# -- _lookup_cvss --------------------------------------------------------------
-
-
+# _lookup_cvss
 class TestLookupCvss:
     def test_sqli_critical(self):
         score, vector = _lookup_cvss("SQLi", Severity.CRITICAL)
@@ -84,9 +80,7 @@ class TestLookupCvss:
         assert len(result) == 2
 
 
-# -- is_in_scope ---------------------------------------------------------------
-
-
+# is_in_scope
 class TestIsInScope:
     def test_in_scope_finding(self, raw_finding_high, programme):
         assert is_in_scope(raw_finding_high, programme) is True
@@ -95,9 +89,7 @@ class TestIsInScope:
         assert is_in_scope(raw_finding_oos, programme) is False
 
 
-# -- triage_findings -----------------------------------------------------------
-
-
+# triage_findings
 class TestTriageFindings:
     def test_filters_out_of_scope(self, raw_finding_high, raw_finding_oos, programme):
         results = triage_findings([raw_finding_high, raw_finding_oos], programme)
@@ -140,9 +132,7 @@ class TestTriageFindings:
         assert results[0].target == raw_finding_high.target
 
 
-# -- run_nuclei ----------------------------------------------------------------
-
-
+# run_nuclei
 class TestRunNuclei:
     def test_parses_nuclei_json_output(self):
         import json
@@ -180,9 +170,7 @@ class TestRunNuclei:
                 run_nuclei(endpoints)
 
 
-# -- check_cors_misconfiguration -----------------------------------------------
-
-
+# check_cors_misconfiguration
 class TestCheckCorsMisconfiguration:
     def test_detects_wildcard_cors(self):
         mock_response = MagicMock()

--- a/tests/test_vuln_tools.py
+++ b/tests/test_vuln_tools.py
@@ -1,5 +1,5 @@
 """
-tests/test_vuln_tools.py — unit tests for tools/vuln_tools.py
+tests/test_vuln_tools.py - unit tests for tools/vuln_tools.py
 """
 
 from __future__ import annotations
@@ -20,7 +20,7 @@ from tools.vuln_tools import (
 pytestmark = pytest.mark.unit
 
 
-# ── _above_floor ──────────────────────────────────────────────────────────────
+# -- _above_floor --------------------------------------------------------------
 
 
 class TestAboveFloor:
@@ -61,7 +61,7 @@ class TestAboveFloor:
         assert vt._above_floor(Severity.INFORMATIONAL) is False
 
 
-# ── _lookup_cvss ──────────────────────────────────────────────────────────────
+# -- _lookup_cvss --------------------------------------------------------------
 
 
 class TestLookupCvss:
@@ -84,7 +84,7 @@ class TestLookupCvss:
         assert len(result) == 2
 
 
-# ── is_in_scope ───────────────────────────────────────────────────────────────
+# -- is_in_scope ---------------------------------------------------------------
 
 
 class TestIsInScope:
@@ -95,7 +95,7 @@ class TestIsInScope:
         assert is_in_scope(raw_finding_oos, programme) is False
 
 
-# ── triage_findings ───────────────────────────────────────────────────────────
+# -- triage_findings -----------------------------------------------------------
 
 
 class TestTriageFindings:
@@ -140,7 +140,7 @@ class TestTriageFindings:
         assert results[0].target == raw_finding_high.target
 
 
-# ── run_nuclei ────────────────────────────────────────────────────────────────
+# -- run_nuclei ----------------------------------------------------------------
 
 
 class TestRunNuclei:
@@ -180,7 +180,7 @@ class TestRunNuclei:
                 run_nuclei(endpoints)
 
 
-# ── check_cors_misconfiguration ───────────────────────────────────────────────
+# -- check_cors_misconfiguration -----------------------------------------------
 
 
 class TestCheckCorsMisconfiguration:

--- a/tools/h1_api.py
+++ b/tools/h1_api.py
@@ -1,5 +1,5 @@
 """
-tools/h1_api.py — HackerOne API wrapper.
+tools/h1_api.py - HackerOne API wrapper.
 
 Covers everything the pipeline needs:
   - Listing & ranking programmes
@@ -33,7 +33,7 @@ from models import (
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Severity mapping — H1 uses strings, we use our enum
+# Severity mapping - H1 uses strings, we use our enum
 # ---------------------------------------------------------------------------
 _H1_SEVERITY_MAP: dict[str, Severity] = {
     "none": Severity.INFORMATIONAL,
@@ -193,7 +193,7 @@ class H1Client:
                     "program": {
                         "data": {
                             "type": "program",
-                            # FIX: was {"attributes": {"handle": ...}} → 422 on every submit
+                            # FIX: was {"attributes": {"handle": ...}} -> 422 on every submit
                             "id": report.programme_handle,
                         }
                     }
@@ -235,6 +235,6 @@ class H1Client:
 
 
 # ---------------------------------------------------------------------------
-# Module-level singleton — import this rather than H1Client directly
+# Module-level singleton - import this rather than H1Client directly
 # ---------------------------------------------------------------------------
 h1 = H1Client()

--- a/tools/h1_api.py
+++ b/tools/h1_api.py
@@ -32,9 +32,7 @@ from models import (
 
 logger = logging.getLogger(__name__)
 
-# ---------------------------------------------------------------------------
 # Severity mapping - H1 uses strings, we use our enum
-# ---------------------------------------------------------------------------
 _H1_SEVERITY_MAP: dict[str, Severity] = {
     "none": Severity.INFORMATIONAL,
     "low": Severity.LOW,
@@ -75,9 +73,7 @@ class H1Client:
             }
         )
 
-    # ------------------------------------------------------------------
     # Internal helpers
-    # ------------------------------------------------------------------
 
     def _get(self, path: str, params: dict | None = None) -> dict:
         url = f"{self._base}{path}"
@@ -91,9 +87,7 @@ class H1Client:
         resp.raise_for_status()
         return cast(dict, resp.json())
 
-    # ------------------------------------------------------------------
     # Programme discovery
-    # ------------------------------------------------------------------
 
     def list_programmes(self, page_size: int = 25) -> list[dict]:
         """
@@ -120,9 +114,7 @@ class H1Client:
         """Fetch the structured scope (in/out) for a programme."""
         return self._get(f"/programs/{handle}/structured_scopes")
 
-    # ------------------------------------------------------------------
     # Data parsers
-    # ------------------------------------------------------------------
 
     def parse_programme(self, raw: dict, scope_data: dict) -> Programme:
         """Convert raw H1 API dicts into a typed Programme model."""
@@ -170,9 +162,7 @@ class H1Client:
             allows_automated_scanning=allows_auto,
         )
 
-    # ------------------------------------------------------------------
     # Report submission
-    # ------------------------------------------------------------------
 
     def submit_report(self, report: DisclosureReport) -> SubmissionResult:
         """
@@ -234,7 +224,5 @@ class H1Client:
         return status_map.get(state, SubmissionStatus.PENDING)
 
 
-# ---------------------------------------------------------------------------
 # Module-level singleton - import this rather than H1Client directly
-# ---------------------------------------------------------------------------
 h1 = H1Client()

--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -1,8 +1,8 @@
 """
-tools/metrics.py — Token-usage accounting and cost estimation.
+tools/metrics.py - Token-usage accounting and cost estimation.
 
 Anthropic pricing is expressed per 1 M tokens; the table below reflects
-rates as of 2026-04. Update the table when pricing changes — do not
+rates as of 2026-04. Update the table when pricing changes - do not
 hardcode rates elsewhere.
 """
 
@@ -30,7 +30,7 @@ def estimate_cost(model: str, input_tokens: int, output_tokens: int) -> float:
     for prefix, (in_price, out_price) in _PRICING.items():
         if model.startswith(prefix):
             return (input_tokens * in_price + output_tokens * out_price) / 1_000_000
-    logger.warning("No pricing entry for model %r — cost will show as $0.00", model)
+    logger.warning("No pricing entry for model %r - cost will show as $0.00", model)
     return 0.0
 
 
@@ -65,11 +65,11 @@ def build_run_metrics(
 
 def print_metrics(metrics: RunMetrics) -> None:
     """Print a human-readable run summary to stdout."""
-    print("\n" + "━" * 50)
+    print("\n" + "-" * 50)
     print("  SQUAD METRICS")
-    print("━" * 50)
+    print("-" * 50)
     print(f"  Run ID       : {metrics.run_id}")
-    print(f"  Programme    : {metrics.programme_handle or '—'}")
+    print(f"  Programme    : {metrics.programme_handle or '-'}")
     print(f"  Duration     : {metrics.duration_seconds:.1f}s")
     print(f"  Model        : {metrics.llm_model}")
     print(f"  Input tokens : {metrics.input_tokens:,}")
@@ -79,7 +79,7 @@ def print_metrics(metrics: RunMetrics) -> None:
     print(f"  Raw findings : {metrics.findings_raw}")
     print(f"  Verified     : {metrics.findings_verified}")
     print(f"  Submitted    : {'yes' if metrics.submitted else 'no'}")
-    print("━" * 50 + "\n")
+    print("-" * 50 + "\n")
 
 
 def save_metrics(metrics: RunMetrics, reports_dir: str) -> Path:

--- a/tools/recon_tools.py
+++ b/tools/recon_tools.py
@@ -23,9 +23,7 @@ from models import Endpoint, Programme, ReconResult, ScopeType
 logger = logging.getLogger(__name__)
 
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def _require_binary(name: str) -> str:
@@ -58,9 +56,7 @@ def _run(
     return result
 
 
-# ---------------------------------------------------------------------------
 # Subdomain enumeration
-# ---------------------------------------------------------------------------
 
 
 def enumerate_subdomains(domain: str) -> list[str]:
@@ -78,9 +74,7 @@ def enumerate_subdomains(domain: str) -> list[str]:
     return list(dict.fromkeys(subdomains))[: config.recon.max_subdomains]
 
 
-# ---------------------------------------------------------------------------
 # HTTP probing
-# ---------------------------------------------------------------------------
 
 
 def probe_endpoints(hosts: list[str]) -> list[Endpoint]:
@@ -124,9 +118,7 @@ def probe_endpoints(hosts: list[str]) -> list[Endpoint]:
     return endpoints
 
 
-# ---------------------------------------------------------------------------
 # Port scanning
-# ---------------------------------------------------------------------------
 
 
 def port_scan(hosts: list[str]) -> dict[str, list[int]]:
@@ -157,9 +149,7 @@ def port_scan(hosts: list[str]) -> dict[str, list[int]]:
     return results
 
 
-# ---------------------------------------------------------------------------
 # Scope guard
-# ---------------------------------------------------------------------------
 
 
 def extract_domain(identifier: str) -> str:
@@ -193,9 +183,7 @@ def filter_in_scope(hosts: list[str], programme: Programme) -> list[str]:
     return allowed
 
 
-# ---------------------------------------------------------------------------
 # Orchestration - called by the OSINT Analyst agent task
-# ---------------------------------------------------------------------------
 
 
 def run_recon(programme: Programme) -> ReconResult:

--- a/tools/recon_tools.py
+++ b/tools/recon_tools.py
@@ -1,5 +1,5 @@
 """
-tools/recon_tools.py — OSINT and reconnaissance tooling for the OSINT Analyst.
+tools/recon_tools.py - OSINT and reconnaissance tooling for the OSINT Analyst.
 
 Wraps external binaries (subfinder, httpx, nmap) and pure-Python helpers.
 
@@ -89,7 +89,7 @@ def probe_endpoints(hosts: list[str]) -> list[Endpoint]:
     Returns Endpoint objects with status codes and detected technologies.
     """
     httpx_bin = _require_binary("httpx")
-    # FIX: input_data was computed but never passed — httpx received no targets
+    # FIX: input_data was computed but never passed - httpx received no targets
     input_data = "\n".join(hosts)
 
     result = _run(
@@ -152,7 +152,7 @@ def port_scan(hosts: list[str]) -> dict[str, list[int]]:
                         except ValueError:
                             pass
         results[host] = open_ports
-        logger.info("nmap: %s → %s", host, open_ports)
+        logger.info("nmap: %s -> %s", host, open_ports)
 
     return results
 
@@ -180,7 +180,7 @@ def filter_in_scope(hosts: list[str], programme: Programme) -> list[str]:
                 continue
             pattern = scope_item.asset_identifier.lstrip("*.")
             # FIX: bare endswith(pattern) allowed evil.notexample.com to match
-            # example.com — must verify a dot boundary or exact match
+            # example.com - must verify a dot boundary or exact match
             if host == pattern or host.endswith("." + pattern):
                 allowed.append(host)
                 break
@@ -194,7 +194,7 @@ def filter_in_scope(hosts: list[str], programme: Programme) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
-# Orchestration — called by the OSINT Analyst agent task
+# Orchestration - called by the OSINT Analyst agent task
 # ---------------------------------------------------------------------------
 
 

--- a/tools/report_tools.py
+++ b/tools/report_tools.py
@@ -14,9 +14,7 @@ from pathlib import Path
 from config import config
 from models import DisclosureReport, Severity, VerifiedVulnerability
 
-# ---------------------------------------------------------------------------
 # CWE quick-reference
-# ---------------------------------------------------------------------------
 
 _VULN_CLASS_TO_CWE: dict[str, int] = {
     "SQLi": 89,

--- a/tools/report_tools.py
+++ b/tools/report_tools.py
@@ -1,5 +1,5 @@
 """
-tools/report_tools.py — Report generation for the Technical Author agent.
+tools/report_tools.py - Report generation for the Technical Author agent.
 
 Produces structured, professional H1-compatible Markdown reports from
 verified vulnerabilities.

--- a/tools/vuln_tools.py
+++ b/tools/vuln_tools.py
@@ -29,9 +29,7 @@ from models import (
 
 logger = logging.getLogger(__name__)
 
-# ---------------------------------------------------------------------------
 # Severity helpers
-# ---------------------------------------------------------------------------
 
 _NUCLEI_SEVERITY_MAP: dict[str, Severity] = {
     "info": Severity.INFORMATIONAL,
@@ -67,9 +65,7 @@ def _run(cmd: list[str], timeout: int = 300) -> subprocess.CompletedProcess:
     return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
 
 
-# ---------------------------------------------------------------------------
 # Nuclei scanner
-# ---------------------------------------------------------------------------
 
 
 def run_nuclei(endpoints: list[Endpoint]) -> list[RawFinding]:
@@ -140,9 +136,7 @@ def run_nuclei(endpoints: list[Endpoint]) -> list[RawFinding]:
     return findings
 
 
-# ---------------------------------------------------------------------------
 # SQLMap scanner
-# ---------------------------------------------------------------------------
 
 
 def run_sqlmap(endpoints: list[Endpoint]) -> list[RawFinding]:
@@ -191,9 +185,7 @@ def run_sqlmap(endpoints: list[Endpoint]) -> list[RawFinding]:
     return findings
 
 
-# ---------------------------------------------------------------------------
 # Custom checks
-# ---------------------------------------------------------------------------
 
 
 def check_cors_misconfiguration(endpoints: list[Endpoint]) -> list[RawFinding]:
@@ -242,9 +234,7 @@ def check_cors_misconfiguration(endpoints: list[Endpoint]) -> list[RawFinding]:
     return findings
 
 
-# ---------------------------------------------------------------------------
 # Penetration Tester orchestration
-# ---------------------------------------------------------------------------
 
 
 def run_pentest(recon: ReconResult) -> list[RawFinding]:
@@ -265,9 +255,7 @@ def run_pentest(recon: ReconResult) -> list[RawFinding]:
     return all_findings
 
 
-# ---------------------------------------------------------------------------
 # Vulnerability Researcher - triage & CVSS
-# ---------------------------------------------------------------------------
 
 _CVSS_DEFAULTS: dict[str, dict[Severity, tuple[float, str]]] = {
     "SQLi": {

--- a/tools/vuln_tools.py
+++ b/tools/vuln_tools.py
@@ -1,9 +1,9 @@
 """
-tools/vuln_tools.py — Penetration testing and vulnerability research tooling.
+tools/vuln_tools.py - Penetration testing and vulnerability research tooling.
 
 Two layers:
-  1. Penetration Tester  — automated scanning with nuclei, sqlmap, custom checks
-  2. Vulnerability Researcher — triage, CVSS scoring, scope validation
+  1. Penetration Tester  - automated scanning with nuclei, sqlmap, custom checks
+  2. Vulnerability Researcher - triage, CVSS scoring, scope validation
 
 External dependencies:
     nuclei   https://github.com/projectdiscovery/nuclei
@@ -104,7 +104,7 @@ def run_nuclei(endpoints: list[Endpoint]) -> list[RawFinding]:
                 config.scan.min_severity,
                 "-json",
                 "-silent",
-                # FIX: was hardcoded "10" — now reads from config
+                # FIX: was hardcoded "10" - now reads from config
                 "-rate-limit",
                 str(config.scan.nuclei_rate_limit),
             ],
@@ -167,7 +167,7 @@ def run_sqlmap(endpoints: list[Endpoint]) -> list[RawFinding]:
                 str(config.scan.sqlmap_level),
                 "--risk",
                 str(config.scan.sqlmap_risk),
-                # FIX: was hardcoded "/tmp/sqlmap-output" — now reads from config
+                # FIX: was hardcoded "/tmp/sqlmap-output" - now reads from config
                 "--output-dir",
                 config.scan.sqlmap_output_dir,
                 "--forms",
@@ -178,7 +178,7 @@ def run_sqlmap(endpoints: list[Endpoint]) -> list[RawFinding]:
         if "sqlmap identified the following injection point" in result.stdout:
             findings.append(
                 RawFinding(
-                    title=f"SQL Injection — {ep.url}",
+                    title=f"SQL Injection - {ep.url}",
                     vuln_class="SQLi",
                     target=ep.url,
                     evidence=result.stdout[-2000:],
@@ -198,7 +198,7 @@ def run_sqlmap(endpoints: list[Endpoint]) -> list[RawFinding]:
 
 def check_cors_misconfiguration(endpoints: list[Endpoint]) -> list[RawFinding]:
     """
-    Simple CORS misconfiguration check — sends a crafted Origin header
+    Simple CORS misconfiguration check - sends a crafted Origin header
     and inspects the Access-Control-Allow-Origin response header.
     """
     import time
@@ -222,7 +222,7 @@ def check_cors_misconfiguration(endpoints: list[Endpoint]) -> list[RawFinding]:
                 sev = Severity.HIGH if acac.lower() == "true" else Severity.MEDIUM
                 findings.append(
                     RawFinding(
-                        title=f"CORS Misconfiguration — {ep.url}",
+                        title=f"CORS Misconfiguration - {ep.url}",
                         vuln_class="CORS",
                         target=ep.url,
                         evidence=(
@@ -261,12 +261,12 @@ def run_pentest(recon: ReconResult) -> list[RawFinding]:
         key=lambda f: _SEVERITY_FLOOR_ORDER.index(f.severity_hint),
         reverse=True,
     )
-    logger.info("Pentest complete — %d raw findings", len(all_findings))
+    logger.info("Pentest complete - %d raw findings", len(all_findings))
     return all_findings
 
 
 # ---------------------------------------------------------------------------
-# Vulnerability Researcher — triage & CVSS
+# Vulnerability Researcher - triage & CVSS
 # ---------------------------------------------------------------------------
 
 _CVSS_DEFAULTS: dict[str, dict[Severity, tuple[float, str]]] = {
@@ -345,13 +345,13 @@ def triage_findings(
                     finding.evidence,
                 ],
                 evidence=finding.evidence,
-                impact=f"Potential {finding.vuln_class} impact — pending manual review.",
+                impact=f"Potential {finding.vuln_class} impact - pending manual review.",
                 remediation=f"Refer to OWASP guidance for {finding.vuln_class} remediation.",
             )
         )
 
     logger.info(
-        "Triage complete — %d/%d findings verified",
+        "Triage complete - %d/%d findings verified",
         len(verified),
         len(raw_findings),
     )


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `CYBERSQUAD_HUMAN_INPUT` env var (default `true`) to `config.py`
- `tasks.py` reads `config.human_input` instead of hardcoding `True` on all three gated tasks — one var now controls all of them
- `.env.example` documents the new var
- README simplified: HITL is now described in terms of the env var, with `CYBERSQUAD_HUMAN_INPUT=false python main.py` shown as the automated/container invocation

## Test plan

- [x] `python main.py` — gates active (default)
- [x] `CYBERSQUAD_HUMAN_INPUT=false python main.py` — no pauses, runs end-to-end
- [x] `pytest -m unit` passes