### PR TITLE
feat: HTTP Parameter Pollution probe for penetration tester (#37)

### DIFF
--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -33,6 +33,7 @@ from tools.cloud import (
 from tools.pentest.cookies import check_cookies
 from tools.pentest.cors import check_cors_misconfiguration
 from tools.pentest.errors import check_error_disclosure
+from tools.pentest.hpp import check_hpp
 from tools.pentest.nosqli import run_nosqli
 from tools.pentest.nuclei import run_nuclei
 from tools.pentest.open_redirect import check_open_redirect
@@ -212,6 +213,34 @@ def path_traversal_tool(endpoints_json: str) -> list[dict]:
     Returns raw findings as dicts.
     """
     return [f.model_dump() for f in check_path_traversal(_parse_endpoints(endpoints_json))]
+
+
+@tool("HTTP Parameter Pollution Probe")
+def hpp_probe_tool(endpoints_json: str) -> list[dict]:
+    """
+    Detect HTTP Parameter Pollution by sending a baseline request
+    (`?param=1`) and a polluted request (`?param=1&param=2`) and comparing
+    status code + body length. Any divergence proves the server treats
+    duplicate values as distinguishable from a single value - the
+    pre-condition for WAF bypass and access-control bypass exploits.
+
+    endpoints_json: JSON array of endpoint objects. Prioritise endpoints
+      where any of the following apply:
+      - Parameter names look authorisation-shaped (role, admin, is_admin,
+        permission, group, user_id) - HPP is most impactful when it can
+        flip a privilege check
+      - Endpoint sits behind a WAF or rate-limit (HPP is a classic WAF
+        bypass primitive)
+      - Endpoint is part of an auth or admin flow
+      Example: '[{"url": "https://example.com/api/user", "parameters": ["role", "id"]}]'
+
+    Severity LOW on its own - HPP is a class of behaviour that enables
+    further exploitation rather than a vuln in itself. The VR should
+    escalate when the divergence can be chained with another finding
+    (SQLi filter bypass, access-control override, cache poisoning).
+    Returns raw findings as dicts.
+    """
+    return [f.model_dump() for f in check_hpp(_parse_endpoints(endpoints_json))]
 
 
 @tool("Server-Side Template Injection Probe")
@@ -611,6 +640,7 @@ MEMBER = SquadMember(
         host_header_tool,
         source_maps_tool,
         ssti_probe_tool,
+        hpp_probe_tool,
         open_redirect_tool,
         path_traversal_tool,
         xss_probe_tool,

--- a/tests/test_hpp.py
+++ b/tests/test_hpp.py
@@ -1,0 +1,155 @@
+"""tests/test_hpp.py - unit tests for tools/pentest/hpp.py"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from models import Endpoint, Severity
+from tools.pentest.hpp import check_hpp
+
+pytestmark = pytest.mark.unit
+
+
+def _resp(status: int = 200, body: str = "") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.text = body
+    return resp
+
+
+class TestCheckHPP:
+    def test_detects_status_delta(self):
+        # Baseline returns 200, polluted returns 302 - server picked one of
+        # the duplicate values and triggered a redirect.
+        ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["id"])
+
+        def fake_get(url, **kwargs):
+            if "id=1&id=2" in url:
+                return _resp(status=302, body="")
+            return _resp(status=200, body="ok")
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_hpp([ep])
+
+        assert len(results) == 1
+        assert results[0].vuln_class == "HPP"
+        assert results[0].severity_hint == Severity.LOW
+        assert "id" in results[0].evidence
+        assert "302" in results[0].evidence
+
+    def test_detects_length_delta(self):
+        # Same status code, but the polluted response body is materially
+        # longer because the server combined both values into the output.
+        ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["q"])
+
+        def fake_get(url, **kwargs):
+            if "q=1&q=2" in url:
+                return _resp(status=200, body="results: 1, 2 (combined)")
+            return _resp(status=200, body="results: 1")
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_hpp([ep])
+
+        assert len(results) == 1
+        assert "HPP behaviour confirmed" in results[0].evidence
+
+    def test_no_finding_when_responses_identical(self):
+        # Server collapses duplicates - baseline and polluted look the same.
+        ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["id"])
+
+        with patch("requests.get", return_value=_resp(status=200, body="ok")):
+            results = check_hpp([ep])
+
+        assert results == []
+
+    def test_skips_endpoints_without_parameters(self):
+        ep = Endpoint(url="https://app.example.com/about", status_code=200)
+        with patch("requests.get") as mock_get:
+            results = check_hpp([ep])
+        mock_get.assert_not_called()
+        assert results == []
+
+    def test_skips_server_error_endpoints(self):
+        ep = Endpoint(url="https://app.example.com/", status_code=503, parameters=["id"])
+        with patch("requests.get") as mock_get:
+            results = check_hpp([ep])
+        mock_get.assert_not_called()
+        assert results == []
+
+    def test_one_finding_per_endpoint(self):
+        # First param triggers - subsequent params should not be probed.
+        ep = Endpoint(
+            url="https://app.example.com/",
+            status_code=200,
+            parameters=["a", "b", "c"],
+        )
+
+        def fake_get(url, **kwargs):
+            if "a=1&a=2" in url:
+                return _resp(status=200, body="much longer body here than baseline")
+            return _resp(status=200, body="ok")
+
+        with patch("requests.get", side_effect=fake_get) as mock_get:
+            results = check_hpp([ep])
+
+        assert len(results) == 1
+        # Only param 'a' probed: baseline + polluted = 2 calls
+        assert mock_get.call_count == 2
+
+    def test_baseline_and_polluted_both_sent(self):
+        ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["q"])
+        urls_seen: list[str] = []
+
+        def fake_get(url, **kwargs):
+            urls_seen.append(url)
+            return _resp(status=200, body="ok")
+
+        with patch("requests.get", side_effect=fake_get):
+            check_hpp([ep])
+
+        assert any(url.endswith("?q=1") for url in urls_seen)
+        assert any(url.endswith("?q=1&q=2") for url in urls_seen)
+        assert len(urls_seen) == 2
+
+    def test_continues_to_next_param_when_first_does_not_trigger(self):
+        # Param 'a' shows no delta; param 'b' does. Tool must keep probing.
+        ep = Endpoint(
+            url="https://app.example.com/",
+            status_code=200,
+            parameters=["a", "b"],
+        )
+
+        def fake_get(url, **kwargs):
+            if "b=1&b=2" in url:
+                return _resp(status=500, body="error: ambiguous parameter")
+            return _resp(status=200, body="ok")
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_hpp([ep])
+
+        assert len(results) == 1
+        assert "b" in results[0].evidence
+
+    def test_network_exception_is_swallowed(self):
+        ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["id"])
+        with patch("requests.get", side_effect=Exception("network error")):
+            results = check_hpp([ep])
+        assert results == []
+
+    def test_evidence_records_both_signatures(self):
+        ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["id"])
+
+        def fake_get(url, **kwargs):
+            if "id=1&id=2" in url:
+                return _resp(status=403, body="forbidden")
+            return _resp(status=200, body="ok")
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_hpp([ep])
+
+        evidence = results[0].evidence
+        # Both signatures should appear so the VR can see the exact delta
+        assert "200" in evidence  # baseline status
+        assert "403" in evidence  # polluted status

