### PR TITLE
feat: LDAP injection probe + fix _recon_from_json infinite recursion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,19 +95,8 @@ jobs:
       - name: Install SAST tools
         run: pip install 'bandit[toml,sarif]' semgrep
 
-      - name: bandit - generate SARIF
-        run: bandit -c pyproject.toml -r . -f sarif -o bandit.sarif || true
-
       - name: bandit - security lint
-        run: bandit -c pyproject.toml -r . -q
-
-      - name: semgrep - generate SARIF
-        if: always()
-        run: semgrep scan --config=.semgrep.yml --sarif-output=semgrep.sarif || true
-
-      - name: semgrep - SAST scan
-        if: always()
-        run: semgrep scan --config=.semgrep.yml --error --quiet
+        run: bandit -c pyproject.toml -r . -f sarif -o bandit.sarif -q
 
       - name: Upload bandit SARIF
         uses: github/codeql-action/upload-sarif@4e828ff8d448a8a6e532957b1811f387a63867e8  # v3.29.4
@@ -115,6 +104,10 @@ jobs:
         with:
           sarif_file: bandit.sarif
           category: bandit
+
+      - name: semgrep - SAST scan
+        if: always()
+        run: semgrep scan --config=.semgrep.yml --error --quiet --sarif-output=semgrep.sarif
 
       - name: Upload semgrep SARIF
         uses: github/codeql-action/upload-sarif@4e828ff8d448a8a6e532957b1811f387a63867e8  # v3.29.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install SAST tools
-        run: pip install bandit[toml] semgrep
+        run: pip install 'bandit[toml,sarif]' semgrep
 
       - name: bandit - generate SARIF
         run: bandit -c pyproject.toml -r . -f sarif -o bandit.sarif || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
   test:
     name: Unit tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write  # required by dorny/test-reporter to post check runs
     env:
       # Dummy creds so H1Client can be imported without KeyError. The contact
       # email seeds the User-Agent helper - see tools/http.py and #46.
@@ -52,9 +55,24 @@ jobs:
         run: pip install -e ".[dev]"
 
       - name: pytest (unit only)
-        run: pytest -m unit --cov --cov-report=term-missing
+        run: pytest -m unit --cov --cov-report=term-missing --cov-report=xml:coverage.xml --cov-report=html --junit-xml=junit.xml
 
-      - name: Upload coverage report
+      - name: Publish test results
+        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5  # v1.9.1
+        if: always()
+        with:
+          name: pytest results
+          path: junit.xml
+          reporter: java-junit
+
+      - name: Upload coverage HTML
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        if: always()
+        with:
+          name: coverage-html
+          path: htmlcov/
+
+      - name: Upload coverage data
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: coverage
@@ -64,6 +82,9 @@ jobs:
   sast:
     name: SAST
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write  # required by github/codeql-action/upload-sarif
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
@@ -74,8 +95,30 @@ jobs:
       - name: Install SAST tools
         run: pip install bandit[toml] semgrep
 
+      - name: bandit - generate SARIF
+        run: bandit -c pyproject.toml -r . -f sarif -o bandit.sarif || true
+
       - name: bandit - security lint
         run: bandit -c pyproject.toml -r . -q
 
+      - name: semgrep - generate SARIF
+        if: always()
+        run: semgrep scan --config=.semgrep.yml --sarif-output=semgrep.sarif || true
+
       - name: semgrep - SAST scan
+        if: always()
         run: semgrep scan --config=.semgrep.yml --error --quiet
+
+      - name: Upload bandit SARIF
+        uses: github/codeql-action/upload-sarif@4e828ff8d448a8a6e532957b1811f387a63867e8  # v3.29.4
+        if: always()
+        with:
+          sarif_file: bandit.sarif
+          category: bandit
+
+      - name: Upload semgrep SARIF
+        uses: github/codeql-action/upload-sarif@4e828ff8d448a8a6e532957b1811f387a63867e8  # v3.29.4
+        if: always()
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep

--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -34,6 +34,7 @@ from tools.pentest.cookies import check_cookies
 from tools.pentest.cors import check_cors_misconfiguration
 from tools.pentest.errors import check_error_disclosure
 from tools.pentest.hpp import check_hpp
