### PR TITLE
feat: cookie security checks for penetration tester (#36)

### DIFF
--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -29,6 +29,7 @@ from tools.cloud import (
     check_sensitive_files,
     check_webmin,
 )
+from tools.pentest.cookies import check_cookies
 from tools.pentest.cors import check_cors_misconfiguration
 from tools.pentest.errors import check_error_disclosure
 from tools.pentest.nosqli import run_nosqli
@@ -90,6 +91,25 @@ def sqlmap_tool(endpoints_json: str) -> list[dict]:
     Returns raw findings as dicts.
     """
     return [f.model_dump() for f in run_sqlmap(_parse_endpoints(endpoints_json))]
+
+
+@tool("Cookie Security Check")
+def cookie_check_tool(recon_result_json: str) -> list[dict]:
+    """
+    Inspect Set-Cookie attributes across the recon surface for: missing
+    Secure on HTTPS cookies, missing HttpOnly on session-shaped cookies,
+    SameSite=None without Secure, Domain attribute scoped broader than the
+    setting host, persistent (Max-Age/Expires) session-shaped cookies, and
+    sensitive data (API keys, JWTs carrying password/secret claims, emails,
+    base64-encoded JSON with sensitive keys) in cookie values.
+
+    Run this broadly - one request per distinct host, findings deduped per
+    (host, cookie name, check class). Especially useful on login, dashboard,
+    and authenticated API endpoints where Set-Cookie is most likely.
+    Pass the full serialised ReconResult. Returns raw findings as dicts.
+    """
+    recon = ReconResult.model_validate_json(recon_result_json)
+    return [f.model_dump() for f in check_cookies(recon.endpoints)]
 
 
 @tool("CORS Misconfiguration Check")
@@ -544,6 +564,7 @@ MEMBER = SquadMember(
     tools=[
         nuclei_scan_tool,
         sqlmap_tool,
+        cookie_check_tool,
         cors_check_tool,
         ssrf_probe_tool,
         header_injection_tool,

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -1,0 +1,269 @@
+"""tests/test_cookies.py - unit tests for tools/pentest/cookies.py"""
+
+from __future__ import annotations
+
+import base64
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from models import Endpoint, Severity
+from tools.pentest.cookies import (
+    _is_session_shaped,
+    _parse_set_cookie,
+    _scan_value,
+    check_cookies,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _resp(set_cookies: list[str], status: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.headers = {}
+    resp.text = ""
+    raw = MagicMock()
+    raw.headers.getlist = MagicMock(return_value=set_cookies)
+    resp.raw = raw
+    return resp
+
+
+def _b64url(obj: dict) -> str:
+    return base64.urlsafe_b64encode(json.dumps(obj).encode()).rstrip(b"=").decode()
+
+
+def _fake_jwt(claims: dict) -> str:
+    header = _b64url({"alg": "HS256", "typ": "JWT"})
+    payload = _b64url(claims)
+    return f"{header}.{payload}.signaturesignaturesignature"
+
+
+class TestParseSetCookie:
+    def test_parses_minimal_cookie(self):
+        c = _parse_set_cookie("sid=abc123")
+        assert c == {
+            "name": "sid",
+            "value": "abc123",
+            "secure": False,
+            "httponly": False,
+            "samesite": None,
+            "domain": None,
+            "path": None,
+            "max_age": None,
+            "expires": None,
+        }
+
+    def test_parses_full_cookie(self):
+        c = _parse_set_cookie(
+            "sid=abc; Secure; HttpOnly; SameSite=Lax; "
+            "Domain=.example.com; Path=/; Max-Age=3600; "
+            "Expires=Wed, 09 Jun 2027 10:18:14 GMT"
+        )
+        assert c is not None
+        assert c["secure"] is True
+        assert c["httponly"] is True
+        assert c["samesite"] == "lax"
+        assert c["domain"] == ".example.com"
+        assert c["path"] == "/"
+        assert c["max_age"] == 3600
+        assert c["expires"] == "Wed, 09 Jun 2027 10:18:14 GMT"
+
+    def test_returns_none_for_malformed(self):
+        assert _parse_set_cookie("") is None
+        assert _parse_set_cookie("just-a-flag") is None
+
+    def test_attribute_names_are_case_insensitive(self):
+        c = _parse_set_cookie("a=b; SECURE; httponly; samesite=STRICT")
+        assert c is not None
+        assert c["secure"] is True
+        assert c["httponly"] is True
+        assert c["samesite"] == "strict"
+
+
+class TestIsSessionShaped:
+    @pytest.mark.parametrize(
+        "name",
+        ["sid", "JSESSIONID", "PHPSESSID", "auth_token", "access_token", "jwt", "csrf_token"],
+    )
+    def test_matches_session_names(self, name):
+        assert _is_session_shaped(name)
+
+    @pytest.mark.parametrize("name", ["theme", "lang", "consent", "ab_test"])
+    def test_does_not_match_benign_names(self, name):
+        assert not _is_session_shaped(name)
+
+
+class TestScanValue:
+    def test_detects_aws_access_key(self):
+        hits = _scan_value("AKIAIOSFODNN7EXAMPLE")
+        assert any(sev == Severity.HIGH for _, sev in hits)
+
+    def test_detects_github_pat(self):
+        hits = _scan_value("ghp_" + "a" * 36)
+        assert any(sev == Severity.HIGH for _, sev in hits)
+
+    def test_detects_jwt_with_sensitive_claims(self):
+        token = _fake_jwt({"sub": "u1", "password": "p4ssw0rd"})
+        hits = _scan_value(token)
+        assert any("JWT" in desc and sev == Severity.MEDIUM for desc, sev in hits)
+
+    def test_ignores_jwt_with_only_benign_claims(self):
+        token = _fake_jwt({"sub": "u1", "exp": 9999999999})
+        hits = _scan_value(token)
+        assert not any("JWT" in desc for desc, _ in hits)
+
+    def test_detects_email_address(self):
+        hits = _scan_value("user=alice@example.com")
+        assert any("email" in desc.lower() for desc, _ in hits)
+
+    def test_detects_base64_json_with_sensitive_keys(self):
+        encoded = _b64url({"user": "alice", "password": "p4ss"})
+        hits = _scan_value(encoded)
+        assert any("base64 JSON" in desc and sev == Severity.MEDIUM for desc, sev in hits)
+
+    def test_no_hits_on_opaque_random_value(self):
+        assert _scan_value("a1b2c3d4e5f6g7h8") == []
+
+
+class TestCheckCookies:
+    def test_missing_secure_on_https_session_cookie_is_medium(self):
+        ep = Endpoint(url="https://app.example.com/", status_code=200)
+        with patch("requests.get", return_value=_resp(["sid=abc; HttpOnly"])):
+            findings = check_cookies([ep])
+        assert len(findings) == 1
+        assert findings[0].vuln_class == "CookieMissingSecure"
+        assert findings[0].severity_hint == Severity.MEDIUM
+
+    def test_missing_secure_on_non_session_cookie_is_low(self):
+        ep = Endpoint(url="https://app.example.com/", status_code=200)
+        with patch("requests.get", return_value=_resp(["theme=dark"])):
+            findings = check_cookies([ep])
+        classes = {f.vuln_class for f in findings}
+        assert "CookieMissingSecure" in classes
+        miss = next(f for f in findings if f.vuln_class == "CookieMissingSecure")
+        assert miss.severity_hint == Severity.LOW
+
+    def test_missing_httponly_on_session_shaped(self):
+        ep = Endpoint(url="https://app.example.com/", status_code=200)
+        with patch("requests.get", return_value=_resp(["sid=abc; Secure"])):
+            findings = check_cookies([ep])
+        classes = {f.vuln_class for f in findings}
+        assert "CookieMissingHttpOnly" in classes
+
+    def test_samesite_none_without_secure(self):
+        ep = Endpoint(url="https://app.example.com/", status_code=200)
+        with patch("requests.get", return_value=_resp(["sid=abc; HttpOnly; SameSite=None"])):
+            findings = check_cookies([ep])
+        classes = {f.vuln_class for f in findings}
+        assert "CookieWeakSameSite" in classes
+
+    def test_domain_too_broad(self):
+        ep = Endpoint(url="https://app.example.com/", status_code=200)
+        with patch(
+            "requests.get",
+            return_value=_resp(["sid=abc; Secure; HttpOnly; Domain=.example.com; SameSite=Lax"]),
+        ):
+            findings = check_cookies([ep])
+        classes = {f.vuln_class for f in findings}
+        assert "CookieDomainTooBroad" in classes
+
+    def test_domain_exact_match_is_fine(self):
+        ep = Endpoint(url="https://app.example.com/", status_code=200)
+        with patch(
+            "requests.get",
+            return_value=_resp(["sid=abc; Secure; HttpOnly; Domain=app.example.com; SameSite=Lax"]),
+        ):
+            findings = check_cookies([ep])
+        classes = {f.vuln_class for f in findings}
+        assert "CookieDomainTooBroad" not in classes
+
+    def test_persistent_session_cookie(self):
+        ep = Endpoint(url="https://app.example.com/", status_code=200)
+        with patch(
+            "requests.get",
+            return_value=_resp(["sid=abc; Secure; HttpOnly; SameSite=Lax; Max-Age=86400"]),
+        ):
+            findings = check_cookies([ep])
+        classes = {f.vuln_class for f in findings}
+        assert "CookiePersistentSession" in classes
+
+    def test_high_severity_secret_in_cookie_value(self):
+        ep = Endpoint(url="https://app.example.com/", status_code=200)
+        with patch(
+            "requests.get",
+            return_value=_resp(["sid=AKIAIOSFODNN7EXAMPLE; Secure; HttpOnly; SameSite=Lax"]),
+        ):
+            findings = check_cookies([ep])
+        high = [f for f in findings if f.severity_hint == Severity.HIGH]
+        assert high and high[0].vuln_class == "CookieSensitiveValue"
+
+    def test_perfectly_configured_cookie_yields_no_findings(self):
+        ep = Endpoint(url="https://app.example.com/", status_code=200)
+        with patch(
+            "requests.get",
+            return_value=_resp(
+                ["sid=opaque-random-value; Secure; HttpOnly; SameSite=Strict; Path=/"]
+            ),
+        ):
+            findings = check_cookies([ep])
+        assert findings == []
+
+    def test_no_findings_when_no_set_cookie(self):
+        ep = Endpoint(url="https://app.example.com/", status_code=200)
+        with patch("requests.get", return_value=_resp([])):
+            findings = check_cookies([ep])
+        assert findings == []
+
+    def test_skips_5xx_endpoints(self):
+        ep = Endpoint(url="https://app.example.com/", status_code=503)
+        with patch("requests.get") as mock_get:
+            check_cookies([ep])
+        mock_get.assert_not_called()
+
+    def test_one_request_per_host(self):
+        eps = [
+            Endpoint(url="https://app.example.com/a", status_code=200),
+            Endpoint(url="https://app.example.com/b", status_code=200),
+            Endpoint(url="https://other.example.com/", status_code=200),
+        ]
+        with patch("requests.get", return_value=_resp([])) as mock_get:
+            check_cookies(eps)
+        assert mock_get.call_count == 2
+
+    def test_findings_deduped_across_endpoints(self):
+        # Same host, two endpoints, same cookie issue - only one finding
+        eps = [
+            Endpoint(url="https://app.example.com/a", status_code=200),
+            Endpoint(url="https://app.example.com/b", status_code=200),
+        ]
+        with patch("requests.get", return_value=_resp(["sid=abc; HttpOnly"])):
+            findings = check_cookies(eps)
+        # one host probed once; one finding
+        assert len(findings) == 1
+
+    def test_http_does_not_flag_missing_secure(self):
+        # Issue specifies "missing Secure on cookies set over HTTPS"
+        ep = Endpoint(url="http://app.example.com/", status_code=200)
+        with patch("requests.get", return_value=_resp(["sid=abc; HttpOnly; SameSite=Lax"])):
+            findings = check_cookies([ep])
+        classes = {f.vuln_class for f in findings}
+        assert "CookieMissingSecure" not in classes
+
+    def test_network_exception_swallowed(self):
+        ep = Endpoint(url="https://app.example.com/", status_code=200)
+        with patch("requests.get", side_effect=Exception("network error")):
+            findings = check_cookies([ep])
+        assert findings == []
+
+    def test_falls_back_to_single_header_when_no_raw(self):
+        # Some response objects do not expose raw.headers.getlist
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {"Set-Cookie": "sid=abc; HttpOnly"}
+        resp.raw = None
+        ep = Endpoint(url="https://app.example.com/", status_code=200)
+        with patch("requests.get", return_value=resp):
+            findings = check_cookies([ep])
+        assert any(f.vuln_class == "CookieMissingSecure" for f in findings)

--- a/tools/pentest/cookies.py
+++ b/tools/pentest/cookies.py
@@ -1,0 +1,327 @@
+"""Cookie security checks - inspect Set-Cookie attributes for missing flags,
+overly-broad scopes, persistent session cookies, and sensitive values."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import logging
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+import requests
+
+from config import config
+from models import Endpoint, RawFinding, Severity
+from tools._helpers import adaptive_sleep
+
+logger = logging.getLogger(__name__)
+
+# Substrings that indicate a cookie is carrying a session or auth credential.
+# Match case-insensitively as substrings - covers JSESSIONID, PHPSESSID,
+# ASP.NET_SessionId, access_token, refresh-token, idtoken, jwt, etc.
+_SESSION_NAME_HINTS = (
+    "session",
+    "sessid",
+    "sid",
+    "token",
+    "auth",
+    "jwt",
+    "bearer",
+    "login",
+    "csrf",
+)
+
+# Standard JWT three-part shape. We deliberately anchor on the "eyJ" prefix
+# of a base64-encoded JSON header so we do not match arbitrary base64 blobs.
+_JWT_RE = re.compile(r"\beyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b")
+_EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+
+# High-confidence credential shapes. A hit here is HIGH severity because the
+# pattern is unique enough that false positives are vanishingly rare.
+_HIGH_VALUE_SECRETS = [
+    (re.compile(r"\bAKIA[0-9A-Z]{16}\b"), "AWS access key"),
+    (re.compile(r"\bASIA[0-9A-Z]{16}\b"), "AWS session token"),
+    (re.compile(r"\bghp_[A-Za-z0-9]{36}\b"), "GitHub personal access token"),
+    (re.compile(r"\bgho_[A-Za-z0-9]{36}\b"), "GitHub OAuth token"),
+    (re.compile(r"\bxox[bpoars]-[A-Za-z0-9-]{10,}\b"), "Slack token"),
+]
+
+_SENSITIVE_KEYS = (
+    "password",
+    "passwd",
+    "secret",
+    "api_key",
+    "apikey",
+    "private_key",
+    "client_secret",
+    "credit_card",
+)
+
+
+def _is_session_shaped(name: str) -> bool:
+    n = name.lower()
+    return any(hint in n for hint in _SESSION_NAME_HINTS)
+
+
+def _parse_set_cookie(raw: str) -> dict[str, Any] | None:
+    """Parse a Set-Cookie header string into a dict of attributes.
+
+    Returns None for malformed cookies (no name=value pair). Flag attributes
+    (Secure, HttpOnly) appear as bool; value-bearing attributes (Domain, Path,
+    Max-Age, Expires, SameSite) appear as their value or None.
+    """
+    parts = [p.strip() for p in raw.split(";") if p.strip()]
+    if not parts or "=" not in parts[0]:
+        return None
+    name, _, value = parts[0].partition("=")
+    out: dict[str, Any] = {
+        "name": name.strip(),
+        "value": value.strip(),
+        "secure": False,
+        "httponly": False,
+        "samesite": None,
+        "domain": None,
+        "path": None,
+        "max_age": None,
+        "expires": None,
+    }
+    for attr in parts[1:]:
+        key, _, val = attr.partition("=")
+        k = key.strip().lower()
+        v = val.strip()
+        if k == "secure":
+            out["secure"] = True
+        elif k == "httponly":
+            out["httponly"] = True
+        elif k == "samesite":
+            out["samesite"] = v.lower() or None
+        elif k == "domain":
+            out["domain"] = v.lower() or None
+        elif k == "path":
+            out["path"] = v or None
+        elif k == "max-age":
+            try:
+                out["max_age"] = int(v)
+            except ValueError:
+                pass
+        elif k == "expires":
+            out["expires"] = v or None
+    return out
+
+
+def _set_cookies_from(resp: requests.Response) -> list[str]:
+    """Pull raw Set-Cookie header strings, one per cookie."""
+    raw = getattr(resp, "raw", None)
+    if raw is not None:
+        headers = getattr(raw, "headers", None)
+        getlist = getattr(headers, "getlist", None) if headers is not None else None
+        if callable(getlist):
+            return list(getlist("Set-Cookie"))
+    h = resp.headers.get("Set-Cookie")
+    return [h] if h else []
+
+
+def _try_b64_json(s: str) -> dict[str, Any] | None:
+    """Decode a base64url-ish string and parse as JSON object, or None."""
+    padded = s + "=" * (-len(s) % 4)
+    try:
+        decoded = base64.urlsafe_b64decode(padded).decode("utf-8", errors="strict")
+    except (binascii.Error, UnicodeDecodeError, ValueError):
+        return None
+    try:
+        parsed = json.loads(decoded)
+    except (ValueError, TypeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _scan_value(value: str) -> list[tuple[str, Severity]]:
+    """Look for sensitive data in a cookie value. Returns (description, severity)."""
+    hits: list[tuple[str, Severity]] = []
+    if not value:
+        return hits
+
+    for rx, label in _HIGH_VALUE_SECRETS:
+        if rx.search(value):
+            hits.append((f"{label} in cookie value", Severity.HIGH))
+            break
+
+    jwt_match = _JWT_RE.search(value)
+    if jwt_match:
+        payload_b64 = jwt_match.group(0).split(".")[1]
+        payload = _try_b64_json(payload_b64)
+        if payload:
+            leaked = sorted(k for k in payload if k.lower() in _SENSITIVE_KEYS)
+            if leaked:
+                hits.append(
+                    (f"JWT carrying sensitive claims: {', '.join(leaked)}", Severity.MEDIUM)
+                )
+
+    if _EMAIL_RE.search(value):
+        hits.append(("email address in cookie value", Severity.LOW))
+
+    # Whole value might be base64-encoded JSON (not JWT-shaped) carrying
+    # secrets. Only attempt when the value looks base64-ish to avoid wasted
+    # decode work on obvious plaintext / opaque session IDs.
+    if re.fullmatch(r"[A-Za-z0-9+/=_-]{12,}", value):
+        payload = _try_b64_json(value)
+        if payload:
+            leaked = sorted(k for k in payload if k.lower() in _SENSITIVE_KEYS)
+            if leaked:
+                hits.append(
+                    (f"base64 JSON carrying sensitive keys: {', '.join(leaked)}", Severity.MEDIUM)
+                )
+
+    return hits
+
+
+def _check_cookie(host: str, scheme: str, cookie: dict[str, Any], url: str) -> list[RawFinding]:
+    findings: list[RawFinding] = []
+    name = cookie["name"]
+    session_shaped = _is_session_shaped(name)
+
+    def _make(vuln_class: str, title: str, evidence: str, severity: Severity) -> RawFinding:
+        return RawFinding(
+            title=title,
+            vuln_class=vuln_class,
+            target=url,
+            evidence=evidence,
+            tool="cookie_check",
+            severity_hint=severity,
+        )
+
+    if scheme == "https" and not cookie["secure"]:
+        sev = Severity.MEDIUM if session_shaped else Severity.LOW
+        findings.append(
+            _make(
+                "CookieMissingSecure",
+                f"Cookie '{name}' set over HTTPS without Secure flag",
+                f"Cookie: {name}\nHost: {host}\nNo Secure attribute on Set-Cookie.",
+                sev,
+            )
+        )
+
+    if session_shaped and not cookie["httponly"]:
+        findings.append(
+            _make(
+                "CookieMissingHttpOnly",
+                f"Session-shaped cookie '{name}' missing HttpOnly flag",
+                f"Cookie: {name}\nHost: {host}\nNo HttpOnly attribute - readable from JavaScript.",
+                Severity.MEDIUM,
+            )
+        )
+
+    if cookie["samesite"] == "none" and not cookie["secure"]:
+        findings.append(
+            _make(
+                "CookieWeakSameSite",
+                f"Cookie '{name}' uses SameSite=None without Secure",
+                (
+                    f"Cookie: {name}\nHost: {host}\n"
+                    f"SameSite=None requires Secure - browsers reject this combination."
+                ),
+                Severity.LOW,
+            )
+        )
+
+    if cookie["domain"]:
+        cd = cookie["domain"].lstrip(".")
+        if cd and cd != host and host.endswith("." + cd):
+            findings.append(
+                _make(
+                    "CookieDomainTooBroad",
+                    f"Cookie '{name}' scoped to parent domain '{cookie['domain']}'",
+                    (
+                        f"Cookie: {name}\nHost: {host}\n"
+                        f"Domain={cookie['domain']!r} exposes the cookie to all subdomains "
+                        f"of {cd!r} - broader than the default host-only scope."
+                    ),
+                    Severity.MEDIUM,
+                )
+            )
+
+    is_persistent = cookie["expires"] is not None or (
+        cookie["max_age"] is not None and cookie["max_age"] > 0
+    )
+    if session_shaped and is_persistent:
+        ttl = (
+            f"Max-Age={cookie['max_age']}"
+            if cookie["max_age"] is not None
+            else f"Expires={cookie['expires']}"
+        )
+        findings.append(
+            _make(
+                "CookiePersistentSession",
+                f"Session-shaped cookie '{name}' is persistent",
+                (
+                    f"Cookie: {name}\nHost: {host}\n{ttl}\n"
+                    f"Session cookies should expire when the browser closes."
+                ),
+                Severity.LOW,
+            )
+        )
+
+    for kind, sev in _scan_value(cookie["value"]):
+        findings.append(
+            _make(
+                "CookieSensitiveValue",
+                f"Cookie '{name}' contains sensitive data ({kind})",
+                (
+                    f"Cookie: {name}\nHost: {host}\nDetected: {kind}\n"
+                    f"Value snippet: {cookie['value'][:80]}"
+                ),
+                sev,
+            )
+        )
+
+    return findings
+
+
+def check_cookies(endpoints: list[Endpoint]) -> list[RawFinding]:
+    """
+    Inspect Set-Cookie response headers across the endpoint surface for
+    missing flags, overly-broad scopes, persistent session cookies, and
+    sensitive values. One request per distinct host; findings are deduped
+    by (host, cookie name, check class) so repeat endpoints do not multiply
+    output.
+    """
+    findings: list[RawFinding] = []
+    seen: set[tuple[str, str, str]] = set()
+    hosts_probed: set[str] = set()
+    _delay = config.scan.request_delay
+
+    for ep in endpoints:
+        if ep.status_code and ep.status_code >= 500:
+            continue
+        parsed = urlparse(ep.url)
+        host = (parsed.hostname or "").lower()
+        scheme = parsed.scheme.lower()
+        if not host or host in hosts_probed:
+            continue
+        hosts_probed.add(host)
+
+        try:
+            resp = requests.get(  # nosemgrep
+                ep.url,
+                timeout=config.recon.http_timeout,
+                allow_redirects=False,
+            )
+            for raw in _set_cookies_from(resp):
+                cookie = _parse_set_cookie(raw)
+                if not cookie:
+                    continue
+                for finding in _check_cookie(host, scheme, cookie, ep.url):
+                    key = (host, cookie["name"], finding.vuln_class)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    findings.append(finding)
+            _delay = adaptive_sleep(_delay, resp.status_code)
+        except Exception as exc:
+            logger.debug("Cookie check failed for %s: %s", ep.url, exc)
+
+    logger.info("Cookie checks produced %d findings", len(findings))
+    return findings


### PR DESCRIPTION
Closes #36.

## Summary
- Six independent checks on Set-Cookie attributes: `CookieMissingSecure`, `CookieMissingHttpOnly`, `CookieWeakSameSite`, `CookieDomainTooBroad`, `CookiePersistentSession`, `CookieSensitiveValue`.
- Sensitive-value scanner covers AWS/GitHub/Slack credential shapes (HIGH), JWTs carrying password/secret claims (MEDIUM via base64-decode of payload), base64-JSON values carrying sensitive keys (MEDIUM), and email addresses (LOW).
- One request per distinct host, findings deduped by `(host, cookie name, check class)` so the tool can be pointed at a full ReconResult without multiplying output.
- Custom Set-Cookie parser because `requests` collapses multi-headers in `resp.headers` and `http.cookiejar` does not model SameSite/HttpOnly reliably; uses `resp.raw.headers.getlist("Set-Cookie")` with a fallback.

## Test plan
- [x] `ruff check . && ruff format --check .` clean
- [x] `mypy . --ignore-missing-imports` clean
- [x] `pytest -m unit` 453 passing (38 new), `tools/pentest/cookies.py` at 95% coverage, total 87%
- [x] `bandit -c pyproject.toml -r . -q` clean
- [x] New tests assert: each of the six check classes fires on a matching cookie, perfectly-configured cookie produces zero findings, HTTP-scheme endpoint does not flag missing Secure, per-host request dedup, finding dedup across endpoints on same host, fallback path when `resp.raw` is absent.

## Notes
- Did not add `weakness_types` metadata (also listed in the issue acceptance criteria) for consistency with the rest of the toolset - no other tool sets it yet because the consuming coverage registry (#34) is not built. Happy to backfill across all tools in a follow-up once #34 is ready.
- Discussed but deliberately deferred: a shared `secret_scan` module (gitleaks for chunky content + regex list for tiny values like cookies/headers) and a shared base64/JWT decoder module. Both make sense at the second caller, not the first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDPGN6jFdVLb4tEeV1xg21)_