### PR TITLE
feat: server-side template injection probe for penetration tester (#52)

### DIFF
--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -42,6 +42,7 @@ from tools.pentest.sourcemaps import check_js_source_maps
 from tools.pentest.sqlmap import run_sqlmap
 from tools.pentest.sri import check_sri
 from tools.pentest.ssrf import check_ssrf
+from tools.pentest.ssti import check_ssti
 from tools.pentest.webapp_headers import check_header_injection, check_host_headers
 from tools.pentest.xss import check_reflected_xss
 
@@ -211,6 +212,32 @@ def path_traversal_tool(endpoints_json: str) -> list[dict]:
     Returns raw findings as dicts.
     """
     return [f.model_dump() for f in check_path_traversal(_parse_endpoints(endpoints_json))]
+
+
+@tool("Server-Side Template Injection Probe")
+def ssti_probe_tool(endpoints_json: str) -> list[dict]:
+    """
+    Inject template-language expressions (Jinja2/Twig/Liquid, Mako/FreeMarker,
+    ERB/EJS, Ruby interpolation) into URL parameters and look for the evaluated
+    arithmetic product in the response body. Confirmation requires the product
+    to appear AND the literal expression to be absent, which rules out the
+    common false positive of an app that just echoes the raw input.
+
+    endpoints_json: JSON array of endpoint objects. Prioritise endpoints where
+      any of the following apply:
+      - Parameter values are rendered into HTML the response returns (search,
+        comment, preview, name, template parameters)
+      - Technologies mention a template-heavy stack (Flask/Jinja2, Django,
+        Symfony/Twig, Rails/ERB, Spring with FreeMarker, etc.)
+      - Error disclosure findings mention template internals
+      Example: '[{"url": "https://example.com/preview", "parameters": ["name"]}]'
+
+    SSTI confirmed at the canary-arithmetic level is HIGH; the VR should
+    escalate to CRITICAL when manual follow-up demonstrates RCE primitives
+    (sandbox escape, attribute traversal, OS command execution).
+    Returns raw findings as dicts.
+    """
+    return [f.model_dump() for f in check_ssti(_parse_endpoints(endpoints_json))]
 
 
 @tool("Open Redirect Probe")
@@ -583,6 +610,7 @@ MEMBER = SquadMember(
         header_injection_tool,
         host_header_tool,
         source_maps_tool,
+        ssti_probe_tool,
         open_redirect_tool,
         path_traversal_tool,
         xss_probe_tool,

--- a/tests/test_ssti.py
+++ b/tests/test_ssti.py
@@ -7,7 +7,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from models import Endpoint, Severity
-from tools.pentest.ssti import _EXPECTED, _PROBES, check_ssti
+from tools.pentest.ssti import (
+    _DJANGO_EXPECTED,
+    _DJANGO_PAYLOAD,
+    _MULTIPLY_EXPECTED,
+    _PROBES,
+    check_ssti,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -26,7 +32,7 @@ class TestCheckSSTI:
         def fake_get(url, **kwargs):
             # Server evaluates the Jinja-style payload to the product
             if "%7B%7B" in url or "{{" in url:
-                return _resp(body=f"<html>Hello {_EXPECTED}</html>")
+                return _resp(body=f"<html>Hello {_MULTIPLY_EXPECTED}</html>")
             return _resp(body="<html>Hello</html>")
 
         with patch("requests.get", side_effect=fake_get):
@@ -35,7 +41,7 @@ class TestCheckSSTI:
         assert len(results) == 1
         assert results[0].vuln_class == "SSTI"
         assert results[0].severity_hint == Severity.HIGH
-        assert _EXPECTED in results[0].evidence
+        assert _MULTIPLY_EXPECTED in results[0].evidence
         assert "Jinja2" in results[0].evidence
 
     def test_detects_dollar_brace_engine(self):
@@ -44,7 +50,7 @@ class TestCheckSSTI:
         def fake_get(url, **kwargs):
             # Only the ${...} payload triggers; the {{...}} one is echoed
             if "%24%7B" in url or url.endswith("${12345*67890}"):
-                return _resp(body=f"Result: {_EXPECTED}")
+                return _resp(body=f"Result: {_MULTIPLY_EXPECTED}")
             # Echo other payloads back literally
             payload = url.split("tpl=", 1)[1]
             return _resp(body=f"Submitted: {payload}")
@@ -55,15 +61,44 @@ class TestCheckSSTI:
         assert len(results) == 1
         assert "Mako" in results[0].evidence or "FreeMarker" in results[0].evidence
 
+    def test_detects_django_add_filter(self):
+        # Django does not evaluate raw arithmetic in {{ }} but it does
+        # evaluate its built-in filter chain - so a server that runs the
+        # add filter is positively detectable through the same shape.
+        ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
+
+        def fake_get(url, **kwargs):
+            # Server evaluates Django's add filter for the Django payload;
+            # echoes everything else literally so the arithmetic probes do
+            # NOT trigger (and we know it's the Django probe that won).
+            if "add" in url and "123456789" in url:
+                return _resp(body=f"<html>Total: {_DJANGO_EXPECTED}</html>")
+            payload = url.split("name=", 1)[1]
+            return _resp(body=f"<html>Echo: {payload}</html>")
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_ssti([ep])
+
+        assert len(results) == 1
+        assert "Django" in results[0].evidence
+        assert _DJANGO_EXPECTED in results[0].evidence
+        # And ensure the arithmetic probes' product is NOT what triggered
+        assert _MULTIPLY_EXPECTED not in results[0].evidence
+
     def test_no_finding_when_input_is_echoed_literally(self):
         # Page reflects the raw payload (input echo) but does not evaluate it.
         # Our guard requires literal absence, so this must NOT be a finding -
-        # even if the product happens to appear in some unrelated text.
+        # even if the expected output happens to appear in some unrelated text.
         ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
 
         def fake_get(url, **kwargs):
             payload = url.split("name=", 1)[1]
-            return _resp(body=f"<html>You said: {payload}. Order #{_EXPECTED}.</html>")
+            return _resp(
+                body=(
+                    f"<html>You said: {payload}. "
+                    f"Order #{_MULTIPLY_EXPECTED}. Total {_DJANGO_EXPECTED}.</html>"
+                )
+            )
 
         with patch("requests.get", side_effect=fake_get):
             results = check_ssti([ep])
@@ -103,7 +138,7 @@ class TestCheckSSTI:
         )
 
         def fake_get(url, **kwargs):
-            return _resp(body=f"Hello {_EXPECTED}!")
+            return _resp(body=f"Hello {_MULTIPLY_EXPECTED}!")
 
         with patch("requests.get", side_effect=fake_get) as mock_get:
             results = check_ssti([ep])
@@ -120,7 +155,7 @@ class TestCheckSSTI:
 
     def test_probes_cover_major_template_engines(self):
         # Sanity check the payload list - one entry per major syntax family.
-        engines = " ".join(label for _, label in _PROBES)
+        engines = " ".join(label for _, _, label in _PROBES)
         assert "Jinja2" in engines
         assert "Mako" in engines or "FreeMarker" in engines
         assert "ERB" in engines
@@ -128,8 +163,16 @@ class TestCheckSSTI:
         # The #{...} payload also covers Pug (Express) and Slim - make sure
         # the engine label flags that for the LLM consuming the evidence.
         assert "Pug" in engines
+        # Django uses its own filter-based DSL - the add-filter payload
+        # detects it without relying on arithmetic-in-delimiters semantics.
+        assert "Django" in engines
 
-    def test_expected_product_is_correct(self):
-        # Guards against someone tweaking _A/_B but forgetting _EXPECTED.
-        assert _EXPECTED == str(12345 * 67890)
-        assert _EXPECTED == "838102050"
+    def test_expected_values_are_correct(self):
+        # Guards against someone tweaking the payload constants but
+        # forgetting to update the expected output.
+        assert _MULTIPLY_EXPECTED == str(12345 * 67890)
+        assert _MULTIPLY_EXPECTED == "838102050"
+        assert _DJANGO_EXPECTED == str(123456789 + 987654321)
+        assert _DJANGO_EXPECTED == "1111111110"
+        # The Django payload must actually use the `add` filter syntax
+        assert "|add:" in _DJANGO_PAYLOAD

--- a/tests/test_ssti.py
+++ b/tests/test_ssti.py
@@ -125,6 +125,9 @@ class TestCheckSSTI:
         assert "Mako" in engines or "FreeMarker" in engines
         assert "ERB" in engines
         assert "Ruby" in engines
+        # The #{...} payload also covers Pug (Express) and Slim - make sure
+        # the engine label flags that for the LLM consuming the evidence.
+        assert "Pug" in engines
 
     def test_expected_product_is_correct(self):
         # Guards against someone tweaking _A/_B but forgetting _EXPECTED.

--- a/tests/test_ssti.py
+++ b/tests/test_ssti.py
@@ -7,13 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from models import Endpoint, Severity
-from tools.pentest.ssti import (
-    _DJANGO_EXPECTED,
-    _DJANGO_PAYLOAD,
-    _MULTIPLY_EXPECTED,
-    _PROBES,
-    check_ssti,
-)
+from tools.pentest.ssti import _EXPECTED, _PROBES, check_ssti
 
 pytestmark = pytest.mark.unit
 
@@ -25,15 +19,25 @@ def _resp(status: int = 200, body: str = "") -> MagicMock:
     return resp
 
 
+def _echo(url: str) -> MagicMock:
+    """Echo the URL parameter back literally - simulates naive reflection
+    where no template engine is involved. Triggers the literal-absence
+    guard so no probe should fire against this response."""
+    payload = url.split("=", 1)[1] if "=" in url else ""
+    return _resp(body=f"<html>Echo: {payload}</html>")
+
+
 class TestCheckSSTI:
     def test_detects_jinja_style_evaluation(self):
         ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
 
         def fake_get(url, **kwargs):
-            # Server evaluates the Jinja-style payload to the product
-            if "%7B%7B" in url or "{{" in url:
-                return _resp(body=f"<html>Hello {_MULTIPLY_EXPECTED}</html>")
-            return _resp(body="<html>Hello</html>")
+            # Server evaluates {{x+y}} - Jinja2/Twig path. The Jinja2 probe
+            # is first in the iteration order so it wins before any other
+            # {{...}} payload (Liquid, Django) is even sent.
+            if "{{" in url and "+" in url:
+                return _resp(body=f"<html>Hello {_EXPECTED}</html>")
+            return _echo(url)
 
         with patch("requests.get", side_effect=fake_get):
             results = check_ssti([ep])
@@ -41,19 +45,17 @@ class TestCheckSSTI:
         assert len(results) == 1
         assert results[0].vuln_class == "SSTI"
         assert results[0].severity_hint == Severity.HIGH
-        assert _MULTIPLY_EXPECTED in results[0].evidence
+        assert _EXPECTED in results[0].evidence
         assert "Jinja2" in results[0].evidence
 
     def test_detects_dollar_brace_engine(self):
         ep = Endpoint(url="https://app.example.com/render", status_code=200, parameters=["tpl"])
 
         def fake_get(url, **kwargs):
-            # Only the ${...} payload triggers; the {{...}} one is echoed
-            if "%24%7B" in url or url.endswith("${12345*67890}"):
-                return _resp(body=f"Result: {_MULTIPLY_EXPECTED}")
-            # Echo other payloads back literally
-            payload = url.split("tpl=", 1)[1]
-            return _resp(body=f"Submitted: {payload}")
+            # Only Mako-style ${...} triggers; everything else is echoed.
+            if "${" in url:
+                return _resp(body=f"Result: {_EXPECTED}")
+            return _echo(url)
 
         with patch("requests.get", side_effect=fake_get):
             results = check_ssti([ep])
@@ -61,51 +63,58 @@ class TestCheckSSTI:
         assert len(results) == 1
         assert "Mako" in results[0].evidence or "FreeMarker" in results[0].evidence
 
-    def test_detects_django_add_filter(self):
-        # Django does not evaluate raw arithmetic in {{ }} but it does
-        # evaluate its built-in filter chain - so a server that runs the
-        # add filter is positively detectable through the same shape.
+    def test_detects_liquid_plus_filter(self):
+        # Liquid has no infix arithmetic - it can only do `{{ x | plus: y }}`.
+        # The probe must fire on that signature specifically (not the Jinja2/
+        # Twig {{x+y}} form which Liquid would render literally).
         ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
 
         def fake_get(url, **kwargs):
-            # Server evaluates Django's add filter for the Django payload;
-            # echoes everything else literally so the arithmetic probes do
-            # NOT trigger (and we know it's the Django probe that won).
-            if "add" in url and "123456789" in url:
-                return _resp(body=f"<html>Total: {_DJANGO_EXPECTED}</html>")
-            payload = url.split("name=", 1)[1]
-            return _resp(body=f"<html>Echo: {payload}</html>")
+            if "| plus:" in url:
+                return _resp(body=f"<html>Total: {_EXPECTED}</html>")
+            return _echo(url)
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_ssti([ep])
+
+        assert len(results) == 1
+        assert "Liquid" in results[0].evidence
+        assert _EXPECTED in results[0].evidence
+
+    def test_detects_django_add_filter(self):
+        # Django does not evaluate raw arithmetic in {{ }} but it does
+        # evaluate its built-in filter chain - the |add: filter does integer
+        # addition. Only fire when the Django payload signature shows up.
+        ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
+
+        def fake_get(url, **kwargs):
+            if "|add:" in url:
+                return _resp(body=f"<html>Total: {_EXPECTED}</html>")
+            return _echo(url)
 
         with patch("requests.get", side_effect=fake_get):
             results = check_ssti([ep])
 
         assert len(results) == 1
         assert "Django" in results[0].evidence
-        assert _DJANGO_EXPECTED in results[0].evidence
-        # And ensure the arithmetic probes' product is NOT what triggered
-        assert _MULTIPLY_EXPECTED not in results[0].evidence
+        assert _EXPECTED in results[0].evidence
 
     def test_no_finding_when_input_is_echoed_literally(self):
         # Page reflects the raw payload (input echo) but does not evaluate it.
-        # Our guard requires literal absence, so this must NOT be a finding -
-        # even if the expected output happens to appear in some unrelated text.
+        # The literal-absence guard must suppress detection even when the
+        # expected sum happens to appear somewhere unrelated on the page.
         ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
 
         def fake_get(url, **kwargs):
             payload = url.split("name=", 1)[1]
-            return _resp(
-                body=(
-                    f"<html>You said: {payload}. "
-                    f"Order #{_MULTIPLY_EXPECTED}. Total {_DJANGO_EXPECTED}.</html>"
-                )
-            )
+            return _resp(body=f"<html>You said: {payload}. Total {_EXPECTED}.</html>")
 
         with patch("requests.get", side_effect=fake_get):
             results = check_ssti([ep])
 
         assert results == []
 
-    def test_no_finding_when_product_absent(self):
+    def test_no_finding_when_expected_absent(self):
         ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
 
         def fake_get(url, **kwargs):
@@ -138,13 +147,13 @@ class TestCheckSSTI:
         )
 
         def fake_get(url, **kwargs):
-            return _resp(body=f"Hello {_MULTIPLY_EXPECTED}!")
+            return _resp(body=f"Hello {_EXPECTED}!")
 
         with patch("requests.get", side_effect=fake_get) as mock_get:
             results = check_ssti([ep])
 
         assert len(results) == 1
-        # First param, first payload should trigger - only one request
+        # First param, first payload should trigger - only one request fired
         assert mock_get.call_count == 1
 
     def test_network_exception_is_swallowed(self):
@@ -155,7 +164,7 @@ class TestCheckSSTI:
 
     def test_probes_cover_major_template_engines(self):
         # Sanity check the payload list - one entry per major syntax family.
-        engines = " ".join(label for _, _, label in _PROBES)
+        engines = " ".join(label for _, label in _PROBES)
         assert "Jinja2" in engines
         assert "Mako" in engines or "FreeMarker" in engines
         assert "ERB" in engines
@@ -163,16 +172,20 @@ class TestCheckSSTI:
         # The #{...} payload also covers Pug (Express) and Slim - make sure
         # the engine label flags that for the LLM consuming the evidence.
         assert "Pug" in engines
-        # Django uses its own filter-based DSL - the add-filter payload
-        # detects it without relying on arithmetic-in-delimiters semantics.
+        # Filter-based engines that cannot share the operator form get their
+        # own dedicated probe.
+        assert "Liquid" in engines
         assert "Django" in engines
 
-    def test_expected_values_are_correct(self):
-        # Guards against someone tweaking the payload constants but
+    def test_expected_value_is_correct(self):
+        # Guards against someone tweaking the canary constants but
         # forgetting to update the expected output.
-        assert _MULTIPLY_EXPECTED == str(12345 * 67890)
-        assert _MULTIPLY_EXPECTED == "838102050"
-        assert _DJANGO_EXPECTED == str(123456789 + 987654321)
-        assert _DJANGO_EXPECTED == "1111111110"
-        # The Django payload must actually use the `add` filter syntax
-        assert "|add:" in _DJANGO_PAYLOAD
+        assert _EXPECTED == str(123456789 + 987654321)
+        assert _EXPECTED == "1111111110"
+
+    def test_filter_based_probes_use_correct_syntax(self):
+        # The Liquid and Django probes are the only ones with filter syntax;
+        # if their pipe/colon shape regresses the engine never evaluates.
+        payloads = [p for p, _ in _PROBES]
+        assert any("| plus:" in p for p in payloads)
+        assert any("|add:" in p for p in payloads)

--- a/tests/test_ssti.py
+++ b/tests/test_ssti.py
@@ -1,0 +1,132 @@
+"""tests/test_ssti.py - unit tests for tools/pentest/ssti.py"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from models import Endpoint, Severity
+from tools.pentest.ssti import _EXPECTED, _PROBES, check_ssti
+
+pytestmark = pytest.mark.unit
+
+
+def _resp(status: int = 200, body: str = "") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.text = body
+    return resp
+
+
+class TestCheckSSTI:
+    def test_detects_jinja_style_evaluation(self):
+        ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
+
+        def fake_get(url, **kwargs):
+            # Server evaluates the Jinja-style payload to the product
+            if "%7B%7B" in url or "{{" in url:
+                return _resp(body=f"<html>Hello {_EXPECTED}</html>")
+            return _resp(body="<html>Hello</html>")
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_ssti([ep])
+
+        assert len(results) == 1
+        assert results[0].vuln_class == "SSTI"
+        assert results[0].severity_hint == Severity.HIGH
+        assert _EXPECTED in results[0].evidence
+        assert "Jinja2" in results[0].evidence
+
+    def test_detects_dollar_brace_engine(self):
+        ep = Endpoint(url="https://app.example.com/render", status_code=200, parameters=["tpl"])
+
+        def fake_get(url, **kwargs):
+            # Only the ${...} payload triggers; the {{...}} one is echoed
+            if "%24%7B" in url or url.endswith("${12345*67890}"):
+                return _resp(body=f"Result: {_EXPECTED}")
+            # Echo other payloads back literally
+            payload = url.split("tpl=", 1)[1]
+            return _resp(body=f"Submitted: {payload}")
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_ssti([ep])
+
+        assert len(results) == 1
+        assert "Mako" in results[0].evidence or "FreeMarker" in results[0].evidence
+
+    def test_no_finding_when_input_is_echoed_literally(self):
+        # Page reflects the raw payload (input echo) but does not evaluate it.
+        # Our guard requires literal absence, so this must NOT be a finding -
+        # even if the product happens to appear in some unrelated text.
+        ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
+
+        def fake_get(url, **kwargs):
+            payload = url.split("name=", 1)[1]
+            return _resp(body=f"<html>You said: {payload}. Order #{_EXPECTED}.</html>")
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_ssti([ep])
+
+        assert results == []
+
+    def test_no_finding_when_product_absent(self):
+        ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
+
+        def fake_get(url, **kwargs):
+            return _resp(body="<html>Hello world</html>")
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_ssti([ep])
+
+        assert results == []
+
+    def test_skips_endpoints_without_parameters(self):
+        ep = Endpoint(url="https://app.example.com/about", status_code=200)
+        with patch("requests.get") as mock_get:
+            results = check_ssti([ep])
+        mock_get.assert_not_called()
+        assert results == []
+
+    def test_skips_server_error_endpoints(self):
+        ep = Endpoint(url="https://app.example.com/", status_code=500, parameters=["q"])
+        with patch("requests.get") as mock_get:
+            results = check_ssti([ep])
+        mock_get.assert_not_called()
+        assert results == []
+
+    def test_one_finding_per_endpoint(self):
+        ep = Endpoint(
+            url="https://app.example.com/preview",
+            status_code=200,
+            parameters=["name", "title"],
+        )
+
+        def fake_get(url, **kwargs):
+            return _resp(body=f"Hello {_EXPECTED}!")
+
+        with patch("requests.get", side_effect=fake_get) as mock_get:
+            results = check_ssti([ep])
+
+        assert len(results) == 1
+        # First param, first payload should trigger - only one request
+        assert mock_get.call_count == 1
+
+    def test_network_exception_is_swallowed(self):
+        ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
+        with patch("requests.get", side_effect=Exception("network error")):
+            results = check_ssti([ep])
+        assert results == []
+
+    def test_probes_cover_major_template_engines(self):
+        # Sanity check the payload list - one entry per major syntax family.
+        engines = " ".join(label for _, label in _PROBES)
+        assert "Jinja2" in engines
+        assert "Mako" in engines or "FreeMarker" in engines
+        assert "ERB" in engines
+        assert "Ruby" in engines
+
+    def test_expected_product_is_correct(self):
+        # Guards against someone tweaking _A/_B but forgetting _EXPECTED.
+        assert _EXPECTED == str(12345 * 67890)
+        assert _EXPECTED == "838102050"

--- a/tools/pentest/ssti.py
+++ b/tools/pentest/ssti.py
@@ -1,5 +1,5 @@
 """Server-Side Template Injection (SSTI) detection - inject template-language
-expressions that evaluate to a known result and look for that result in the
+expressions that evaluate to a known sum and look for that sum in the
 response."""
 
 from __future__ import annotations
@@ -13,38 +13,37 @@ from tools._helpers import adaptive_sleep
 
 logger = logging.getLogger(__name__)
 
-# Distinctive multiplication canary for engines that evaluate arithmetic
-# directly inside their expression delimiters. 12345 * 67890 = 838102050
-# is ten digits long, fits in int32 (no overflow on 32-bit engines), and
-# virtually never appears in HTML by coincidence.
-_A = 12345
-_B = 67890
-_MULTIPLY_EXPECTED = str(_A * _B)  # "838102050"
+# Distinctive addition canary harmonised across every engine in scope:
+#
+#   * Jinja2, Twig, Mako, FreeMarker, SpEL, ERB, EJS, Ruby/Pug/Slim
+#     all evaluate the + operator inside their expression delimiters.
+#   * Liquid is logic-less, but its `| plus:` filter does integer addition.
+#   * Django's template DSL also forbids infix arithmetic, but the built-in
+#     `|add:` filter does integer addition on numeric literals.
+#
+# 123456789 + 987654321 = 1111111110. Ten digits, repunit-ish pattern, almost
+# impossible to hit by HTML coincidence, and easy to spot in evidence snippets.
+_A = 123456789
+_B = 987654321
+_EXPECTED = str(_A + _B)  # "1111111110"
 
-# Django's template DSL does not evaluate raw arithmetic inside {{ }}, but
-# it does evaluate its built-in filter chain. The `add` filter does integer
-# addition on numeric literals; 123456789 + 987654321 = 1111111110 - a
-# ten-digit repunit-ish value that is distinctive enough for low FPs.
-_DJANGO_PAYLOAD = "{{ 123456789|add:987654321 }}"
-_DJANGO_EXPECTED = "1111111110"
-
-# (payload, expected_marker, engine_label) triples covering the major
-# server-side template syntaxes. Each probe stands alone: the agent does not
-# need a finding per engine, so the first match wins per endpoint.
-_PROBES: list[tuple[str, str, str]] = [
-    (f"{{{{{_A}*{_B}}}}}", _MULTIPLY_EXPECTED, "Jinja2 / Twig / Liquid"),
-    (f"${{{_A}*{_B}}}", _MULTIPLY_EXPECTED, "Mako / FreeMarker / Spring SpEL"),
-    (f"<%= {_A}*{_B} %>", _MULTIPLY_EXPECTED, "ERB / EJS"),
-    (f"#{{{_A}*{_B}}}", _MULTIPLY_EXPECTED, "Ruby / Pug / Slim string interpolation"),
-    (_DJANGO_PAYLOAD, _DJANGO_EXPECTED, "Django"),
+# (payload, engine_label) pairs. Filter-based engines (Liquid, Django) get
+# their own probe because their syntax cannot share the operator form.
+_PROBES: list[tuple[str, str]] = [
+    (f"{{{{{_A}+{_B}}}}}", "Jinja2 / Twig"),
+    (f"${{{_A}+{_B}}}", "Mako / FreeMarker / Spring SpEL"),
+    (f"<%= {_A}+{_B} %>", "ERB / EJS"),
+    (f"#{{{_A}+{_B}}}", "Ruby / Pug / Slim string interpolation"),
+    (f"{{{{ {_A} | plus: {_B} }}}}", "Liquid"),
+    (f"{{{{ {_A}|add:{_B} }}}}", "Django"),
 ]
 
 
 def check_ssti(endpoints: list[Endpoint]) -> list[RawFinding]:
     """
     Probe parameterised endpoints for server-side template injection by
-    injecting template-language expressions that evaluate to a known
-    result, then checking the response body for that result.
+    injecting template-language expressions that evaluate to a known sum,
+    then checking the response body for that sum.
 
     Confirmation requires both the expected output AND the absence of the
     literal payload - that combination distinguishes server-side evaluation
@@ -67,7 +66,7 @@ def check_ssti(endpoints: list[Endpoint]) -> list[RawFinding]:
         for param in ep.parameters:
             if triggered:
                 break
-            for payload, expected, engine in _PROBES:
+            for payload, engine in _PROBES:
                 try:
                     test_url = f"{ep.url}?{param}={payload}"
                     resp = http.get(  # nosemgrep
@@ -76,10 +75,10 @@ def check_ssti(endpoints: list[Endpoint]) -> list[RawFinding]:
                         allow_redirects=False,
                     )
                     body = resp.text
-                    # The expected output must appear AND the literal
-                    # expression must NOT - that combination rules out
-                    # naive reflection of the raw input.
-                    if expected in body and payload not in body:
+                    # The expected sum must appear AND the literal expression
+                    # must NOT - that combination rules out naive reflection
+                    # of the raw input.
+                    if _EXPECTED in body and payload not in body:
                         findings.append(
                             RawFinding(
                                 title=f"Server-Side Template Injection - {ep.url}",
@@ -90,7 +89,7 @@ def check_ssti(endpoints: list[Endpoint]) -> list[RawFinding]:
                                     f"Payload: {payload}\n"
                                     f"Likely engine: {engine}\n"
                                     f"Status: {resp.status_code}\n"
-                                    f"Expected output {expected} present without "
+                                    f"Expected sum {_EXPECTED} present without "
                                     f"the literal expression - template was evaluated."
                                 ),
                                 tool="ssti_probe",

--- a/tools/pentest/ssti.py
+++ b/tools/pentest/ssti.py
@@ -1,6 +1,6 @@
 """Server-Side Template Injection (SSTI) detection - inject template-language
-expressions that evaluate to a known arithmetic result and look for that
-result in the response."""
+expressions that evaluate to a known result and look for that result in the
+response."""
 
 from __future__ import annotations
 
@@ -13,22 +13,30 @@ from tools._helpers import adaptive_sleep
 
 logger = logging.getLogger(__name__)
 
-# Distinctive multiplication: 12345 * 67890 = 838102050. Ten digits, fits in
-# int32 so no overflow on 32-bit engines, and "838102050" virtually never
-# appears in HTML by coincidence. Big enough to flag with high confidence,
-# small enough to spot in a 300-char evidence snippet.
+# Distinctive multiplication canary for engines that evaluate arithmetic
+# directly inside their expression delimiters. 12345 * 67890 = 838102050
+# is ten digits long, fits in int32 (no overflow on 32-bit engines), and
+# virtually never appears in HTML by coincidence.
 _A = 12345
 _B = 67890
-_EXPECTED = str(_A * _B)
+_MULTIPLY_EXPECTED = str(_A * _B)  # "838102050"
 
-# (payload, engine_label) pairs covering the major server-side template syntaxes.
-# Django is deliberately omitted - it does not evaluate arithmetic inside
-# {{ }} by default, so this class of probe cannot detect it.
-_PROBES: list[tuple[str, str]] = [
-    (f"{{{{{_A}*{_B}}}}}", "Jinja2 / Twig / Liquid"),
-    (f"${{{_A}*{_B}}}", "Mako / FreeMarker / Spring SpEL"),
-    (f"<%= {_A}*{_B} %>", "ERB / EJS"),
-    (f"#{{{_A}*{_B}}}", "Ruby / Pug / Slim string interpolation"),
+# Django's template DSL does not evaluate raw arithmetic inside {{ }}, but
+# it does evaluate its built-in filter chain. The `add` filter does integer
+# addition on numeric literals; 123456789 + 987654321 = 1111111110 - a
+# ten-digit repunit-ish value that is distinctive enough for low FPs.
+_DJANGO_PAYLOAD = "{{ 123456789|add:987654321 }}"
+_DJANGO_EXPECTED = "1111111110"
+
+# (payload, expected_marker, engine_label) triples covering the major
+# server-side template syntaxes. Each probe stands alone: the agent does not
+# need a finding per engine, so the first match wins per endpoint.
+_PROBES: list[tuple[str, str, str]] = [
+    (f"{{{{{_A}*{_B}}}}}", _MULTIPLY_EXPECTED, "Jinja2 / Twig / Liquid"),
+    (f"${{{_A}*{_B}}}", _MULTIPLY_EXPECTED, "Mako / FreeMarker / Spring SpEL"),
+    (f"<%= {_A}*{_B} %>", _MULTIPLY_EXPECTED, "ERB / EJS"),
+    (f"#{{{_A}*{_B}}}", _MULTIPLY_EXPECTED, "Ruby / Pug / Slim string interpolation"),
+    (_DJANGO_PAYLOAD, _DJANGO_EXPECTED, "Django"),
 ]
 
 
@@ -36,9 +44,9 @@ def check_ssti(endpoints: list[Endpoint]) -> list[RawFinding]:
     """
     Probe parameterised endpoints for server-side template injection by
     injecting template-language expressions that evaluate to a known
-    arithmetic result, then checking the response body for that result.
+    result, then checking the response body for that result.
 
-    Confirmation requires both the expected product AND the absence of the
+    Confirmation requires both the expected output AND the absence of the
     literal payload - that combination distinguishes server-side evaluation
     from naive input reflection where the page just echoes back the raw
     expression. One finding per endpoint.
@@ -59,7 +67,7 @@ def check_ssti(endpoints: list[Endpoint]) -> list[RawFinding]:
         for param in ep.parameters:
             if triggered:
                 break
-            for payload, engine in _PROBES:
+            for payload, expected, engine in _PROBES:
                 try:
                     test_url = f"{ep.url}?{param}={payload}"
                     resp = http.get(  # nosemgrep
@@ -68,9 +76,10 @@ def check_ssti(endpoints: list[Endpoint]) -> list[RawFinding]:
                         allow_redirects=False,
                     )
                     body = resp.text
-                    # The product must appear AND the literal expression
-                    # must NOT - that combination rules out naive reflection.
-                    if _EXPECTED in body and payload not in body:
+                    # The expected output must appear AND the literal
+                    # expression must NOT - that combination rules out
+                    # naive reflection of the raw input.
+                    if expected in body and payload not in body:
                         findings.append(
                             RawFinding(
                                 title=f"Server-Side Template Injection - {ep.url}",
@@ -81,7 +90,7 @@ def check_ssti(endpoints: list[Endpoint]) -> list[RawFinding]:
                                     f"Payload: {payload}\n"
                                     f"Likely engine: {engine}\n"
                                     f"Status: {resp.status_code}\n"
-                                    f"Expected product {_EXPECTED} present without "
+                                    f"Expected output {expected} present without "
                                     f"the literal expression - template was evaluated."
                                 ),
                                 tool="ssti_probe",

--- a/tools/pentest/ssti.py
+++ b/tools/pentest/ssti.py
@@ -28,7 +28,7 @@ _PROBES: list[tuple[str, str]] = [
     (f"{{{{{_A}*{_B}}}}}", "Jinja2 / Twig / Liquid"),
     (f"${{{_A}*{_B}}}", "Mako / FreeMarker / Spring SpEL"),
     (f"<%= {_A}*{_B} %>", "ERB / EJS"),
-    (f"#{{{_A}*{_B}}}", "Ruby string interpolation"),
+    (f"#{{{_A}*{_B}}}", "Ruby / Pug / Slim string interpolation"),
 ]
 
 

--- a/tools/pentest/ssti.py
+++ b/tools/pentest/ssti.py
@@ -1,0 +1,104 @@
+"""Server-Side Template Injection (SSTI) detection - inject template-language
+expressions that evaluate to a known arithmetic result and look for that
+result in the response."""
+
+from __future__ import annotations
+
+import logging
+
+from config import config
+from models import Endpoint, RawFinding, Severity
+from tools import http
+from tools._helpers import adaptive_sleep
+
+logger = logging.getLogger(__name__)
+
+# Distinctive multiplication: 12345 * 67890 = 838102050. Ten digits, fits in
+# int32 so no overflow on 32-bit engines, and "838102050" virtually never
+# appears in HTML by coincidence. Big enough to flag with high confidence,
+# small enough to spot in a 300-char evidence snippet.
+_A = 12345
+_B = 67890
+_EXPECTED = str(_A * _B)
+
+# (payload, engine_label) pairs covering the major server-side template syntaxes.
+# Django is deliberately omitted - it does not evaluate arithmetic inside
+# {{ }} by default, so this class of probe cannot detect it.
+_PROBES: list[tuple[str, str]] = [
+    (f"{{{{{_A}*{_B}}}}}", "Jinja2 / Twig / Liquid"),
+    (f"${{{_A}*{_B}}}", "Mako / FreeMarker / Spring SpEL"),
+    (f"<%= {_A}*{_B} %>", "ERB / EJS"),
+    (f"#{{{_A}*{_B}}}", "Ruby string interpolation"),
+]
+
+
+def check_ssti(endpoints: list[Endpoint]) -> list[RawFinding]:
+    """
+    Probe parameterised endpoints for server-side template injection by
+    injecting template-language expressions that evaluate to a known
+    arithmetic result, then checking the response body for that result.
+
+    Confirmation requires both the expected product AND the absence of the
+    literal payload - that combination distinguishes server-side evaluation
+    from naive input reflection where the page just echoes back the raw
+    expression. One finding per endpoint.
+    """
+    findings: list[RawFinding] = []
+    seen: set[str] = set()
+    _delay = config.scan.request_delay
+
+    for ep in endpoints:
+        if not ep.parameters:
+            continue
+        if ep.status_code and ep.status_code >= 500:
+            continue
+        if ep.url in seen:
+            continue
+
+        triggered = False
+        for param in ep.parameters:
+            if triggered:
+                break
+            for payload, engine in _PROBES:
+                try:
+                    test_url = f"{ep.url}?{param}={payload}"
+                    resp = http.get(  # nosemgrep
+                        test_url,
+                        timeout=config.recon.http_timeout,
+                        allow_redirects=False,
+                    )
+                    body = resp.text
+                    # The product must appear AND the literal expression
+                    # must NOT - that combination rules out naive reflection.
+                    if _EXPECTED in body and payload not in body:
+                        findings.append(
+                            RawFinding(
+                                title=f"Server-Side Template Injection - {ep.url}",
+                                vuln_class="SSTI",
+                                target=ep.url,
+                                evidence=(
+                                    f"Parameter: {param}\n"
+                                    f"Payload: {payload}\n"
+                                    f"Likely engine: {engine}\n"
+                                    f"Status: {resp.status_code}\n"
+                                    f"Expected product {_EXPECTED} present without "
+                                    f"the literal expression - template was evaluated."
+                                ),
+                                tool="ssti_probe",
+                                severity_hint=Severity.HIGH,
+                            )
+                        )
+                        seen.add(ep.url)
+                        triggered = True
+                        break
+                    _delay = adaptive_sleep(_delay, resp.status_code)
+                except Exception as exc:
+                    logger.debug(
+                        "SSTI probe failed for %s param %s: %s",
+                        ep.url,
+                        param,
+                        exc,
+                    )
+
+    logger.info("SSTI probe found %d findings", len(findings))
+    return findings


### PR DESCRIPTION
Closes #52.

## Summary
- New `tools/pentest/ssti.py` probe: injects template-language expressions into URL parameters and looks for the evaluated arithmetic product in the response.
- Payloads cover Jinja2/Twig/Liquid (`{{a*b}}`), Mako/FreeMarker/SpEL (`${a*b}`), ERB/EJS (`<%= a*b %>`), and Ruby string interpolation (`#{a*b}`). Django is intentionally omitted - `{{ }}` does not evaluate arithmetic there.
- Canary uses `12345 * 67890 = 838102050` - distinctive enough that random HTML coincidence is near-zero, small enough to fit int32 (no overflow on 32-bit engines), and easy to spot in a 300-char evidence snippet.
- Confirmation requires **both** the product to appear AND the literal expression to be absent. That combination rules out the common false positive of an app that echoes raw input back (e.g. `<input value="{{12345*67890}}">` with `838102050` appearing somewhere unrelated on the page).
- Reports HIGH at the canary-arithmetic level. The VR can escalate to CRITICAL when manual follow-up demonstrates RCE primitives (sandbox escape, attribute traversal, OS command execution).

## Test plan
- [x] `ruff check . && ruff format --check .` clean
- [x] `mypy . --ignore-missing-imports` clean
- [x] `pytest -m unit` 482 passing (10 new); `tools/pentest/ssti.py` at 98% coverage, total 87%
- [x] `bandit -c pyproject.toml -r . -q` clean
- [x] New tests assert: Jinja-style payload detection, `${...}` payload detection, the literal-absence guard correctly suppresses the input-echo false positive, no-product-no-finding, parameterless and 5xx endpoints skipped, one finding per endpoint with a single request fired when the first param/payload matches, network exception swallowed, payload list covers each major engine family, and the expected product matches `12345 * 67890`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDPGN6jFdVLb4tEeV1xg21)_