### PR TITLE
docs(CLAUDE.md): fix stale file refs and add tool guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,23 @@ This file is for AI assistants working on this codebase. It covers the architect
 
 3. **Never push a change you haven't actually executed.** A passing mypy run after a `type: ignore` removal means nothing if the file wasn't reachable. Run the tests.
 
+4. **Read the relevant source files and docs before planning any change.** Do not rely on a summary or prior context. Read the actual file. Check `proposals/` for in-flight design work that may affect your approach.
+
+5. **Never include session URLs in commit messages.** Links of the form `https://claude.ai/code/session_...` embed a reference to a private conversation and must not appear in commit history. Use a plain one- or two-sentence description instead.
+
+---
+
+## Git workflow
+
+The remote can change under you at any time - PRs get merged, branches get rebased, force-pushes happen. Before starting work or opening a PR:
+
+```bash
+git fetch origin
+git log --oneline origin/main..HEAD   # confirm only your commits are ahead
+```
+
+If the session assigns you a branch, verify it is actually current with `origin/main` before committing to it. If a PR has been merged since the branch was cut, create a fresh branch from updated main rather than pushing on top of a stale one. A `git diff origin/main --stat` before any push is a fast sanity check.
+
 ---
 
 ## What this project does
@@ -162,14 +179,6 @@ Tools are `@tool`-decorated functions in a `squad/<agent>/__init__.py`. The docs
 One concern per tool. The PT agent selects tools based on nmap evidence and detected technologies; bundling unrelated checks removes that selectivity.
 
 Tests must mock all network and binary calls. Patch `socket.create_connection` at the module path where it is imported (e.g. `tools.cloud.databases.redis.socket.create_connection`), not at the top-level `socket` module.
-
----
-
-## Adding a new config value
-
-1. Add a field to the appropriate dataclass in `config.py` using `default_factory=lambda: os.getenv(...)`.
-2. Document it in `.env.example` with a comment explaining valid values.
-3. If the value is used in a tool, thread it through via `config.<section>.<field>` - do not hardcode fallback values in the tool.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,11 @@ Bounty Squad is a six-agent CrewAI pipeline that autonomously selects HackerOne 
 | `squad/<member>/{description,expected_output}.md` | Two single-purpose files driving the Task description and expected output. |
 | `squad/<member>/__init__.py` | Tool functions (`@tool`) + a module-level `MEMBER = SquadMember(...)` constant. |
 | `tools/h1_api.py` | HackerOne REST client. Singleton: `from tools.h1_api import h1`. |
-| `tools/recon_tools.py` | Wraps subfinder, httpx, nmap. Contains the scope guard. |
-| `tools/vuln_tools.py` | Wraps nuclei, sqlmap, custom checks. |
+| `tools/recon/` | Recon tools: subfinder, httpx, nmap, TLS, DNS, dirfuzz, waybackurls, cert transparency, traceroute, scope guard. |
+| `tools/recon/scope.py` | `filter_in_scope()` - hard scope enforcement boundary. Do not weaken. |
+| `tools/pentest/` | Pentest tools: nuclei, sqlmap, CORS, SSRF, XSS, SRI, header injection, source maps, error disclosure. |
+| `tools/cloud/` | Cloud/service checks: S3, Azure Blob, per-engine databases, admin panels, branded panels. |
+| `tools/cloud/databases/` | Per-engine unauthenticated database checks: one file per engine. |
 | `tools/report_tools.py` | Renders Markdown reports and writes them to disk. |
 
 ---
@@ -102,7 +105,7 @@ Each agent's prose lives in five single-purpose markdown files inside its packag
 
 ## Safety invariants - do not break these
 
-**Scope enforcement** - `filter_in_scope()` in `recon_tools.py` uses an exact-match or dot-boundary check:
+**Scope enforcement** - `filter_in_scope()` in `tools/recon/scope.py` uses an exact-match or dot-boundary check:
 
 ```python
 if host == pattern or host.endswith("." + pattern):
@@ -141,6 +144,24 @@ Coverage floor is 70%. Every new public function in `tools/` needs a test. Every
 2. Import the new `MEMBER` into `_SQUAD` in `crew.py`.
 3. Wire its task into `build_tasks()` in `tasks.py` with correct `context` dependencies.
 4. Add unit tests covering the new tool's logic.
+
+---
+
+## Adding a new config value
+
+1. Add a field to the appropriate dataclass in `config.py` using `default_factory=lambda: os.getenv(...)`.
+2. Document it in `.env.example` with a comment explaining valid values.
+3. If the value is used in a tool, thread it through via `config.<section>.<field>` - do not hardcode fallback values in the tool.
+
+---
+
+## Adding a new tool
+
+Tools are `@tool`-decorated functions in a `squad/<agent>/__init__.py`. The docstring is the agent's only guidance for when and how to call the tool - write it as an instruction, not a description.
+
+One concern per tool. The PT agent selects tools based on nmap evidence and detected technologies; bundling unrelated checks removes that selectivity.
+
+Tests must mock all network and binary calls. Patch `socket.create_connection` at the module path where it is imported (e.g. `tools.cloud.databases.redis.socket.create_connection`), not at the top-level `socket` module.
 
 ---
 


### PR DESCRIPTION
- Update key files table: replace deleted recon_tools.py/vuln_tools.py with actual modular layout (tools/recon/, tools/pentest/, tools/cloud/)
- Fix scope guard file path in safety invariants (now tools/recon/scope.py)
- Add concise "Adding a new tool" section: one-concern-per-tool principle and socket patch-path gotcha for unit tests