--- a/tools/pentest/hpp.py
+++ b/tools/pentest/hpp.py
@@ -1,0 +1,106 @@
+"""HTTP Parameter Pollution (HPP) detection - send a baseline request and a
+duplicate-parameter request, and flag endpoints whose responses diverge."""
+
+from __future__ import annotations
+
+import logging
+
+import requests
+
+from config import config
+from models import Endpoint, RawFinding, Severity
+from tools import http
+from tools._helpers import adaptive_sleep
+
+logger = logging.getLogger(__name__)
+
+
+def _signature(resp: requests.Response) -> tuple[int, int]:
+    """Status + body length. Tight enough to detect HPP behaviour deltas,
+    loose enough to ignore byte-level wobble from dynamic content (CSRF
+    tokens and session IDs are typically fixed length per response)."""
+    return (resp.status_code, len(resp.text))
+
+
+def check_hpp(endpoints: list[Endpoint]) -> list[RawFinding]:
+    """
+    Probe parameterised endpoints for HTTP Parameter Pollution by sending
+    a baseline request (`?param=1`) and a polluted request (`?param=1&param=2`)
+    and flagging endpoints whose responses diverge.
+
+    Different frameworks resolve duplicate parameters differently - Apache
+    and PHP keep the last value, Tomcat returns an array, ASP.NET joins on
+    commas, others reject outright. Any divergent behaviour from the
+    single-value baseline is the signal we care about: it confirms the
+    server treats duplicates as distinguishable from singles, which is the
+    pre-condition for WAF bypass and access-control bypass exploits.
+
+    One finding per endpoint. Severity LOW - HPP is a class of behaviour
+    that enables further exploitation rather than a vuln on its own.
+    """
+    findings: list[RawFinding] = []
+    seen: set[str] = set()
+    _delay = config.scan.request_delay
+
+    for ep in endpoints:
+        if not ep.parameters:
+            continue
+        if ep.status_code and ep.status_code >= 500:
+            continue
+        if ep.url in seen:
+            continue
+
+        triggered = False
+        for param in ep.parameters:
+            if triggered:
+                break
+            try:
+                baseline_url = f"{ep.url}?{param}=1"
+                baseline = http.get(  # nosemgrep
+                    baseline_url,
+                    timeout=config.recon.http_timeout,
+                    allow_redirects=False,
+                )
+                baseline_sig = _signature(baseline)
+                _delay = adaptive_sleep(_delay, baseline.status_code)
+
+                polluted_url = f"{ep.url}?{param}=1&{param}=2"
+                polluted = http.get(  # nosemgrep
+                    polluted_url,
+                    timeout=config.recon.http_timeout,
+                    allow_redirects=False,
+                )
+                polluted_sig = _signature(polluted)
+
+                if baseline_sig != polluted_sig:
+                    findings.append(
+                        RawFinding(
+                            title=f"HTTP Parameter Pollution - {ep.url}",
+                            vuln_class="HPP",
+                            target=ep.url,
+                            evidence=(
+                                f"Parameter: {param}\n"
+                                f"Baseline ({baseline_url}):\n"
+                                f"  Status {baseline_sig[0]}, body length {baseline_sig[1]}\n"
+                                f"Polluted ({polluted_url}):\n"
+                                f"  Status {polluted_sig[0]}, body length {polluted_sig[1]}\n"
+                                f"Server handled duplicate values differently from "
+                                f"a single value - HPP behaviour confirmed."
+                            ),
+                            tool="hpp_probe",
+                            severity_hint=Severity.LOW,
+                        )
+                    )
+                    seen.add(ep.url)
+                    triggered = True
+                _delay = adaptive_sleep(_delay, polluted.status_code)
+            except Exception as exc:
+                logger.debug(
+                    "HPP probe failed for %s param %s: %s",
+                    ep.url,
+                    param,
+                    exc,
+                )
+
+    logger.info("HPP probe found %d findings", len(findings))
+    return findings