+from tools.pentest.ldap_injection import check_ldap_injection
 from tools.pentest.nosqli import run_nosqli
 from tools.pentest.nuclei import run_nuclei
 from tools.pentest.open_redirect import check_open_redirect
@@ -60,7 +61,7 @@ def _recon_from_json(recon_result_json: str) -> ReconResult:
     programme handle into outbound User-Agent headers without each call site
     having to remember the http.set_programme(...) call.
     """
-    recon = _recon_from_json(recon_result_json)
+    recon = ReconResult.model_validate_json(recon_result_json)
     http.set_programme(recon.programme.handle)
     return recon
 
@@ -627,6 +628,31 @@ def nosqli_tool(endpoints_json: str) -> list[dict]:
     return [f.model_dump() for f in run_nosqli(_parse_endpoints(endpoints_json))]
 
 
+@tool("LDAP Injection Probe")
+def ldap_injection_tool(endpoints_json: str) -> list[dict]:
+    """
+    Inject LDAP bypass and enumeration payloads into URL parameters to detect
+    LDAP injection vulnerabilities against Active Directory or OpenLDAP backends.
+
+    endpoints_json: JSON array of endpoint objects. Prioritise endpoints that have
+      parameters AND where any of the following apply:
+      - Parameter names suggest authentication or directory lookup (username, user,
+        login, email, uid, cn, search, filter, q)
+      - URL path suggests auth or directory (/login, /auth, /search, /directory,
+        /ldap, /user)
+      - Technologies mention LDAP, Active Directory, OpenLDAP, or JNDI
+      Example: '[{"url": "https://example.com/login", "parameters": ["username"]}]'
+
+    Detection tiers:
+      HIGH   - status code change vs baseline suggests auth bypass
+      MEDIUM - LDAP/AD error strings in response body (confirms LDAP backend)
+      MEDIUM - server error (500) only on LDAP payload, not on baseline
+
+    Returns raw findings as dicts.
+    """
+    return [f.model_dump() for f in check_ldap_injection(_parse_endpoints(endpoints_json))]
+
+
 MEMBER = SquadMember(
     slug="penetration_tester",
     dir=Path(__file__).parent,
@@ -666,5 +692,6 @@ MEMBER = SquadMember(
         consul_vault_tool,
         nosqli_tool,
         prompt_injection_tool,
+        ldap_injection_tool,
     ],
 )

--- a/tests/test_ldap_injection.py
+++ b/tests/test_ldap_injection.py
@@ -1,0 +1,219 @@
+"""tests/test_ldap_injection.py - unit tests for tools/pentest/ldap_injection.py"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from models import Endpoint, Severity
+from tools.pentest.ldap_injection import (
+    _BASELINE_VALUE,
+    _LDAP_ERROR_MARKERS,
+    _PAYLOADS,
+    check_ldap_injection,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _resp(status: int = 200, body: str = "") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.text = body
+    return resp
+
+
+def _baseline_or_probe(
+    url: str, baseline_resp: MagicMock, probe_resp: MagicMock, **_: object
+) -> MagicMock:
+    """Return baseline_resp for the baseline URL, probe_resp for everything else."""
+    if _BASELINE_VALUE in url:
+        return baseline_resp
+    return probe_resp
+
+
+class TestCheckLDAPInjection:
+    def test_detects_auth_bypass_high(self) -> None:
+        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
+
+        with patch(
+            "requests.get",
+            side_effect=lambda url, **kw: _baseline_or_probe(
+                url, _resp(401, "Invalid credentials"), _resp(200, "Welcome!")
+            ),
+        ):
+            results = check_ldap_injection([ep])
+
+        assert len(results) == 1
+        assert results[0].vuln_class == "LDAPInjection"
+        assert results[0].severity_hint == Severity.HIGH
+        assert "auth-bypass" in results[0].evidence or "bypass" in results[0].evidence.lower()
+        assert "username" in results[0].evidence
+
+    def test_detects_ldap_error_marker_medium(self) -> None:
+        ep = Endpoint(url="https://app.example.com/search", status_code=200, parameters=["q"])
+
+        with patch(
+            "requests.get",
+            side_effect=lambda url, **kw: _baseline_or_probe(
+                url,
+                _resp(200, "No results"),
+                _resp(200, "javax.naming.NamingException: invalid attribute"),
+            ),
+        ):
+            results = check_ldap_injection([ep])
+
+        assert len(results) == 1
+        assert results[0].severity_hint == Severity.MEDIUM
+        assert "javax.naming" in results[0].evidence
+
+    def test_detects_server_error_on_payload_medium(self) -> None:
+        ep = Endpoint(url="https://app.example.com/auth", status_code=200, parameters=["user"])
+
+        with patch(
+            "requests.get",
+            side_effect=lambda url, **kw: _baseline_or_probe(
+                url, _resp(200, "ok"), _resp(500, "Internal Server Error")
+            ),
+        ):
+            results = check_ldap_injection([ep])
+
+        assert len(results) == 1
+        assert results[0].severity_hint == Severity.MEDIUM
+        assert "500" in results[0].evidence
+
+    def test_no_finding_on_clean_response(self) -> None:
+        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
+
+        with patch("requests.get", return_value=_resp(401, "Invalid credentials")):
+            results = check_ldap_injection([ep])
+
+        assert results == []
+
+    def test_skips_endpoints_without_parameters(self) -> None:
+        ep = Endpoint(url="https://app.example.com/about", status_code=200)
+
+        with patch("requests.get") as mock_get:
+            results = check_ldap_injection([ep])
+
+        mock_get.assert_not_called()
+        assert results == []
+
+    def test_skips_server_error_endpoints(self) -> None:
+        ep = Endpoint(url="https://app.example.com/login", status_code=500, parameters=["username"])
+
+        with patch("requests.get") as mock_get:
+            results = check_ldap_injection([ep])
+
+        mock_get.assert_not_called()
+        assert results == []
+
+    def test_one_finding_per_endpoint_with_multiple_params(self) -> None:
+        ep = Endpoint(
+            url="https://app.example.com/login",
+            status_code=200,
+            parameters=["username", "email"],
+        )
+
+        with patch(
+            "requests.get",
+            side_effect=lambda url, **kw: _baseline_or_probe(
+                url, _resp(401, "bad"), _resp(200, "Welcome!")
+            ),
+        ):
+            results = check_ldap_injection([ep])
+
+        assert len(results) == 1
+
+    def test_stops_probing_after_first_match(self) -> None:
+        ep = Endpoint(
+            url="https://app.example.com/login",
+            status_code=200,
+            parameters=["username"],
+        )
+
+        with patch(
+            "requests.get",
+            side_effect=lambda url, **kw: _baseline_or_probe(
+                url, _resp(401, "bad"), _resp(200, "Welcome!")
+            ),
+        ) as mock_get:
+            check_ldap_injection([ep])
+
+        # One baseline + one payload before match - should stop immediately.
+        assert mock_get.call_count == 2
+
+    def test_baseline_exception_skips_param(self) -> None:
+        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
+
+        def raise_on_baseline(url: str, **kw: object) -> MagicMock:
+            if _BASELINE_VALUE in url:
+                raise OSError("connection refused")
+            return _resp(200, "Welcome!")
+
+        with patch("requests.get", side_effect=raise_on_baseline):
+            results = check_ldap_injection([ep])
+
+        assert results == []
+
+    def test_probe_exception_is_swallowed(self) -> None:
+        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
+
+        def raise_on_probe(url: str, **kw: object) -> MagicMock:
+            if _BASELINE_VALUE in url:
+                return _resp(401, "bad")
+            raise OSError("timeout")
+
+        with patch("requests.get", side_effect=raise_on_probe):
+            results = check_ldap_injection([ep])
+
+        assert results == []
+
+    def test_deduplicates_across_multiple_endpoints_same_url(self) -> None:
+        ep1 = Endpoint(
+            url="https://app.example.com/login", status_code=200, parameters=["username"]
+        )
+        ep2 = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["email"])
+
+        with patch(
+            "requests.get",
+            side_effect=lambda url, **kw: _baseline_or_probe(
+                url, _resp(401, "bad"), _resp(200, "Welcome!")
+            ),
+        ):
+            results = check_ldap_injection([ep1, ep2])
+
+        assert len(results) == 1
+
+    def test_high_takes_priority_over_medium(self) -> None:
+        # Response triggers both a status-code bypass AND an error marker -
+        # the finding should be HIGH, not MEDIUM.
+        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
+
+        with patch(
+            "requests.get",
+            side_effect=lambda url, **kw: _baseline_or_probe(
+                url,
+                _resp(401, "bad"),
+                _resp(200, "Welcome! objectClass=person"),
+            ),
+        ):
+            results = check_ldap_injection([ep])
+
+        assert len(results) == 1
+        assert results[0].severity_hint == Severity.HIGH
+
+    def test_payload_list_covers_required_classes(self) -> None:
+        payloads = [p for p, _ in _PAYLOADS]
+        joined = " ".join(payloads)
+        assert "uid=*" in joined
+        assert "objectClass" in joined
+        assert "*" in joined
+        assert "admin" in joined
+        assert "%00" in joined
+
+    def test_error_markers_cover_required_strings(self) -> None:
+        assert "javax.naming" in _LDAP_ERROR_MARKERS
+        assert "ldap_search" in _LDAP_ERROR_MARKERS
+        assert "objectClass" in _LDAP_ERROR_MARKERS

