### PR TITLE
fix: `--dry-run` - ensure CYBERSQUAD_HUMAN_INPUT is global

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ import argparse
 import logging
 import os
 import sys
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
@@ -116,8 +116,8 @@ def main() -> None:
         dry_run_summary(crew)
         return
 
-    run_id = datetime.utcnow().strftime("%Y%m%d-%H%M%S") + "-" + uuid4().hex[:6]
-    started_at = datetime.utcnow()
+    run_id = datetime.now(UTC).strftime("%Y%m%d-%H%M%S") + "-" + uuid4().hex[:6]
+    started_at = datetime.now(UTC)
 
     console.rule("[bold]Bounty Squad[/bold]")
     logger.info(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,12 +3,12 @@ requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "bounty-squad"
+name = "cybersquad"
 version = "0.1.0"
 description = "Autonomous bug bounty pipeline powered by CrewAI"
 requires-python = ">=3.12"
 dependencies = [
-    "crewai>=0.80.0",
+    "crewai[anthropic]>=0.80.0",
     "crewai-tools>=0.15.0",
     "pydantic>=2.7.0",
     "requests>=2.32.0",

--- a/tasks.py
+++ b/tasks.py
@@ -26,17 +26,28 @@ from squad.vulnerability_researcher import MEMBER as VULNERABILITY_RESEARCHER
 
 def build_tasks(agents: dict) -> list[Task]:
     hi = config.human_input
+
     select = build_task(PROGRAMME_MANAGER, agents["programme_manager"], human_input=hi)
-    recon = build_task(OSINT_ANALYST, agents["osint_analyst"], context=[select])
-    pentest = build_task(PENETRATION_TESTER, agents["penetration_tester"], context=[recon])
+
+    recon = build_task(OSINT_ANALYST, agents["osint_analyst"], context=[select], human_input=hi)
+
+    pentest = build_task(
+        PENETRATION_TESTER, agents["penetration_tester"], context=[recon], human_input=hi
+    )
+
     triage = build_task(
         VULNERABILITY_RESEARCHER,
         agents["vulnerability_researcher"],
         context=[pentest, recon, select],
         human_input=hi,
     )
+
     write = build_task(
         TECHNICAL_AUTHOR, agents["technical_author"], context=[triage, select], human_input=hi
     )
-    submit = build_task(DISCLOSURE_COORDINATOR, agents["disclosure_coordinator"], context=[write])
+
+    submit = build_task(
+        DISCLOSURE_COORDINATOR, agents["disclosure_coordinator"], context=[write], human_input=hi
+    )
+
     return [select, recon, pentest, triage, write, submit]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -40,7 +40,7 @@ class TestEstimateCost:
 
 class TestBuildRunMetrics:
     def _started(self) -> datetime:
-        return datetime.utcnow() - timedelta(seconds=10)
+        return datetime.now(UTC) - timedelta(seconds=10)
 
     def test_duration_is_positive(self) -> None:
         m = build_run_metrics("r1", self._started(), "claude-sonnet-4-20250514", 100, 50)
@@ -63,7 +63,7 @@ class TestBuildRunMetrics:
 
 class TestSaveMetrics:
     def test_writes_valid_json(self, tmp_path: Path) -> None:
-        started = datetime.utcnow() - timedelta(seconds=5)
+        started = datetime.now(UTC) - timedelta(seconds=5)
         m = build_run_metrics("test-run", started, "claude-sonnet-4-20250514", 100, 50)
         out = save_metrics(m, str(tmp_path))
         assert out.exists()
@@ -72,7 +72,7 @@ class TestSaveMetrics:
         assert data["total_tokens"] == 150
 
     def test_creates_parent_dirs(self, tmp_path: Path) -> None:
-        started = datetime.utcnow() - timedelta(seconds=1)
+        started = datetime.now(UTC) - timedelta(seconds=1)
         m = build_run_metrics("nested-run", started, "claude-haiku-4-5-20251001", 0, 0)
         out = save_metrics(m, str(tmp_path / "new" / "dir"))
         assert out.exists()
@@ -80,7 +80,7 @@ class TestSaveMetrics:
 
 class TestPrintMetrics:
     def test_prints_without_error(self, capsys: pytest.CaptureFixture) -> None:
-        started = datetime.utcnow() - timedelta(seconds=3)
+        started = datetime.now(UTC) - timedelta(seconds=3)
         m = build_run_metrics(
             "print-test",
             started,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -155,13 +155,13 @@ class TestSubmissionResult:
         assert result.report_id is None
 
     def test_successful_submission(self):
-        from datetime import datetime
+        from datetime import UTC, datetime
 
         result = SubmissionResult(
             report_id="12345",
             status=SubmissionStatus.SUBMITTED,
             h1_url="https://hackerone.com/reports/12345",
-            submitted_at=datetime.utcnow(),
+            submitted_at=datetime.now(UTC),
         )
         assert result.report_id == "12345"
         assert result.submitted_at is not None

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -98,6 +98,7 @@ class TestBuildTasks:
 
     def test_human_input_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import importlib
+
         import config as config_mod
         import tasks as tasks_mod
 
@@ -112,6 +113,7 @@ class TestBuildTasks:
 
     def test_human_input_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import importlib
+
         import config as config_mod
         import tasks as tasks_mod
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -108,6 +108,7 @@ class TestBuildTasks:
         monkeypatch.setattr(squad, "Task", _FakeTask)
 
         from tasks import build_tasks as _build_tasks
+
         tasks = _build_tasks(self._agents())
         assert all(t.human_input is True for t in tasks)
 
@@ -123,5 +124,6 @@ class TestBuildTasks:
         monkeypatch.setattr(squad, "Task", _FakeTask)
 
         from tasks import build_tasks as _build_tasks
+
         tasks = _build_tasks(self._agents())
         assert all(t.human_input is False for t in tasks)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -96,13 +96,30 @@ class TestBuildTasks:
         assert write.context == [triage, select]
         assert submit.context == [write]
 
-    def test_human_input_gates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_human_input_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import importlib
+        import config as config_mod
+        import tasks as tasks_mod
+
+        monkeypatch.setenv("CYBERSQUAD_HUMAN_INPUT", "true")
+        importlib.reload(config_mod)
+        importlib.reload(tasks_mod)
         monkeypatch.setattr(squad, "Task", _FakeTask)
-        tasks = build_tasks(self._agents())
-        select, recon, pentest, triage, write, submit = tasks
-        # Three gates: after selection, after triage, after writing.
-        assert select.human_input is True
-        assert triage.human_input is True
-        assert write.human_input is True
-        for task in (recon, pentest, submit):
-            assert task.human_input is False
+
+        from tasks import build_tasks as _build_tasks
+        tasks = _build_tasks(self._agents())
+        assert all(t.human_input is True for t in tasks)
+
+    def test_human_input_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import importlib
+        import config as config_mod
+        import tasks as tasks_mod
+
+        monkeypatch.setenv("CYBERSQUAD_HUMAN_INPUT", "false")
+        importlib.reload(config_mod)
+        importlib.reload(tasks_mod)
+        monkeypatch.setattr(squad, "Task", _FakeTask)
+
+        from tasks import build_tasks as _build_tasks
+        tasks = _build_tasks(self._agents())
+        assert all(t.human_input is False for t in tasks)

--- a/tools/h1_api.py
+++ b/tools/h1_api.py
@@ -13,7 +13,7 @@ H1 API docs: https://api.hackerone.com/docs/v1
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import cast
 
 import requests
@@ -221,7 +221,7 @@ class H1Client:
                 status=SubmissionStatus.SUBMITTED,
                 h1_url=f"https://hackerone.com/reports/{report_id}",
                 # FIX: submitted_at was not set, leaving it always None
-                submitted_at=datetime.utcnow(),
+                submitted_at=datetime.now(UTC),
             )
         except requests.HTTPError as exc:
             logger.error("Submission failed: %s", exc.response.text)

--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from models import RunMetrics
@@ -45,7 +45,7 @@ def build_run_metrics(
     findings_verified: int = 0,
     submitted: bool = False,
 ) -> RunMetrics:
-    completed_at = datetime.utcnow()
+    completed_at = datetime.now(UTC)
     return RunMetrics(
         run_id=run_id,
         started_at=started_at,

--- a/tools/report_tools.py
+++ b/tools/report_tools.py
@@ -8,7 +8,7 @@ verified vulnerabilities.
 from __future__ import annotations
 
 import textwrap
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from config import config
@@ -185,7 +185,7 @@ def build_report_markdown(
         evidence=textwrap.indent(vulnerability.evidence[:2000], "  "),
         impact=vulnerability.impact,
         remediation=vulnerability.remediation,
-        timestamp=datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC"),
+        timestamp=datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC"),
     )
 
 
@@ -214,7 +214,7 @@ def save_report(report: DisclosureReport) -> Path:
     reports_dir = Path(config.reports_dir)
     reports_dir.mkdir(parents=True, exist_ok=True)
 
-    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
     safe_title = report.title.replace(" ", "_").replace("/", "-")[:60]
     filename = reports_dir / f"{timestamp}_{report.programme_handle}_{safe_title}.md"
 


### PR DESCRIPTION
fixes made to get `--dry-run` firing and looking legit

- ensure CYBERSQUAD_HUMAN_INPUT is global
- anthropic package required
- fix project name
- deprecated usage of datetime.datetime.utcnow bleeding all over pytest