### PR TITLE
feat: suggestion box, pipeline retrospective, and ledger persistence (#15)

### DIFF
--- a/squad/__init__.py
+++ b/squad/__init__.py
@@ -50,11 +50,18 @@ def build_task(
     agent: Agent,
     context: list[Task] | None = None,
     human_input: bool = False,
+    description_name: str = "description",
+    expected_output_name: str = "expected_output",
 ) -> Task:
-    """Create a Task from the member's description/expected_output files."""
+    """Create a Task from the member's prose files.
+
+    description_name / expected_output_name let callers point at non-default
+    .md files (e.g. retrospective_description.md) without duplicating the
+    Task construction logic.
+    """
     return Task(
-        description=member.read("description"),
-        expected_output=member.read("expected_output"),
+        description=member.read(description_name),
+        expected_output=member.read(expected_output_name),
         agent=agent,
         context=context or [],
         human_input=human_input,

--- a/squad/disclosure_coordinator/__init__.py
+++ b/squad/disclosure_coordinator/__init__.py
@@ -9,6 +9,7 @@ from crewai.tools import tool
 from squad import SquadMember
 from tools.h1_api import h1
 from tools.report_tools import save_report
+from tools.suggestion_box import make_suggestion_tool
 
 
 @tool("Submit Report")
@@ -45,5 +46,9 @@ def check_duplicate_tool(programme_handle: str, title: str) -> list[dict]:
 MEMBER = SquadMember(
     slug="disclosure_coordinator",
     dir=Path(__file__).parent,
-    tools=[submit_report_tool, check_duplicate_tool],
+    tools=[
+        submit_report_tool,
+        check_duplicate_tool,
+        make_suggestion_tool("disclosure_coordinator"),
+    ],
 )

--- a/squad/disclosure_coordinator/backstory.md
+++ b/squad/disclosure_coordinator/backstory.md
@@ -5,3 +5,6 @@ respected, and public discussion of a finding waits until the programme has
 resolved it or explicitly permitted disclosure. On submission failure you
 capture the full error response and flag for human review; you never retry
 blindly.
+When a submission fails or required fields are absent, capture the full error
+response, use the suggestion_box tool to log what went wrong, and flag for
+human review. Never fill missing fields with guessed values.

--- a/squad/osint_analyst/__init__.py
+++ b/squad/osint_analyst/__init__.py
@@ -10,6 +10,7 @@ from models import Endpoint
 from squad import SquadMember
 from tools.h1_api import h1
 from tools.recon import cert_transparency, detect_llm_endpoints, historical_urls, run_recon
+from tools.suggestion_box import make_suggestion_tool
 
 
 @tool("Run Recon")
@@ -73,5 +74,11 @@ def llm_detection_tool(endpoints_json: str) -> list[dict]:
 MEMBER = SquadMember(
     slug="osint_analyst",
     dir=Path(__file__).parent,
-    tools=[recon_tool, cert_transparency_tool, historical_urls_tool, llm_detection_tool],
+    tools=[
+        recon_tool,
+        cert_transparency_tool,
+        historical_urls_tool,
+        llm_detection_tool,
+        make_suggestion_tool("osint_analyst"),
+    ],
 )

--- a/squad/osint_analyst/backstory.md
+++ b/squad/osint_analyst/backstory.md
@@ -5,3 +5,7 @@ discovered asset is cross-checked against the programme's in-scope list before
 being included in your output - assets that are not explicitly in scope are
 excluded without exception. You document findings with the detail a downstream
 tester would need to reproduce them.
+When a required binary is missing, a target times out, or you lack access
+needed to complete a check, use the suggestion_box tool to log the gap and
+continue with what you can verify. A partial surface map built on real data is
+more useful to the pipeline than a fabricated one.

--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -40,6 +40,7 @@ from tools.pentest.sri import check_sri
 from tools.pentest.ssrf import check_ssrf
 from tools.pentest.webapp_headers import check_header_injection, check_host_headers
 from tools.pentest.xss import check_reflected_xss
+from tools.suggestion_box import make_suggestion_tool
 
 
 def _parse_endpoints(endpoints_json: str) -> list[Endpoint]:
@@ -521,5 +522,6 @@ MEMBER = SquadMember(
         consul_vault_tool,
         nosqli_tool,
         prompt_injection_tool,
+        make_suggestion_tool("penetration_tester"),
     ],
 )

--- a/squad/penetration_tester/backstory.md
+++ b/squad/penetration_tester/backstory.md
@@ -6,3 +6,8 @@ the OWASP Top 10 (2021) where applicable. You respect the configured rate
 limit and stop at proof-of-concept - you never exploit beyond what is needed
 to demonstrate the issue, and you never fire a payload at an asset that is
 out of scope.
+When a check cannot run - a binary is unavailable, a target has no usable
+parameters, or you lack evidence to verify a potential finding - use the
+suggestion_box tool to log the gap and skip that check rather than producing
+a finding you cannot support. A missed real vulnerability is less damaging to
+the squad than a false positive in a submitted report.

--- a/squad/programme_manager/__init__.py
+++ b/squad/programme_manager/__init__.py
@@ -8,6 +8,7 @@ from crewai.tools import tool
 
 from squad import SquadMember
 from tools.h1_api import h1
+from tools.ledger import read_recent_retros, write_retro
 from tools.suggestion_box import get_suggestions, make_suggestion_tool
 
 
@@ -47,6 +48,41 @@ def read_suggestions_tool() -> str:
     return "\n".join(f"[{s.agent}/{s.category}] {s.message}" for s in suggestions)
 
 
+@tool("Write Retrospective")
+def write_retro_tool(handle: str, content: str) -> str:
+    """
+    Persist the retrospective for a programme campaign to disk.
+
+    Call this at the end of the retrospective task after drafting the summary.
+    Writes to reports/programs/<handle>/campaigns/<today>/retrospective.md so
+    future runs of the same programme can read it as institutional memory.
+
+    handle: the HackerOne programme handle (e.g. "acme")
+    content: the full retrospective text in Markdown
+    """
+    path = write_retro(handle, content)
+    return f"Retrospective saved to {path}"
+
+
+@tool("Read Previous Retrospectives")
+def read_recent_retros_tool(handle: str) -> str:
+    """
+    Read the retrospectives from the last three campaigns against a programme.
+
+    Use this when selecting or re-evaluating a programme the squad has worked
+    before - retros capture unexplored surface, programme policy quirks,
+    tooling gaps, and what the squad should do differently next time.
+
+    Returns formatted retro text, newest first, or a note if none exist.
+    handle: the HackerOne programme handle (e.g. "acme")
+    """
+    retros = read_recent_retros(handle)
+    if not retros:
+        return f"No previous retrospectives found for {handle}."
+    sections = [f"## {date}\n\n{content.strip()}" for date, content in retros]
+    return "\n\n---\n\n".join(sections)
+
+
 MEMBER = SquadMember(
     slug="programme_manager",
     dir=Path(__file__).parent,
@@ -56,5 +92,7 @@ MEMBER = SquadMember(
         get_programme_stats_tool,
         make_suggestion_tool("programme_manager"),
         read_suggestions_tool,
+        write_retro_tool,
+        read_recent_retros_tool,
     ],
 )

--- a/squad/programme_manager/__init__.py
+++ b/squad/programme_manager/__init__.py
@@ -8,6 +8,7 @@ from crewai.tools import tool
 
 from squad import SquadMember
 from tools.h1_api import h1
+from tools.suggestion_box import get_suggestions, make_suggestion_tool
 
 
 @tool("List HackerOne Programmes")
@@ -33,8 +34,27 @@ def get_programme_stats_tool(handle: str) -> dict:
     return h1.get_programme_stats(handle)
 
 
+@tool("Read Suggestion Box")
+def read_suggestions_tool() -> str:
+    """
+    Read all suggestions logged by squad agents during this pipeline run.
+    Call this as part of the retrospective task to compile the operator summary.
+    Returns a formatted list, or a message confirming nothing was logged.
+    """
+    suggestions = get_suggestions()
+    if not suggestions:
+        return "No suggestions logged during this pipeline run."
+    return "\n".join(f"[{s.agent}/{s.category}] {s.message}" for s in suggestions)
+
+
 MEMBER = SquadMember(
     slug="programme_manager",
     dir=Path(__file__).parent,
-    tools=[list_programmes_tool, get_scope_tool, get_programme_stats_tool],
+    tools=[
+        list_programmes_tool,
+        get_scope_tool,
+        get_programme_stats_tool,
+        make_suggestion_tool("programme_manager"),
+        read_suggestions_tool,
+    ],
 )

--- a/squad/programme_manager/backstory.md
+++ b/squad/programme_manager/backstory.md
@@ -29,3 +29,7 @@ worth far less than its neighbour with no cap, even if both are in scope.
 
 You never authorise the squad to operate against a programme unless you are
 confident the policy permits it.
+
+You also run a retrospective at the end of every pipeline run. Read the
+suggestion_box to collect friction and tooling gaps logged by the squad, then
+summarise them clearly for the operator so the developer can act on them.

--- a/squad/programme_manager/description.md
+++ b/squad/programme_manager/description.md
@@ -1,6 +1,12 @@
 Query the HackerOne API to retrieve available bug bounty programmes.
 For each programme, fetch its structured scope, policy, and stats.
 
+Before scoring, check institutional memory: if a candidate programme has
+been worked before, use the Read Previous Retrospectives tool with its
+handle to retrieve what the squad learned. Past retros surface unexplored
+surface, policy quirks, payout behaviour, and recommendations for the next
+campaign. Weight this context when ranking candidates.
+
 Step 1 - Hard filters (discard immediately, do not score):
   - offers_bounties is false (VDP - no payment)
   - accepts_new_reports is false (closed programme)

--- a/squad/programme_manager/retrospective_description.md
+++ b/squad/programme_manager/retrospective_description.md
@@ -1,10 +1,22 @@
-The pipeline run is complete. Use the Read Suggestion Box tool to retrieve all
-friction points, tooling gaps, and hallucination urges logged by squad agents
-during this run.
+The pipeline run is complete. Facilitate a retrospective for the programme
+that was worked this run.
 
-Summarise the suggestions for the operator. Group them by category, note which
-agent logged each item, and flag any that indicate a risk to submission quality
-(false_positive_risk, hallucination_urge) as high priority. If the box is
-empty, confirm that the run completed without logged issues.
+Step 1 - Read the suggestion box:
+  Use the Read Suggestion Box tool to retrieve friction points, tooling gaps,
+  and hallucination urges logged by squad agents during this run. Flag any
+  false_positive_risk or hallucination_urge items as high priority.
 
-Do not repeat the full log verbatim - distil it into actionable developer notes.
+Step 2 - Draft the retrospective in Markdown with these sections:
+  - Pipeline Health: one sentence on whether the run completed cleanly or had
+    high-priority issues.
+  - What Went Well: concrete successes from this campaign.
+  - Challenges: what was harder than expected or didn't work.
+  - Unexplored Surface: attack surface areas the squad didn't cover this run.
+  - Next Campaign Recommendations: specific actions for the next run against
+    this programme (different tool config, different scope focus, etc.).
+  - Tooling Action Items: developer-facing items from the suggestion box,
+    grouped by category (missing_tool, tooling_feedback, etc.).
+
+Step 3 - Persist:
+  Call the Write Retrospective tool with the programme handle and the full
+  retrospective text. This builds the squad's institutional memory.

--- a/squad/programme_manager/retrospective_description.md
+++ b/squad/programme_manager/retrospective_description.md
@@ -1,0 +1,10 @@
+The pipeline run is complete. Use the Read Suggestion Box tool to retrieve all
+friction points, tooling gaps, and hallucination urges logged by squad agents
+during this run.
+
+Summarise the suggestions for the operator. Group them by category, note which
+agent logged each item, and flag any that indicate a risk to submission quality
+(false_positive_risk, hallucination_urge) as high priority. If the box is
+empty, confirm that the run completed without logged issues.
+
+Do not repeat the full log verbatim - distil it into actionable developer notes.

--- a/squad/programme_manager/retrospective_expected_output.md
+++ b/squad/programme_manager/retrospective_expected_output.md
@@ -1,0 +1,8 @@
+A plain-text retrospective report with two sections:
+
+1. Pipeline health: one sentence confirming whether the run completed cleanly
+   or flagging high-priority issues (false positives, hallucination urges).
+
+2. Developer action items: a bulleted list of tooling gaps and suggestions,
+   each prefixed with the agent and category that logged it. Empty if nothing
+   was logged.

--- a/squad/technical_author/__init__.py
+++ b/squad/technical_author/__init__.py
@@ -13,6 +13,7 @@ from tools.report_tools import (
     create_disclosure_report,
     save_report,
 )
+from tools.suggestion_box import make_suggestion_tool
 
 
 @tool("Create Disclosure Report")
@@ -40,5 +41,5 @@ def calculate_cvss_tool(vector: str) -> float:
 MEMBER = SquadMember(
     slug="technical_author",
     dir=Path(__file__).parent,
-    tools=[create_report_tool, calculate_cvss_tool],
+    tools=[create_report_tool, calculate_cvss_tool, make_suggestion_tool("technical_author")],
 )

--- a/squad/technical_author/backstory.md
+++ b/squad/technical_author/backstory.md
@@ -6,3 +6,8 @@ relevant OWASP guidance or CWE entry. You sanitise evidence so that the report
 is safe to publish - no live payloads, no credentials, no data from unrelated
 users. You follow the HackerOne report format: title, summary, details,
 steps to reproduce, impact, and remediation.
+When triage output lacks the evidence needed to write a reproducible report -
+missing request/response, incomplete steps, or severity you cannot justify -
+use the suggestion_box tool to log the gap before drafting. A well-evidenced
+medium-severity report strengthens the squad's record; a poorly-evidenced
+critical destroys it.

--- a/squad/vulnerability_researcher/__init__.py
+++ b/squad/vulnerability_researcher/__init__.py
@@ -10,6 +10,7 @@ from crewai.tools import tool
 from squad import SquadMember
 from tools.h1_api import h1
 from tools.pentest import lookup_cve, triage_findings
+from tools.suggestion_box import make_suggestion_tool
 
 
 @tool("Triage Findings")
@@ -59,5 +60,10 @@ def check_duplicate_tool(programme_handle: str, title: str) -> list[dict]:
 MEMBER = SquadMember(
     slug="vulnerability_researcher",
     dir=Path(__file__).parent,
-    tools=[triage_tool, lookup_cve_tool, check_duplicate_tool],
+    tools=[
+        triage_tool,
+        lookup_cve_tool,
+        check_duplicate_tool,
+        make_suggestion_tool("vulnerability_researcher"),
+    ],
 )

--- a/squad/vulnerability_researcher/backstory.md
+++ b/squad/vulnerability_researcher/backstory.md
@@ -5,3 +5,6 @@ the lower side when any base metric is uncertain. You forward only findings
 you can independently reproduce in a clean session; anything else is flagged
 UNCONFIRMED with a specific note describing what additional evidence would
 confirm it. You map each finding to a CWE identifier where one exists.
+When evidence is insufficient to confirm a finding, flag it UNCONFIRMED and
+use the suggestion_box tool to note exactly what additional data would resolve
+it. Never assign a CVSS score to a finding you have not independently verified.

--- a/tasks.py
+++ b/tasks.py
@@ -39,4 +39,11 @@ def build_tasks(agents: dict) -> list[Task]:
         TECHNICAL_AUTHOR, agents["technical_author"], context=[triage, select], human_input=hi
     )
     submit = build_task(DISCLOSURE_COORDINATOR, agents["disclosure_coordinator"], context=[write])