--- a/tools/pentest/ldap_injection.py
+++ b/tools/pentest/ldap_injection.py
@@ -1,0 +1,161 @@
+"""LDAP injection detection - inject bypass and enumeration payloads into
+parameters and detect auth bypass, error disclosure, or server errors."""
+
+from __future__ import annotations
+
+import logging
+
+from config import config
+from models import Endpoint, RawFinding, Severity
+from tools import http
+from tools._helpers import adaptive_sleep
+
+logger = logging.getLogger(__name__)
+
+# (payload, label) pairs covering the main LDAP injection classes:
+# auth bypass, wildcard enumeration, boolean blind, null-byte truncation.
+_PAYLOADS: list[tuple[str, str]] = [
+    ("*)(uid=*))(|(uid=*", "auth-bypass"),
+    ("*)(objectClass=*", "objectClass-bypass"),
+    ("*", "wildcard"),
+    ("admin)(&)", "boolean-blind-false"),
+    ("admin)(|(", "boolean-blind-true"),
+    ("admin%00", "null-byte"),
+]
+
+# Substrings that confirm an LDAP backend is leaking error detail into the
+# response. Specific enough that false positives are rare.
+_LDAP_ERROR_MARKERS: list[str] = [
+    "javax.naming",
+    "ldap_search",
+    "LDAP error",
+    "LDAPException",
+    "NamingException",
+    "invalid DN",
+    "objectClass",
+]
+
+# Sent as the baseline value - unlikely to match any real directory entry.
+_BASELINE_VALUE = "baseline_ldap_test_1234"
+
+
+def check_ldap_injection(endpoints: list[Endpoint]) -> list[RawFinding]:
+    """
+    Probe parameterised endpoints for LDAP injection by injecting bypass and
+    enumeration payloads and comparing against a baseline request.
+
+    Detection tiers (stop at the highest tier that fires):
+      HIGH   - status code changes from an error state to 200/302, suggesting
+               the payload bypassed an LDAP authentication filter.
+      MEDIUM - response body contains known LDAP/AD error substrings,
+               confirming an LDAP backend that leaks internals.
+      MEDIUM - baseline returns non-500 but the LDAP payload triggers 500,
+               suggesting the payload was parsed and caused a server fault.
+
+    One finding per endpoint - stops after the first param+payload that
+    triggers, because confirming the class is enough for triage.
+    """
+    findings: list[RawFinding] = []
+    seen: set[str] = set()
+    _delay = config.scan.request_delay
+
+    for ep in endpoints:
+        if not ep.parameters:
+            continue
+        if ep.status_code and ep.status_code >= 500:
+            continue
+        if ep.url in seen:
+            continue
+
+        triggered = False
+        for param in ep.parameters:
+            if triggered:
+                break
+
+            try:
+                baseline_url = f"{ep.url}?{param}={_BASELINE_VALUE}"
+                baseline_resp = http.get(  # nosemgrep
+                    baseline_url,
+                    timeout=config.recon.http_timeout,
+                    allow_redirects=False,
+                )
+                baseline_status = baseline_resp.status_code
+                _delay = adaptive_sleep(_delay, baseline_status)
+            except Exception as exc:
+                logger.debug(
+                    "LDAP baseline request failed for %s param %s: %s",
+                    ep.url,
+                    param,
+                    exc,
+                )
+                continue
+
+            for payload, label in _PAYLOADS:
+                try:
+                    test_url = f"{ep.url}?{param}={payload}"
+                    resp = http.get(  # nosemgrep
+                        test_url,
+                        timeout=config.recon.http_timeout,
+                        allow_redirects=False,
+                    )
+
+                    severity: Severity | None = None
+                    reason = ""
+
+                    # Tier 1: status change from error to success - auth bypass.
+                    if baseline_status not in (200, 302) and resp.status_code in (200, 302):
+                        severity = Severity.HIGH
+                        reason = (
+                            f"Status changed {baseline_status} -> {resp.status_code}"
+                            " (possible auth bypass)"
+                        )
+
+                    # Tier 2: LDAP error marker leaked in response body.
+                    if severity is None:
+                        for marker in _LDAP_ERROR_MARKERS:
+                            if marker in resp.text:
+                                severity = Severity.MEDIUM
+                                reason = f"LDAP error marker in response: {marker!r}"
+                                break
+
+                    # Tier 3: server fault only on LDAP payload.
+                    if severity is None and baseline_status < 500 and resp.status_code >= 500:
+                        severity = Severity.MEDIUM
+                        reason = (
+                            f"Server error ({resp.status_code}) on LDAP payload"
+                            f" (baseline: {baseline_status})"
+                        )
+
+                    if severity is not None:
+                        findings.append(
+                            RawFinding(
+                                title=f"LDAP Injection - {ep.url}",
+                                vuln_class="LDAPInjection",
+                                target=ep.url,
+                                evidence=(
+                                    f"Parameter: {param}\n"
+                                    f"Payload ({label}): {payload}\n"
+                                    f"Baseline status: {baseline_status}\n"
+                                    f"Probe status: {resp.status_code}\n"
+                                    f"Detection: {reason}\n"
+                                    f"Response snippet: {resp.text[:300]}"
+                                ),
+                                tool="ldap_injection_probe",
+                                severity_hint=severity,
+                            )
+                        )
+                        seen.add(ep.url)
+                        triggered = True
+                        break
+                    _delay = adaptive_sleep(_delay, resp.status_code)
+                except Exception as exc:
+                    logger.debug(
+                        "LDAP injection probe failed for %s param %s payload %s: %s",
+                        ep.url,
+                        param,
+                        label,
+                        exc,
+                    )
+
+    logger.info("LDAP injection probe found %d findings", len(findings))
+    return findings


