### PR TITLE
fix: use hacker API endpoints (/hackers/*) instead of customer endpoints

### DIFF
--- a/tests/test_h1_api.py
+++ b/tests/test_h1_api.py
@@ -258,11 +258,12 @@ class TestListProgrammes:
         for r in responses:
             r.raise_for_status = MagicMock()
 
-        with patch.object(h1_client._session, "get", side_effect=responses):
+        with patch.object(h1_client._session, "get", side_effect=responses) as mock_get:
             result = h1_client.list_programmes(page_size=5)
 
         assert len(result) <= 10
         assert result[0]["id"] == "p0"
+        assert "/hackers/programs" in mock_get.call_args_list[0][0][0]
 
     def test_get_programme_policy_hits_endpoint(self, h1_client):
         mock_response = MagicMock()
@@ -273,7 +274,7 @@ class TestListProgrammes:
             result = h1_client.get_programme_policy("acme")
 
         assert result == {"data": {"attributes": {"handle": "acme"}}}
-        assert "/programs/acme" in mock_get.call_args[0][0]
+        assert "/hackers/programs/acme" in mock_get.call_args[0][0]
 
     def test_get_structured_scope_hits_endpoint(self, h1_client):
         mock_response = MagicMock()
@@ -284,7 +285,7 @@ class TestListProgrammes:
             result = h1_client.get_structured_scope("acme")
 
         assert result == {"data": []}
-        assert "/programs/acme/structured_scopes" in mock_get.call_args[0][0]
+        assert "/hackers/programs/acme/structured_scopes" in mock_get.call_args[0][0]
 
 
 class TestGetProgrammeStats:

--- a/tests/test_h1_api.py
+++ b/tests/test_h1_api.py
@@ -2,6 +2,10 @@
 tests/test_h1_api.py - unit tests for tools/h1_api.py
 
 All HTTP calls are mocked - no real H1 API calls made.
+
+These tests cover the HACKER API (/hackers/* endpoints), not the customer API
+(/programs). Endpoint path assertions explicitly require the /hackers/ prefix
+so a regression back to customer endpoints will fail immediately.
 """
 
 from __future__ import annotations

--- a/tools/h1_api.py
+++ b/tools/h1_api.py
@@ -96,7 +96,7 @@ class H1Client:
         """
         results: list[dict] = []
         params = {"page[size]": page_size}
-        path = "/programs"
+        path = "/hackers/programs"
 
         while path and len(results) < config.h1.max_programmes:
             data = self._get(path, params)
@@ -108,11 +108,11 @@ class H1Client:
 
     def get_programme_policy(self, handle: str) -> dict:
         """Fetch full policy detail for a given programme handle."""
-        return self._get(f"/programs/{handle}")
+        return self._get(f"/hackers/programs/{handle}")
 
     def get_structured_scope(self, handle: str) -> dict:
         """Fetch the structured scope (in/out) for a programme."""
-        return self._get(f"/programs/{handle}/structured_scopes")
+        return self._get(f"/hackers/programs/{handle}/structured_scopes")
 
     # Data parsers
 
@@ -232,7 +232,7 @@ class H1Client:
 
     def get_programme_stats(self, handle: str) -> dict:
         """Return response efficiency and payout stats for a programme."""
-        data = self._get(f"/programs/{handle}")
+        data = self._get(f"/hackers/programs/{handle}")
         attrs = data.get("data", {}).get("attributes", {})
         return {
             "handle": handle,
@@ -249,7 +249,7 @@ class H1Client:
     def list_reports(self, programme_handle: str, page_size: int = 25) -> list[dict]:
         """List recent reports for a programme - used for duplicate detection."""
         data = self._get(
-            "/reports",
+            "/hackers/me/reports",
             params={"filter[program][]": programme_handle, "page[size]": page_size},
         )
         return list(data.get("data", []))

--- a/tools/h1_api.py
+++ b/tools/h1_api.py
@@ -1,13 +1,19 @@
 """
 tools/h1_api.py - HackerOne API wrapper.
 
+Uses the HACKER API (api.hackerone.com/v1/hackers/*), not the customer/company
+API. The hacker API authenticates with a personal H1 API token and returns
+programmes accessible to that hacker (public programmes + private invitations).
+The customer API (/v1/programs) requires company admin credentials and is not
+used here.
+
 Covers everything the pipeline needs:
   - Listing & ranking programmes
   - Fetching programme policy / scope
   - Submitting reports
   - Polling submission status
 
-H1 API docs: https://api.hackerone.com/docs/v1
+H1 hacker API docs: https://api.hackerone.com/hacker-resources/
 """
 
 from __future__ import annotations
@@ -54,8 +60,11 @@ _H1_SCOPE_TYPE_MAP: dict[str, ScopeType] = {
 
 class H1Client:
     """
-    Thin, authenticated wrapper around the HackerOne v1 REST API.
+    Thin, authenticated wrapper around the HackerOne v1 hacker REST API.
     All methods raise on non-2xx responses after logging the error.
+
+    Authenticates as a hacker (personal API token), not as a company/customer.
+    All programme endpoints use the /hackers/ namespace.
     """
 
     def __init__(self) -> None:
@@ -91,7 +100,9 @@ class H1Client:
 
     def list_programmes(self, page_size: int = 25) -> list[dict]:
         """
-        Return raw programme data from /programs.
+        Return raw programme data from /hackers/programs.
+        Returns only programmes accessible to the authenticated hacker -
+        public programmes plus any private invitations.
         Paginates until we have at least config.h1.max_programmes results.
         """
         results: list[dict] = []


### PR DESCRIPTION
Some dumb shit from poor promoting on my part due to not actually looking at the H1 API myself. This addresses the fact that the program managers tools were pointed at the flippin organisation /customer API and not at the hacker API.

/programs, /programs/{handle}, /programs/{handle}/structured_scopes and /reports were all customer-only endpoints returning 401 with a hacker API key. Replaced with /hackers/programs, /hackers/programs/{handle}, /hackers/programs/{handle}/structured_scopes and /hackers/me/reports.