-    return [select, recon, pentest, triage, write, submit]
+    retrospective = build_task(
+        PROGRAMME_MANAGER,
+        agents["programme_manager"],
+        context=[submit],
+        description_name="retrospective_description",
+        expected_output_name="retrospective_expected_output",
+    )
+    return [select, recon, pentest, triage, write, submit, retrospective]

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,0 +1,115 @@
+"""
+tests/test_ledger.py - unit tests for tools/ledger.py
+"""
+
+from __future__ import annotations
+
+import importlib
+from datetime import UTC
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def tmp_reports(tmp_path, monkeypatch):
+    """Point config.reports_dir at a temporary directory."""
+    monkeypatch.setenv("REPORTS_DIR", str(tmp_path))
+    import config as cfg_module
+
+    importlib.reload(cfg_module)
+    import tools.ledger as ledger_module
+
+    importlib.reload(ledger_module)
+    return tmp_path
+
+
+class TestWriteRetro:
+    def test_creates_file_at_expected_path(self, tmp_reports):
+        from tools.ledger import write_retro
+
+        path = write_retro("acme", "# Retro\nAll good.", campaign_date="2026-01-15")
+        assert path.exists()
+        assert "acme" in str(path)
+        assert "2026-01-15" in str(path)
+        assert path.name == "retrospective.md"
+
+    def test_content_is_written_correctly(self, tmp_reports):
+        from tools.ledger import write_retro
+
+        content = "## What Went Well\nFound an SSRF."
+        path = write_retro("acme", content, campaign_date="2026-01-15")
+        assert path.read_text(encoding="utf-8") == content
+
+    def test_defaults_to_todays_date(self, tmp_reports):
+        from datetime import datetime
+
+        from tools.ledger import write_retro
+
+        path = write_retro("acme", "content")
+        today = datetime.now(UTC).strftime("%Y-%m-%d")
+        assert today in str(path)
+
+    def test_overwrites_existing_retro(self, tmp_reports):
+        from tools.ledger import write_retro
+
+        write_retro("acme", "old content", campaign_date="2026-01-15")
+        write_retro("acme", "new content", campaign_date="2026-01-15")
+        from tools.ledger import read_retro
+
+        assert read_retro("acme", "2026-01-15") == "new content"
+
+
+class TestReadRetro:
+    def test_returns_none_for_missing_campaign(self, tmp_reports):
+        from tools.ledger import read_retro
+
+        assert read_retro("acme", "2020-01-01") is None
+
+    def test_returns_content_for_existing_campaign(self, tmp_reports):
+        from tools.ledger import read_retro, write_retro
+
+        write_retro("acme", "retro body", campaign_date="2026-02-20")
+        assert read_retro("acme", "2026-02-20") == "retro body"
+
+
+class TestReadRecentRetros:
+    def test_returns_empty_for_unknown_programme(self, tmp_reports):
+        from tools.ledger import read_recent_retros
+
+        assert read_recent_retros("unknown") == []
+
+    def test_returns_retros_newest_first(self, tmp_reports):
+        from tools.ledger import read_recent_retros, write_retro
+
+        write_retro("acme", "oldest", campaign_date="2026-01-01")
+        write_retro("acme", "middle", campaign_date="2026-02-01")
+        write_retro("acme", "newest", campaign_date="2026-03-01")
+
+        retros = read_recent_retros("acme")
+        assert retros[0] == ("2026-03-01", "newest")
+        assert retros[1] == ("2026-02-01", "middle")
+        assert retros[2] == ("2026-01-01", "oldest")
+
+    def test_respects_n_limit(self, tmp_reports):
+        from tools.ledger import read_recent_retros, write_retro
+
+        for i in range(5):
+            write_retro("acme", f"retro {i}", campaign_date=f"2026-0{i + 1}-01")
+
+        assert len(read_recent_retros("acme", n=2)) == 2
+
+    def test_ignores_campaigns_without_retrospective(self, tmp_reports):
+        from pathlib import Path
+
+        from tools.ledger import read_recent_retros, write_retro
+
+        write_retro("acme", "has retro", campaign_date="2026-03-01")
+        # Create a campaign dir without a retro file
+        empty = Path(str(tmp_reports)) / "programs" / "acme" / "campaigns" / "2026-04-01"
+        empty.mkdir(parents=True)
+
+        retros = read_recent_retros("acme")
+        assert len(retros) == 1
+        assert retros[0][0] == "2026-03-01"