### PR DESCRIPTION
Closes #37.

## Summary
- New `tools/pentest/hpp.py`: for each parameterised endpoint, sends a baseline `?param=1` request and a polluted `?param=1&param=2` request, then compares status code + body length. Any divergence is the finding.
- The compared signature is `(status, len(body))` - tight enough to catch real HPP behaviour deltas, loose enough to not trip on per-response wobble from CSRF tokens / session IDs (which are typically fixed length).
- Severity LOW: HPP is a class of behaviour that enables further exploitation (WAF bypass, access-control bypass, cache poisoning) rather than a vuln on its own. The VR can escalate when the divergence chains with another finding.
- One finding per endpoint with early break - if param `a` triggers, params `b`/`c` are not probed.

## Scope note
Query-string HPP only for v1. POST-body HPP is mentioned in the issue but our `Endpoint` model does not track HTTP method - probing POST blindly would 405 on most targets and add noise. Leaving as a known follow-up; the H1 weakness type is the same so the v2 patch would slot into the same `hpp_probe_tool`.

## Test plan
- [x] `ruff check . && ruff format --check .` clean
- [x] `mypy . --ignore-missing-imports` clean
- [x] `pytest -m unit` 495 passing (10 new); `tools/pentest/hpp.py` at 98%, total coverage 87%
- [x] `bandit -c pyproject.toml -r . -q` clean
- [x] Tests cover: status-code delta detection, body-length delta detection, no-finding-when-identical, parameterless and 5xx endpoints skipped, one-finding-per-endpoint with early break (request count == 2 when first param triggers), continues to next param when first does not trigger, baseline and polluted are both sent (exact URLs asserted), network exception swallowed, evidence records both signatures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDPGN6jFdVLb4tEeV1xg21)_