### PR TITLE
feat: open redirect probe for penetration tester (#48)

### DIFF
--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -33,6 +33,7 @@ from tools.pentest.cors import check_cors_misconfiguration
 from tools.pentest.errors import check_error_disclosure
 from tools.pentest.nosqli import run_nosqli
 from tools.pentest.nuclei import run_nuclei
+from tools.pentest.open_redirect import check_open_redirect
 from tools.pentest.prompt_injection import check_prompt_injection
 from tools.pentest.sourcemaps import check_js_source_maps
 from tools.pentest.sqlmap import run_sqlmap
@@ -150,6 +151,29 @@ def source_maps_tool(recon_result_json: str) -> list[dict]:
     """
     recon = ReconResult.model_validate_json(recon_result_json)
     return [f.model_dump() for f in check_js_source_maps(recon.endpoints)]
+
+
+@tool("Open Redirect Probe")
+def open_redirect_tool(endpoints_json: str) -> list[dict]:
+    """
+    Inject external URL payloads (https, protocol-relative, backslash, userinfo)
+    into URL parameters and check whether the response Location, Refresh header,
+    or meta-refresh tag points to the canary host.
+
+    endpoints_json: JSON array of endpoint objects. Prioritise endpoints that have
+      parameters AND where any of the following apply:
+      - Parameter names look redirect-shaped (redirect, redirect_uri, return,
+        return_to, returnto, next, url, dest, destination, goto, target, link,
+        forward, continue, callback, rurl, r, u)
+      - Path looks like an auth flow (/login, /logout, /signin, /oauth, /sso)
+      - Recon noted a 30x response on the endpoint already
+      Example: '[{"url": "https://example.com/login", "parameters": ["next"]}]'
+
+    Open redirect on its own is typically MEDIUM, but it escalates on OAuth
+    redirect_uri and SSO callback endpoints (token theft) - flag those for VR.
+    Returns raw findings as dicts.
+    """
+    return [f.model_dump() for f in check_open_redirect(_parse_endpoints(endpoints_json))]
 
 
 @tool("Reflected XSS Probe")
@@ -498,6 +522,7 @@ MEMBER = SquadMember(
         header_injection_tool,
         host_header_tool,
         source_maps_tool,
+        open_redirect_tool,
         xss_probe_tool,
         sri_check_tool,
         error_disclosure_tool,

--- a/tests/test_open_redirect.py
+++ b/tests/test_open_redirect.py
@@ -1,0 +1,174 @@
+"""tests/test_open_redirect.py - unit tests for tools/pentest/open_redirect.py"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from models import Endpoint, Severity
+from tools.pentest.open_redirect import (
+    _PAYLOAD_HOST,
+    _redirect_target,
+    _redirects_to_canary,
+    check_open_redirect,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _resp(status: int = 302, headers: dict[str, str] | None = None, body: str = "") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.headers = headers or {}
+    resp.text = body
+    return resp
+
+
+class TestRedirectTarget:
+    def test_picks_up_location_header(self):
+        assert _redirect_target(_resp(headers={"Location": "https://x/"})) == "https://x/"
+
+    def test_picks_up_refresh_header(self):
+        target = _redirect_target(_resp(status=200, headers={"Refresh": "0; url=https://x/"}))
+        assert target == "https://x/"
+
+    def test_picks_up_meta_refresh(self):
+        body = '<html><head><meta http-equiv="refresh" content="0;url=https://x/"></head></html>'
+        assert _redirect_target(_resp(status=200, body=body)) == "https://x/"
+
+    def test_returns_none_when_no_redirect(self):
+        assert _redirect_target(_resp(status=200, body="<html>plain page</html>")) is None
+
+
+class TestRedirectsToCanary:
+    def test_matches_absolute_url(self):
+        assert _redirects_to_canary(f"https://{_PAYLOAD_HOST}/")
+
+    def test_matches_protocol_relative(self):
+        assert _redirects_to_canary(f"//{_PAYLOAD_HOST}/some/path")
+
+    def test_matches_subdomain_of_canary(self):
+        assert _redirects_to_canary(f"https://sub.{_PAYLOAD_HOST}/")
+
+    def test_does_not_match_when_canary_is_only_in_path(self):
+        # Server safely placed our payload inside the path of the legitimate
+        # host - browser would stay on-origin, so this is NOT a finding.
+        assert not _redirects_to_canary(f"https://app.example.com/{_PAYLOAD_HOST}/")
+
+    def test_does_not_match_unrelated_host(self):
+        assert not _redirects_to_canary("https://app.example.com/dashboard")
+
+
+class TestCheckOpenRedirect:
+    def test_detects_30x_to_canary(self):
+        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
+
+        def fake_get(url, **kwargs):
+            payload = url.split("next=", 1)[1]
+            return _resp(status=302, headers={"Location": payload})
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_open_redirect([ep])
+
+        assert len(results) == 1
+        assert results[0].vuln_class == "OpenRedirect"
+        assert results[0].severity_hint == Severity.MEDIUM
+        assert "next" in results[0].evidence
+        assert _PAYLOAD_HOST in results[0].evidence
+
+    def test_detects_meta_refresh_redirect(self):
+        ep = Endpoint(url="https://app.example.com/go", status_code=200, parameters=["dest"])
+
+        def fake_get(url, **kwargs):
+            payload = url.split("dest=", 1)[1]
+            body = (
+                f'<html><head><meta http-equiv="refresh" content="0;url={payload}"></head></html>'
+            )
+            return _resp(status=200, body=body)
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_open_redirect([ep])
+
+        assert len(results) == 1
+        assert "Redirect target" in results[0].evidence
+
+    def test_no_finding_when_redirect_stays_on_origin(self):
+        # Application sanitises by ignoring our payload and redirecting home
+        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
+
+        def fake_get(url, **kwargs):
+            return _resp(status=302, headers={"Location": "/dashboard"})
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_open_redirect([ep])
+
+        assert results == []
+
+    def test_no_finding_when_no_redirect_at_all(self):
+        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
+
+        def fake_get(url, **kwargs):
+            return _resp(status=200, body="<html>login form</html>")
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_open_redirect([ep])
+
+        assert results == []
+
+    def test_skips_endpoints_without_parameters(self):
+        ep = Endpoint(url="https://app.example.com/about", status_code=200)
+        with patch("requests.get") as mock_get:
+            results = check_open_redirect([ep])
+        mock_get.assert_not_called()
+        assert results == []
+
+    def test_skips_server_error_endpoints(self):
+        ep = Endpoint(url="https://app.example.com/", status_code=500, parameters=["url"])
+        with patch("requests.get") as mock_get:
+            results = check_open_redirect([ep])
+        mock_get.assert_not_called()
+        assert results == []
+
+    def test_one_finding_per_endpoint_even_with_multiple_vuln_params(self):
+        ep = Endpoint(
+            url="https://app.example.com/login",
+            status_code=200,
+            parameters=["next", "return_to"],
+        )
+
+        def fake_get(url, **kwargs):
+            # Both params would redirect if probed
+            for key in ("next=", "return_to="):
+                if key in url:
+                    payload = url.split(key, 1)[1]
+                    return _resp(status=302, headers={"Location": payload})
+            return _resp(status=200)
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_open_redirect([ep])
+
+        assert len(results) == 1
+
+    def test_protocol_relative_payload_in_location(self):
+        # Server normalises a backslash payload to protocol-relative
+        ep = Endpoint(url="https://app.example.com/r", status_code=200, parameters=["u"])
+
+        def fake_get(url, **kwargs):
+            return _resp(status=302, headers={"Location": f"//{_PAYLOAD_HOST}/"})
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_open_redirect([ep])
+
+        assert len(results) == 1
+
+    def test_network_exception_is_swallowed(self):
+        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
+        with patch("requests.get", side_effect=Exception("network error")):
+            results = check_open_redirect([ep])
+        assert results == []
+
+    def test_payloads_use_a_reserved_canary_host(self):
+        # Defence in depth: our payload host must be a reserved TLD so even
+        # if a victim browser followed the redirect, no live service receives it.
+        assert _PAYLOAD_HOST.endswith(".invalid")

--- a/tools/pentest/open_redirect.py
+++ b/tools/pentest/open_redirect.py
@@ -1,0 +1,133 @@
+"""Open Redirect detection by injecting external URL payloads into parameters."""
+
+from __future__ import annotations
+
+import logging
+import re
+from urllib.parse import urlparse
+
+import requests
+
+from config import config
+from models import Endpoint, RawFinding, Severity
+from tools._helpers import adaptive_sleep
+
+logger = logging.getLogger(__name__)
+
+# Reserved-TLD canary host (RFC 2606) - guaranteed not to resolve, so even if
+# a victim browser followed the redirect there is no live host to receive it.
+_PAYLOAD_HOST = "evil.bountysquad-canary.invalid"
+
+# Multiple encodings of the same canary so we catch apps that try to
+# allowlist-by-prefix or strip the scheme without parsing the rest.
+_PAYLOADS = [
+    f"https://{_PAYLOAD_HOST}/",
+    f"//{_PAYLOAD_HOST}/",
+    # Backslash trick: some servers normalise \ to / before placing the value
+    # in a Location header, turning this into a protocol-relative redirect.
+    f"/\\{_PAYLOAD_HOST}/",
+    # Userinfo confusion: naive validators that look for a known prefix can
+    # be fooled into letting the real host through as the "user" component.
+    f"https://example.com@{_PAYLOAD_HOST}/",
+]
+
+# Catch <meta http-equiv="refresh" content="0;url=..."> in the body when the
+# server returns 200 + meta-refresh instead of an HTTP 30x.
+_META_REFRESH_RE = re.compile(
+    r"""<meta[^>]+http-equiv\s*=\s*["']?refresh["']?[^>]+url\s*=\s*([^"'>\s]+)""",
+    re.IGNORECASE,
+)
+
+
+def _redirect_target(resp: requests.Response) -> str | None:
+    """Return the URL the response would redirect to, or None."""
+    loc = resp.headers.get("Location")
+    if loc:
+        return loc
+    refresh = resp.headers.get("Refresh")
+    if refresh:
+        # Format: "0; url=https://..." (case-insensitive on the url= key)
+        match = re.search(r"url\s*=\s*(.+)", refresh, re.IGNORECASE)
+        if match:
+            return match.group(1).strip().strip(";").strip()
+    body = resp.text[:4000]
+    match = _META_REFRESH_RE.search(body)
+    if match:
+        return match.group(1).strip()
+    return None
+
+
+def _redirects_to_canary(target: str) -> bool:
+    """True if the redirect target resolves to our canary host."""
+    # Treat protocol-relative URLs as having an http scheme so urlparse can
+    # populate hostname. Backslash-prefixed values that the server did NOT
+    # normalise stay as paths (no host) and correctly fall through as False.
+    parsed = urlparse(target if "://" in target else f"http:{target}")
+    host = (parsed.hostname or "").lower()
+    return host == _PAYLOAD_HOST or host.endswith("." + _PAYLOAD_HOST)
+
+
+def check_open_redirect(endpoints: list[Endpoint]) -> list[RawFinding]:
+    """
+    Probe parameterised endpoints for open redirect by injecting external URL
+    payloads and checking whether the response Location, Refresh header, or
+    meta-refresh tag points to our canary host.
+
+    One finding per endpoint - we stop after the first parameter+payload that
+    triggers, because the agent only needs to know the endpoint is vulnerable.
+    """
+    findings: list[RawFinding] = []
+    seen: set[str] = set()
+    _delay = config.scan.request_delay
+
+    for ep in endpoints:
+        if not ep.parameters:
+            continue
+        if ep.status_code and ep.status_code >= 500:
+            continue
+        if ep.url in seen:
+            continue
+
+        triggered = False
+        for param in ep.parameters:
+            if triggered:
+                break
+            for payload in _PAYLOADS:
+                try:
+                    test_url = f"{ep.url}?{param}={payload}"
+                    resp = requests.get(  # nosemgrep
+                        test_url,
+                        timeout=config.recon.http_timeout,
+                        allow_redirects=False,
+                    )
+                    target = _redirect_target(resp)
+                    if target and _redirects_to_canary(target):
+                        findings.append(
+                            RawFinding(
+                                title=f"Open Redirect - {ep.url}",
+                                vuln_class="OpenRedirect",
+                                target=ep.url,
+                                evidence=(
+                                    f"Parameter: {param}\n"
+                                    f"Payload: {payload}\n"
+                                    f"Status: {resp.status_code}\n"
+                                    f"Redirect target: {target}"
+                                ),
+                                tool="open_redirect_probe",
+                                severity_hint=Severity.MEDIUM,
+                            )
+                        )
+                        seen.add(ep.url)
+                        triggered = True
+                        break
+                    _delay = adaptive_sleep(_delay, resp.status_code)
+                except Exception as exc:
+                    logger.debug(
+                        "Open redirect probe failed for %s param %s: %s",
+                        ep.url,
+                        param,
+                        exc,
+                    )
+
+    logger.info("Open redirect probe found %d findings", len(findings))
+    return findings


### PR DESCRIPTION
Detects open redirect by injecting external URL payloads (https,
protocol-relative, backslash, userinfo) into URL parameters and
checking the response Location header, Refresh header, and
meta-refresh tag against an RFC 2606 .invalid canary host.