### PR DESCRIPTION
## Summary

- Implements #64: new `check_ldap_injection` tool in `tools/pentest/ldap_injection.py`, wired into the PT agent as `ldap_injection_tool`
- Fixes #70: `_recon_from_json` in `squad/penetration_tester/__init__.py` called itself instead of `ReconResult.model_validate_json`, causing a `RecursionError` at runtime on every tool that accepts a `recon_result_json` argument

## LDAP injection tool

Six payloads covering auth bypass, wildcard enumeration, boolean blind, null-byte truncation, and objectClass bypass. Detection is tiered:

- **HIGH** - status code changes from an error state (4xx) to 200/302 vs baseline, suggesting the payload bypassed an LDAP auth filter
- **MEDIUM** - LDAP/AD error substrings in the response body (`javax.naming`, `ldap_search`, `LDAPException`, etc.), confirming an LDAP backend that leaks internals
- **MEDIUM** - server error (500) only on the LDAP payload, not on the baseline, suggesting the payload was parsed and caused a fault

One finding per endpoint. Stops after the first triggering param+payload.

## Recursion bug

Introduced in aa41d55 (PR #59). The `_recon_from_json` helper was added to centralise `ReconResult` deserialisation + `http.set_programme()` side-effect, but the body called itself. Fix is a one-line change: `_recon_from_json(...)` -> `ReconResult.model_validate_json(...)`. The 22 affected tools all have unit tests that call the underlying functions directly, bypassing the wrapper - which is why CI never caught it.

## Test plan

- [ ] CI lint (ruff check + format) passes
- [ ] CI mypy passes
- [ ] CI unit tests pass (13 new tests, 100% coverage on `ldap_injection.py`, overall coverage 88%)
- [ ] CI bandit/semgrep passes
- [ ] Verify `_recon_from_json` no longer recurses by checking the one-line fix in `squad/penetration_tester/__init__.py:63`