### PR TITLE
feat: SCAN_MODE + smart dirfuzz targeting (#19)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,8 @@ CREWAI_TEMPERATURE=0.2
 H1_MIN_BOUNTY=500        # ignore programmes paying less than this (USD)
 H1_MAX_PROGRAMMES=10     # how many programmes to evaluate per run
 MIN_SEVERITY=medium      # low | medium | high | critical
-SCAN_DELAY=0.5           # seconds between requests
+SCAN_MODE=normal         # stealth | normal | raid  (sets rate-limit defaults; see config.py)
+# SCAN_DELAY=0.5         # override per-request delay (seconds); derived from SCAN_MODE if unset
 
 # -- Paths ----------------------------------------------------
 REPORTS_DIR=./reports

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,14 +39,16 @@ This file is for AI assistants working on this codebase. It covers the architect
 
 ## Git workflow
 
-The remote can change under you at any time - PRs get merged, branches get rebased, force-pushes happen. Before starting work or opening a PR:
+Always cut branches fresh from a current main. Do not reuse or rebase a branch that was used for a previous PR - once a PR merges, its commits are in main and rebasing on top of them causes conflicts that require skipping commits. The correct flow every time:
 
 ```bash
 git fetch origin
-git log --oneline origin/main..HEAD   # confirm only your commits are ahead
+git checkout main
+git pull origin main
+git checkout -b feat/your-branch-name
 ```
 
-If the session assigns you a branch, verify it is actually current with `origin/main` before committing to it. If a PR has been merged since the branch was cut, create a fresh branch from updated main rather than pushing on top of a stale one. A `git diff origin/main --stat` before any push is a fast sanity check.
+A `git diff origin/main --stat` before any push is a fast sanity check that only your intended changes are included.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -88,8 +88,7 @@ ANTHROPIC_API_KEY=your-anthropic-key
 | `H1_MIN_BOUNTY` | `500` | Minimum max-bounty in USD to consider a programme |
 | `H1_MAX_PROGRAMMES` | `10` | Number of programmes evaluated per run |
 | `MIN_SEVERITY` | `medium` | Discard findings below this severity |
-| `SCAN_DELAY` | `0.5` | Seconds between scan requests |
-| `NUCLEI_RATE_LIMIT` | `10` | Nuclei requests per second |
+| `SCAN_MODE` | `normal` | Rate-limit profile: `stealth` (2s delay, low rate), `normal` (0.5s), `raid` (0.05s + 429-adaptive backoff). Individual vars (`SCAN_DELAY`, `NUCLEI_RATE_LIMIT`, etc.) override the profile when set. |
 | `REPORTS_DIR` | `./reports` | Directory for generated report files |
 | `CYBERSQUAD_HUMAN_INPUT` | `true` | Pause for operator approval between stages; set `false` for automated runs |
 
@@ -214,7 +213,7 @@ Edit any of the five prose files in `squad/<member>/`: `role.md`, `goal.md`, `ba
 ## Ethical and legal considerations
 
 - **Only scan authorised targets.** The Programme Manager filters for programmes that explicitly permit automated scanning. Do not remove or weaken this check.
-- **Respect rate limits.** `SCAN_DELAY` and `NUCLEI_RATE_LIMIT` exist for a reason. Aggressive scanning can violate programme terms and get you banned.
+- **Respect rate limits.** Use `SCAN_MODE=stealth` or `normal` against live production targets. `raid` mode is for lab environments or programmes that explicitly invite aggressive testing. Hammering a target can violate programme terms and get you banned.
 - **Read before you approve.** When running with `CYBERSQUAD_HUMAN_INPUT=true`, review the programme selection and the report carefully before confirming each pause.
 - **Check for duplicates.** Submitting a known duplicate wastes triage time and reflects poorly on the submission record.
 - **Handle reports carefully.** The `reports/` directory contains vulnerability details and evidence. It is gitignored - do not commit or share its contents.

--- a/config.py
+++ b/config.py
@@ -5,7 +5,15 @@ Load secrets from environment variables; never hardcode credentials.
 
 import os
 from dataclasses import dataclass, field
+from enum import StrEnum
 from pathlib import Path
+
+
+class ScanMode(StrEnum):
+    STEALTH = "stealth"  # slow and quiet - conservative delays, low rate limits
+    NORMAL = "normal"  # balanced defaults
+    RAID = "raid"  # fast - aggressive rate limits, 429-adaptive backoff
+
 
 _BUNDLE_WORDLIST = str(Path(__file__).parent / "data" / "wordlists" / "common.txt")
 
@@ -59,6 +67,7 @@ class ReconConfig:
 class ScanConfig:
     """Tuning parameters for the penetration testing phase."""
 
+    scan_mode: ScanMode = field(default_factory=lambda: ScanMode(os.getenv("SCAN_MODE", "normal")))
     nuclei_templates_path: str = field(
         default_factory=lambda: os.getenv("NUCLEI_TEMPLATES", "~/.local/nuclei-templates")
     )
@@ -86,6 +95,48 @@ class ScanConfig:
     )
     tls_max_targets: int = field(default_factory=lambda: int(os.getenv("TLS_MAX_TARGETS", "10")))
     testssl_timeout: int = field(default_factory=lambda: int(os.getenv("TESTSSL_TIMEOUT", "300")))
+
+    def __post_init__(self) -> None:
+        # Per-mode rate defaults. Explicit env vars always win; this only fills
+        # in fields that were not set via their own env var.
+        _MODES: dict[ScanMode, dict[str, object]] = {
+            ScanMode.STEALTH: {
+                "request_delay": 2.0,
+                "nuclei_rate_limit": 2,
+                "dirfuzz_rate_limit": 5,
+                "dirfuzz_threads": 5,
+                "sqlmap_level": 1,
+                "sqlmap_risk": 1,
+            },
+            ScanMode.NORMAL: {
+                "request_delay": 0.5,
+                "nuclei_rate_limit": 10,
+                "dirfuzz_rate_limit": 20,
+                "dirfuzz_threads": 40,
+                "sqlmap_level": 2,
+                "sqlmap_risk": 1,
+            },
+            ScanMode.RAID: {
+                "request_delay": 0.05,
+                "nuclei_rate_limit": 100,
+                "dirfuzz_rate_limit": 150,
+                "dirfuzz_threads": 80,
+                "sqlmap_level": 3,
+                "sqlmap_risk": 2,
+            },
+        }
+        _ENV_MAP = {
+            "SCAN_DELAY": "request_delay",
+            "NUCLEI_RATE_LIMIT": "nuclei_rate_limit",
+            "DIRFUZZ_RATE_LIMIT": "dirfuzz_rate_limit",
+            "DIRFUZZ_THREADS": "dirfuzz_threads",
+            "SQLMAP_LEVEL": "sqlmap_level",
+            "SQLMAP_RISK": "sqlmap_risk",
+        }
+        mode_vals = _MODES.get(self.scan_mode, _MODES[ScanMode.NORMAL])
+        for env_var, attr in _ENV_MAP.items():
+            if os.getenv(env_var) is None:
+                setattr(self, attr, mode_vals[attr])
 
 
 @dataclass

--- a/tests/test_scan_mode.py
+++ b/tests/test_scan_mode.py
@@ -1,0 +1,155 @@
+"""
+tests/test_scan_mode.py - unit tests for SCAN_MODE config and adaptive_sleep.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class TestScanMode:
+    def test_invalid_mode_raises(self):
+        from config import ScanMode
+
+        with pytest.raises(ValueError):
+            ScanMode("turbo")
+
+    def test_stealth_sets_conservative_defaults(self, monkeypatch):
+        monkeypatch.setenv("SCAN_MODE", "stealth")
+        for var in ("SCAN_DELAY", "NUCLEI_RATE_LIMIT", "DIRFUZZ_RATE_LIMIT",
+                    "DIRFUZZ_THREADS", "SQLMAP_LEVEL", "SQLMAP_RISK"):
+            monkeypatch.delenv(var, raising=False)
+        from config import ScanConfig
+
+        c = ScanConfig()
+        assert c.request_delay == 2.0
+        assert c.nuclei_rate_limit == 2
+        assert c.dirfuzz_rate_limit == 5
+        assert c.dirfuzz_threads == 5
+        assert c.sqlmap_level == 1
+        assert c.sqlmap_risk == 1
+
+    def test_normal_preserves_existing_defaults(self, monkeypatch):
+        monkeypatch.setenv("SCAN_MODE", "normal")
+        for var in ("SCAN_DELAY", "NUCLEI_RATE_LIMIT", "DIRFUZZ_RATE_LIMIT",
+                    "DIRFUZZ_THREADS", "SQLMAP_LEVEL", "SQLMAP_RISK"):
+            monkeypatch.delenv(var, raising=False)
+        from config import ScanConfig
+
+        c = ScanConfig()
+        assert c.request_delay == 0.5
+        assert c.nuclei_rate_limit == 10
+        assert c.dirfuzz_rate_limit == 20
+        assert c.dirfuzz_threads == 40
+        assert c.sqlmap_level == 2
+
+    def test_raid_sets_aggressive_defaults(self, monkeypatch):
+        monkeypatch.setenv("SCAN_MODE", "raid")
+        for var in ("SCAN_DELAY", "NUCLEI_RATE_LIMIT", "DIRFUZZ_RATE_LIMIT",
+                    "DIRFUZZ_THREADS", "SQLMAP_LEVEL", "SQLMAP_RISK"):
+            monkeypatch.delenv(var, raising=False)
+        from config import ScanConfig
+
+        c = ScanConfig()
+        assert c.request_delay == 0.05
+        assert c.nuclei_rate_limit == 100
+        assert c.dirfuzz_rate_limit == 150
+        assert c.dirfuzz_threads == 80
+        assert c.sqlmap_level == 3
+        assert c.sqlmap_risk == 2
+
+    def test_explicit_env_var_wins_over_mode(self, monkeypatch):
+        monkeypatch.setenv("SCAN_MODE", "stealth")
+        monkeypatch.setenv("NUCLEI_RATE_LIMIT", "50")
+        monkeypatch.delenv("SCAN_DELAY", raising=False)
+        from config import ScanConfig
+
+        c = ScanConfig()
+        assert c.nuclei_rate_limit == 50  # explicit wins
+        assert c.request_delay == 2.0     # mode default applies
+
+    def test_default_mode_is_normal(self, monkeypatch):
+        monkeypatch.delenv("SCAN_MODE", raising=False)
+        for var in ("SCAN_DELAY", "NUCLEI_RATE_LIMIT"):
+            monkeypatch.delenv(var, raising=False)
+        from config import ScanConfig
+
+        c = ScanConfig()
+        assert c.scan_mode == "normal"
+        assert c.request_delay == 0.5
+
+
+class TestAdaptiveSleep:
+    def test_sleeps_for_given_delay(self, monkeypatch):
+        import importlib
+
+        import config as cfg_module
+
+        importlib.reload(cfg_module)
+        from tools._helpers import adaptive_sleep
+
+        with patch("time.sleep") as mock_sleep:
+            adaptive_sleep(1.0, 200)
+        mock_sleep.assert_called_once_with(1.0)
+
+    def test_429_doubles_delay(self, monkeypatch):
+        monkeypatch.delenv("SCAN_MODE", raising=False)
+        monkeypatch.delenv("SCAN_DELAY", raising=False)
+        from tools._helpers import adaptive_sleep
+
+        with patch("time.sleep"):
+            new_delay = adaptive_sleep(1.0, 429)
+        assert new_delay == 2.0
+
+    def test_429_caps_at_60_seconds(self, monkeypatch):
+        from tools._helpers import adaptive_sleep
+
+        with patch("time.sleep"):
+            new_delay = adaptive_sleep(50.0, 429)
+        assert new_delay == 60.0
+
+    def test_200_recovers_elevated_delay(self, monkeypatch):
+        monkeypatch.delenv("SCAN_MODE", raising=False)
+        monkeypatch.setenv("SCAN_DELAY", "0.5")
+        import importlib
+
+        import config as cfg_module
+
+        importlib.reload(cfg_module)
+        from tools._helpers import adaptive_sleep
+
+        with patch("time.sleep"):
+            new_delay = adaptive_sleep(10.0, 200)
+        # should recover towards base (0.5) by 10%
+        assert new_delay == pytest.approx(9.0, rel=0.01)
+
+    def test_200_at_base_delay_stays_constant(self, monkeypatch):
+        monkeypatch.setenv("SCAN_DELAY", "0.5")
+        import importlib
+
+        import config as cfg_module
+
+        importlib.reload(cfg_module)
+        from tools._helpers import adaptive_sleep
+
+        with patch("time.sleep"):
+            new_delay = adaptive_sleep(0.5, 200)
+        assert new_delay == 0.5
+
+    def test_recovery_does_not_go_below_base(self, monkeypatch):
+        monkeypatch.setenv("SCAN_DELAY", "0.5")
+        import importlib
+
+        import config as cfg_module
+
+        importlib.reload(cfg_module)
+        from tools._helpers import adaptive_sleep
+
+        # elevated by only a hair above base
+        with patch("time.sleep"):
+            new_delay = adaptive_sleep(0.51, 200)
+        assert new_delay >= 0.5

--- a/tests/test_scan_mode.py
+++ b/tests/test_scan_mode.py
@@ -20,8 +20,14 @@ class TestScanMode:
 
     def test_stealth_sets_conservative_defaults(self, monkeypatch):
         monkeypatch.setenv("SCAN_MODE", "stealth")
-        for var in ("SCAN_DELAY", "NUCLEI_RATE_LIMIT", "DIRFUZZ_RATE_LIMIT",
-                    "DIRFUZZ_THREADS", "SQLMAP_LEVEL", "SQLMAP_RISK"):
+        for var in (
+            "SCAN_DELAY",
+            "NUCLEI_RATE_LIMIT",
+            "DIRFUZZ_RATE_LIMIT",
+            "DIRFUZZ_THREADS",
+            "SQLMAP_LEVEL",
+            "SQLMAP_RISK",
+        ):
             monkeypatch.delenv(var, raising=False)
         from config import ScanConfig
 
@@ -35,8 +41,14 @@ class TestScanMode:
 
     def test_normal_preserves_existing_defaults(self, monkeypatch):
         monkeypatch.setenv("SCAN_MODE", "normal")
-        for var in ("SCAN_DELAY", "NUCLEI_RATE_LIMIT", "DIRFUZZ_RATE_LIMIT",
-                    "DIRFUZZ_THREADS", "SQLMAP_LEVEL", "SQLMAP_RISK"):
+        for var in (
+            "SCAN_DELAY",
+            "NUCLEI_RATE_LIMIT",
+            "DIRFUZZ_RATE_LIMIT",
+            "DIRFUZZ_THREADS",
+            "SQLMAP_LEVEL",
+            "SQLMAP_RISK",
+        ):
             monkeypatch.delenv(var, raising=False)
         from config import ScanConfig
 
@@ -49,8 +61,14 @@ class TestScanMode:
 
     def test_raid_sets_aggressive_defaults(self, monkeypatch):
         monkeypatch.setenv("SCAN_MODE", "raid")
-        for var in ("SCAN_DELAY", "NUCLEI_RATE_LIMIT", "DIRFUZZ_RATE_LIMIT",
-                    "DIRFUZZ_THREADS", "SQLMAP_LEVEL", "SQLMAP_RISK"):
+        for var in (
+            "SCAN_DELAY",
+            "NUCLEI_RATE_LIMIT",
+            "DIRFUZZ_RATE_LIMIT",
+            "DIRFUZZ_THREADS",
+            "SQLMAP_LEVEL",
+            "SQLMAP_RISK",
+        ):
             monkeypatch.delenv(var, raising=False)
         from config import ScanConfig
 
@@ -70,7 +88,7 @@ class TestScanMode:
 
         c = ScanConfig()
         assert c.nuclei_rate_limit == 50  # explicit wins
-        assert c.request_delay == 2.0     # mode default applies
+        assert c.request_delay == 2.0  # mode default applies
 
     def test_default_mode_is_normal(self, monkeypatch):
         monkeypatch.delenv("SCAN_MODE", raising=False)

--- a/tools/_helpers.py
+++ b/tools/_helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import shutil
 import subprocess
+import time
 
 from models import Severity
 
@@ -28,6 +29,30 @@ def _require_binary(name: str) -> str:
             f"Please install it before running the pipeline."
         )
     return path
+
+
+def adaptive_sleep(delay: float, status_code: int) -> float:
+    """Sleep for delay seconds then adjust based on HTTP status.
+
+    Returns the new delay to use for the next request. On 429 the delay
+    doubles (capped at 60s); when the delay is elevated it recovers gradually
+    back to config.scan.request_delay. Callers track the returned value:
+
+        _delay = config.scan.request_delay
+        for ...:
+            resp = requests.get(...)
+            _delay = adaptive_sleep(_delay, resp.status_code)
+    """
+    from config import config  # deferred - config imports nothing from tools
+
+    time.sleep(delay)
+    if status_code == 429:
+        new = min(delay * 2.0, 60.0)
+        logger.debug("429 rate-limited - backing off to %.1fs", new)
+        return new
+    if delay > config.scan.request_delay:
+        return max(delay * 0.9, config.scan.request_delay)
+    return delay
 
 
 def _run(

--- a/tools/pentest/cors.py
+++ b/tools/pentest/cors.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import logging
-import time
 
 import requests
 
 from config import config
 from models import Endpoint, RawFinding, Severity
+from tools._helpers import adaptive_sleep
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +21,7 @@ def check_cors_misconfiguration(endpoints: list[Endpoint]) -> list[RawFinding]:
     detect overly permissive CORS policies.
     """
     findings: list[RawFinding] = []
+    _delay = config.scan.request_delay
     for ep in endpoints:
         try:
             resp = requests.get(
@@ -47,7 +48,7 @@ def check_cors_misconfiguration(endpoints: list[Endpoint]) -> list[RawFinding]:
                         severity_hint=sev,
                     )
                 )
-            time.sleep(config.scan.request_delay)
+            _delay = adaptive_sleep(_delay, resp.status_code)
         except Exception as exc:
             logger.debug("CORS check failed for %s: %s", ep.url, exc)
 

--- a/tools/pentest/prompt_injection.py
+++ b/tools/pentest/prompt_injection.py
@@ -7,12 +7,12 @@ hundred battles.' - Sun Tzu
 from __future__ import annotations
 
 import logging
-import time
 
 import requests
 
 from config import config
 from models import Endpoint, RawFinding, Severity
+from tools._helpers import adaptive_sleep
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +62,7 @@ def check_prompt_injection(endpoints: list[Endpoint]) -> list[RawFinding]:
     """
     findings: list[RawFinding] = []
     seen: set[str] = set()
+    _delay = config.scan.request_delay
 
     for ep in endpoints:
         if ep.url in seen:
@@ -111,7 +112,7 @@ def check_prompt_injection(endpoints: list[Endpoint]) -> list[RawFinding]:
                         )
                         break
 
-                    time.sleep(config.scan.request_delay)
+                    _delay = adaptive_sleep(_delay, resp.status_code)
                 except Exception as exc:
                     logger.debug("Prompt injection probe failed for %s: %s", ep.url, exc)
 

--- a/tools/pentest/ssrf.py
+++ b/tools/pentest/ssrf.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import logging
-import time
 
 import requests
 
 from config import config
 from models import Endpoint, RawFinding, Severity
+from tools._helpers import adaptive_sleep
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +31,7 @@ def check_ssrf(endpoints: list[Endpoint]) -> list[RawFinding]:
     and flagging responses that contain cloud metadata markers.
     """
     findings: list[RawFinding] = []
+    _delay = config.scan.request_delay
     for ep in endpoints:
         if not ep.parameters:
             continue
@@ -58,7 +59,7 @@ def check_ssrf(endpoints: list[Endpoint]) -> list[RawFinding]:
                             )
                         )
                         break
-                    time.sleep(config.scan.request_delay)
+                    _delay = adaptive_sleep(_delay, resp.status_code)
                 except Exception as exc:
                     logger.debug("SSRF probe failed for %s: %s", ep.url, exc)
 

--- a/tools/pentest/webapp_headers.py
+++ b/tools/pentest/webapp_headers.py
@@ -8,13 +8,13 @@ check_host_headers     - Host header reflection and URL-override access-control 
 from __future__ import annotations
 
 import logging
-import time
 from urllib.parse import urlparse, urlunparse
 
 import requests
 
 from config import config
 from models import Endpoint, RawFinding, Severity
+from tools._helpers import adaptive_sleep
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +31,7 @@ def check_header_injection(endpoints: list[Endpoint]) -> list[RawFinding]:
     request headers and detecting reflected canary values in the response.
     """
     findings: list[RawFinding] = []
+    _delay = config.scan.request_delay
     for ep in endpoints:
         try:
             for header_name in _CRLF_HEADERS:
@@ -56,7 +57,7 @@ def check_header_injection(endpoints: list[Endpoint]) -> list[RawFinding]:
                         )
                     )
                     break
-            time.sleep(config.scan.request_delay)
+            _delay = adaptive_sleep(_delay, resp.status_code)
         except Exception as exc:
             logger.debug("Header injection check failed for %s: %s", ep.url, exc)
 
@@ -96,6 +97,7 @@ def check_host_headers(endpoints: list[Endpoint]) -> list[RawFinding]:
        but not directly, that is an access-control bypass.
     """
     findings: list[RawFinding] = []
+    _delay = config.scan.request_delay
 
     # De-duplicate by origin so we test each host once
     seen_origins: set[str] = set()
@@ -136,7 +138,7 @@ def check_host_headers(endpoints: list[Endpoint]) -> list[RawFinding]:
                         )
                     )
                     break
-                time.sleep(config.scan.request_delay)
+                _delay = adaptive_sleep(_delay, resp.status_code)
             except Exception as exc:
                 logger.debug("Host header check failed for %s: %s", ep.url, exc)
 
@@ -176,7 +178,7 @@ def check_host_headers(endpoints: list[Endpoint]) -> list[RawFinding]:
                                 severity_hint=Severity.HIGH,
                             )
                         )
-                    time.sleep(config.scan.request_delay)
+                    _delay = adaptive_sleep(_delay, override.status_code)
                 except Exception as exc:
                     logger.debug("URL override check failed for %s %s: %s", hdr, path, exc)
 

--- a/tools/pentest/xss.py
+++ b/tools/pentest/xss.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import logging
-import time
 import uuid
 
 import requests
 
 from config import config
 from models import Endpoint, RawFinding, Severity
+from tools._helpers import adaptive_sleep
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +29,7 @@ def check_reflected_xss(endpoints: list[Endpoint]) -> list[RawFinding]:
     """
     findings: list[RawFinding] = []
     seen: set[str] = set()
+    _delay = config.scan.request_delay
 
     for ep in endpoints:
         if not ep.parameters:
@@ -48,7 +49,7 @@ def check_reflected_xss(endpoints: list[Endpoint]) -> list[RawFinding]:
                 body = resp.text
 
                 if canary not in body:
-                    time.sleep(config.scan.request_delay)
+                    _delay = adaptive_sleep(_delay, resp.status_code)
                     continue
 
                 # Deduplicate: one finding per endpoint even if multiple params reflect
@@ -69,7 +70,7 @@ def check_reflected_xss(endpoints: list[Endpoint]) -> list[RawFinding]:
                         severity_hint=Severity.HIGH,
                     )
                 )
-                time.sleep(config.scan.request_delay)
+                _delay = adaptive_sleep(_delay, resp.status_code)
             except Exception as exc:
                 logger.debug("XSS probe failed for %s param %s: %s", ep.url, param, exc)
 

--- a/tools/recon/__init__.py
+++ b/tools/recon/__init__.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 from urllib.parse import urlparse
 
-from models import Programme, ReconResult, ScopeType
+from models import Endpoint, Programme, ReconResult, ScopeType
 from tools.recon.cert_transparency import cert_transparency
 from tools.recon.dirfuzz import discover_paths
 from tools.recon.llm import detect_llm_endpoints
@@ -22,6 +22,41 @@ from tools.recon.traceroute import run_traceroute
 from tools.recon.waybackurls import historical_urls
 
 logger = logging.getLogger(__name__)
+
+# Subdomain prefixes that are high-value dirfuzz targets: more likely to expose
+# admin interfaces, internal APIs, or sensitive paths than generic subdomains.
+_DIRFUZZ_HIGH_VALUE_PREFIXES = frozenset(
+    {
+        "admin",
+        "api",
+        "app",
+        "beta",
+        "console",
+        "dashboard",
+        "dev",
+        "internal",
+        "manage",
+        "portal",
+        "staging",
+        "test",
+    }
+)
+
+
+def _dirfuzz_targets(endpoints: list[Endpoint], seed_domains: list[str]) -> list[Endpoint]:
+    """Sort endpoints for dirfuzz priority: root domains first, high-value subdomains second."""
+    seed_set = set(seed_domains)
+
+    def _priority(ep: Endpoint) -> int:
+        hostname = urlparse(ep.url).hostname or ""
+        if hostname in seed_set:
+            return 0
+        if hostname.split(".")[0].lower() in _DIRFUZZ_HIGH_VALUE_PREFIXES:
+            return 1
+        return 2
+
+    return sorted(endpoints, key=_priority)
+
 
 __all__ = [
     "cert_transparency",
@@ -52,13 +87,14 @@ def run_recon(programme: Programme) -> ReconResult:
     all_subdomains: list[str] = []
     for domain in seed_domains:
         all_subdomains.extend(enumerate_subdomains(domain))
+    all_subdomains = list(dict.fromkeys(all_subdomains))
 
     in_scope_hosts = filter_in_scope(all_subdomains, programme)
     endpoints = probe_endpoints(in_scope_hosts)
     live_hosts = [ep.url for ep in endpoints if ep.status_code and ep.status_code < 500]
     open_ports = port_scan(live_hosts[:20])
 
-    discovered = discover_paths(endpoints)
+    discovered = discover_paths(_dirfuzz_targets(endpoints, seed_domains))
     endpoints = endpoints + discovered
 
     all_tech: list[str] = []


### PR DESCRIPTION
## Summary

- **Subdomain dedup + smart dirfuzz priority** - `run_recon()` now deduplicates subdomains before probing, and `_dirfuzz_targets()` sorts endpoints so root seed domains run first, high-value subdomains (admin, api, portal, staging, etc.) second, everything else third. Cuts wasted ffuf runs on low-value targets.
- **`SCAN_MODE=stealth/normal/raid`** - single env var sets rate-limit defaults across all tools. Explicit env vars (`NUCLEI_RATE_LIMIT`, `SCAN_DELAY`, etc.) always override the mode.
- **429-adaptive backoff** - custom HTTP tools (xss, cors, ssrf, webapp_headers, prompt_injection) now track delay state via `adaptive_sleep()`: doubles on 429 (cap 60s), recovers gradually back to the configured base. Raid mode can push hard without hammering a target that fights back.
- **CLAUDE.md** - documents the correct branch management workflow (always cut fresh from main).

## Rate profiles

| Mode | request_delay | nuclei rate | dirfuzz rate/threads | sqlmap level |
|---|---|---|---|---|
| stealth | 2.0s | 2/s | 5/s, 5 threads | 1 |
| normal | 0.5s | 10/s | 20/s, 40 threads | 2 |
| raid | 0.05s | 100/s | 150/s, 80 threads | 3 |

## Test plan

- [x] `SCAN_MODE=stealth` - verify `ScanConfig.request_delay == 2.0`, `nuclei_rate_limit == 2`
- [x] `SCAN_MODE=stealth NUCLEI_RATE_LIMIT=50` - explicit env var wins, `nuclei_rate_limit == 50`
- [x] `SCAN_MODE=invalid` - raises `ValueError` at startup
- [x] 429 response in a probe loop - delay doubles each time, caps at 60s
- [x] `pytest -m unit` - 384 passed