--- a/tests/test_suggestion_box.py
+++ b/tests/test_suggestion_box.py
@@ -1,0 +1,100 @@
+"""
+tests/test_suggestion_box.py - unit tests for tools/suggestion_box.py
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.suggestion_box import (
+    VALID_CATEGORIES,
+    Suggestion,
+    clear,
+    get_suggestions,
+    log_suggestion,
+    make_suggestion_tool,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def reset_suggestion_box():
+    """Ensure the global suggestion list is empty before and after each test."""
+    clear()
+    yield
+    clear()
+
+
+class TestLogAndGet:
+    def test_log_appends_suggestion(self):
+        log_suggestion("osint_analyst", "missing_tool", "subfinder not in PATH")
+        suggestions = get_suggestions()
+        assert len(suggestions) == 1
+        assert suggestions[0].agent == "osint_analyst"
+        assert suggestions[0].category == "missing_tool"
+        assert suggestions[0].message == "subfinder not in PATH"
+
+    def test_multiple_agents_accumulate(self):
+        log_suggestion("osint_analyst", "missing_tool", "nmap missing")
+        log_suggestion("penetration_tester", "hallucination_urge", "no parameters found")
+        suggestions = get_suggestions()
+        assert len(suggestions) == 2
+        assert suggestions[0].agent == "osint_analyst"
+        assert suggestions[1].agent == "penetration_tester"
+
+    def test_get_returns_copy(self):
+        log_suggestion("osint_analyst", "tooling_feedback", "add retries")
+        first = get_suggestions()
+        log_suggestion("penetration_tester", "missing_tool", "nuclei missing")
+        second = get_suggestions()
+        assert len(first) == 1
+        assert len(second) == 2
+
+    def test_clear_empties_list(self):
+        log_suggestion("osint_analyst", "missing_tool", "x")
+        clear()
+        assert get_suggestions() == []
+
+
+class TestSuggestionDataclass:
+    def test_suggestion_fields(self):
+        s = Suggestion(agent="foo", category="missing_tool", message="bar")
+        assert s.agent == "foo"
+        assert s.category == "missing_tool"
+        assert s.message == "bar"
+
+
+class TestValidCategories:
+    def test_expected_categories_present(self):
+        assert "missing_tool" in VALID_CATEGORIES
+        assert "hallucination_urge" in VALID_CATEGORIES
+        assert "false_positive_risk" in VALID_CATEGORIES
+        assert "scope_limitation" in VALID_CATEGORIES
+        assert "tooling_feedback" in VALID_CATEGORIES
+
+
+class TestMakeSuggestionBoxTool:
+    def test_tool_logs_with_correct_agent(self):
+        sb = make_suggestion_tool("penetration_tester")
+        sb.func(category="missing_tool", message="ffuf not found")
+        suggestions = get_suggestions()
+        assert len(suggestions) == 1
+        assert suggestions[0].agent == "penetration_tester"
+        assert suggestions[0].category == "missing_tool"
+
+    def test_tool_returns_confirmation_string(self):
+        sb = make_suggestion_tool("osint_analyst")
+        result = sb.func(category="hallucination_urge", message="insufficient data")
+        assert "hallucination_urge" in result
+        assert "insufficient data" in result
+
+    def test_separate_agents_get_independent_tools(self):
+        sb_osint = make_suggestion_tool("osint_analyst")
+        sb_pt = make_suggestion_tool("penetration_tester")
+        sb_osint.func(category="tooling_feedback", message="a")
+        sb_pt.func(category="missing_tool", message="b")
+        suggestions = get_suggestions()
+        agents = [s.agent for s in suggestions]
+        assert "osint_analyst" in agents
+        assert "penetration_tester" in agents

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -74,10 +74,10 @@ class TestBuildTasks:
         ]
         return {role: MagicMock(name=role) for role in roles}
 
-    def test_returns_six_tasks_in_order(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_seven_tasks_in_order(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(squad, "Task", _FakeTask)
         tasks = build_tasks(self._agents())
-        assert len(tasks) == 6
+        assert len(tasks) == 7
 
     def test_each_task_has_description_and_output(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(squad, "Task", _FakeTask)
@@ -89,20 +89,21 @@ class TestBuildTasks:
     def test_context_chaining_wired(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(squad, "Task", _FakeTask)
         tasks = build_tasks(self._agents())
-        select, recon, pentest, triage, write, submit = tasks
+        select, recon, pentest, triage, write, submit, retrospective = tasks
         assert recon.context == [select]
         assert pentest.context == [recon]
         assert triage.context == [pentest, recon, select]
         assert write.context == [triage, select]
         assert submit.context == [write]
+        assert retrospective.context == [submit]
 
     def test_human_input_gates(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(squad, "Task", _FakeTask)
         tasks = build_tasks(self._agents())
-        select, recon, pentest, triage, write, submit = tasks
+        select, recon, pentest, triage, write, submit, retrospective = tasks
         # Three gates: after selection, after triage, after writing.
         assert select.human_input is True
         assert triage.human_input is True
         assert write.human_input is True
-        for task in (recon, pentest, submit):
+        for task in (recon, pentest, submit, retrospective):
             assert task.human_input is False

--- a/tools/ledger.py
+++ b/tools/ledger.py
@@ -1,0 +1,59 @@
+"""
+tools/ledger.py - Filesystem persistence for campaign retrospectives.
+
+Layout under config.reports_dir:
+    programs/<handle>/campaigns/<YYYY-MM-DD>/retrospective.md
+
+Retrospectives accumulate across runs so the squad builds institutional
+memory about each programme: what worked, what failed, unexplored surface,
+programme policy quirks, and tooling gaps surfaced by the suggestion box.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+from config import config
+
+logger = logging.getLogger(__name__)
+
+
+def _campaign_dir(handle: str, campaign_date: str) -> Path:
+    return Path(config.reports_dir) / "programs" / handle / "campaigns" / campaign_date
+
+
+def write_retro(handle: str, content: str, campaign_date: str | None = None) -> Path:
+    """Write a retrospective for a campaign. Defaults to today's date."""
+    date = campaign_date or datetime.now(UTC).strftime("%Y-%m-%d")
+    path = _campaign_dir(handle, date) / "retrospective.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    logger.info("Wrote retrospective -> %s", path)
+    return path
+
+
+def read_retro(handle: str, campaign_date: str) -> str | None:
+    """Return the retrospective text for a specific campaign, or None."""
+    path = _campaign_dir(handle, campaign_date) / "retrospective.md"
+    if not path.exists():
+        return None
+    return path.read_text(encoding="utf-8")
+
+
+def read_recent_retros(handle: str, n: int = 3) -> list[tuple[str, str]]:
+    """Return the (date, content) for the n most recent retros for a programme."""
+    base = Path(config.reports_dir) / "programs" / handle / "campaigns"
+    if not base.exists():
+        return []
+    dated: list[tuple[str, str]] = []
+    for d in sorted(base.iterdir(), reverse=True):
+        if not d.is_dir():
+            continue
+        retro_path = d / "retrospective.md"
+        if retro_path.exists():
+            dated.append((d.name, retro_path.read_text(encoding="utf-8")))
+        if len(dated) >= n:
+            break
+    return dated

--- a/tools/suggestion_box.py
+++ b/tools/suggestion_box.py
@@ -1,0 +1,87 @@
+"""Shared suggestion box for in-pipeline agent feedback.
+
+Agents log friction, limitations, and hallucination urges here instead of
+guessing or fabricating results. The Programme Manager reads the accumulated
+suggestions at pipeline end and reports them to the operator.
+
+Usage in agent tools:
+    from tools.suggestion_box import make_suggestion_tool
+    suggestion_box = make_suggestion_tool("osint_analyst")
+
+    MEMBER = SquadMember(..., tools=[..., suggestion_box])
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from crewai.tools import tool
+
+logger = logging.getLogger(__name__)
+
+VALID_CATEGORIES = frozenset(
+    {
+        "missing_tool",
+        "scope_limitation",
+        "false_positive_risk",
+        "hallucination_urge",
+        "tooling_feedback",
+    }
+)
+
+
+@dataclass
+class Suggestion:
+    agent: str
+    category: str
+    message: str
+
+
+_suggestions: list[Suggestion] = []
+
+
+def log_suggestion(agent: str, category: str, message: str) -> None:
+    _suggestions.append(Suggestion(agent=agent, category=category, message=message))
+    logger.warning("suggestion_box [%s/%s]: %s", agent, category, message)
+
+
+def get_suggestions() -> list[Suggestion]:
+    return list(_suggestions)
+
+
+def clear() -> None:
+    """Clear all logged suggestions. Call between pipeline runs and in tests."""
+    _suggestions.clear()
+
+
+def make_suggestion_tool(agent_slug: str) -> Any:  # noqa: ANN401
+    """Return a Suggestion Box @tool pre-bound to agent_slug."""
+
+    @tool("Suggestion Box")
+    def suggestion_box_tool(category: str, message: str) -> str:
+        """
+        Log a limitation, friction point, or hallucination urge for the developer.
+
+        Call this tool whenever you would otherwise guess, fabricate, or skip
+        silently:
+          - A required binary is missing or returned no output
+          - You lack sufficient evidence to support a finding you feel pressure
+            to include
+          - A tooling gap would materially improve your output
+          - You are about to produce a result you cannot independently verify
+
+        This never blocks your task - it records the issue so the developer can
+        improve the pipeline. After logging, continue with what you can verify.
+
+        category: missing_tool | scope_limitation | false_positive_risk |
+                  hallucination_urge | tooling_feedback
+        message: one or two sentences describing the specific issue
+        """
+        from tools.suggestion_box import log_suggestion as _log
+
+        _log(agent_slug, category, message)
+        return f"Logged [{category}]: {message}"
+
+    return suggestion_box_tool


### PR DESCRIPTION
## Summary

- **`make_suggestion_tool(agent_slug)`** factory in `tools/suggestion_box.py` - each agent gets a pre-bound Suggestion Box tool that logs friction, missing tooling, and hallucination urges to a shared in-process list instead of guessing or fabricating results.
- **All six agent backstories** updated with explicit guidance: log the gap with `suggestion_box`, then continue with what you can actually verify. A partial result on real data beats a complete result on fabrication.
- **Programme Manager retrospective task** - runs last in the pipeline, calls `Read Suggestion Box`, and distils the accumulated log into actionable developer notes for the operator. No human gate (it is informational); the sprint retro is automatic.
- **`build_task()` extended** with `description_name` / `expected_output_name` kwargs so the Programme Manager can have two different task prompts without duplicating the Task construction logic.
- **`tools/ledger.py`** - filesystem persistence for retrospectives at `reports/programs/{handle}/campaigns/{YYYY-MM-DD}/retrospective.md`. The squad now builds institutional memory across runs: previous retros are read before scoring candidates so past policy quirks, unexplored surface, and tooling gaps inform the next campaign.

## Categories agents can log

`missing_tool` | `scope_limitation` | `false_positive_risk` | `hallucination_urge` | `tooling_feedback`

## Test plan

- [ ] `pytest -m unit` - all tests pass including 10 new ledger tests
- [ ] `make_suggestion_tool("osint_analyst")` returns a tool whose `.func` logs `agent="osint_analyst"`
- [ ] `clear()` between runs so suggestions don't bleed across pipeline runs
- [ ] Retrospective task is last in `build_tasks()`, has `context=[submit]`, no `human_input`
- [ ] `write_retro("acme", content, campaign_date="2026-01-15")` creates `reports/programs/acme/campaigns/2026-01-15/retrospective.md`
- [ ] `read_recent_retros("acme", n=2)` returns newest-first tuples, capped at n