### PR TITLE
feat: command injection probe for penetration tester (#50)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ This file is for AI assistants working on this codebase. It covers the architect
    .venv/bin/ruff check .
    .venv/bin/ruff format --check .
    .venv/bin/mypy . --ignore-missing-imports
-   H1_API_USERNAME=test H1_API_TOKEN=test CYBERSQUAD_CONTACT_EMAIL=test@example.invalid .venv/bin/pytest -m unit --cov --cov-report=term-missing
+   H1_API_USERNAME=ci-user H1_API_TOKEN=ci-token CYBERSQUAD_CONTACT_EMAIL=ci@example.invalid .venv/bin/pytest -m unit --cov --cov-report=term-missing
    .venv/bin/bandit -c pyproject.toml -r . -q
    ```
 

--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -30,6 +30,7 @@ from tools.cloud import (
     check_sensitive_files,
     check_webmin,
 )
+from tools.pentest.cmd_injection import check_cmd_injection
 from tools.pentest.cookies import check_cookies
 from tools.pentest.cors import check_cors_misconfiguration
 from tools.pentest.errors import check_error_disclosure
@@ -653,6 +654,30 @@ def ldap_injection_tool(endpoints_json: str) -> list[dict]:
     return [f.model_dump() for f in check_ldap_injection(_parse_endpoints(endpoints_json))]
 
 
+@tool("Command Injection Probe")
+def cmd_injection_tool(endpoints_json: str) -> list[dict]:
+    """
+    Append OS command payloads to URL parameter values using common shell
+    separators and look for a canary string echoed back in the response body.
+    Confirmed echo is CRITICAL - it is direct proof of arbitrary command execution.
+
+    endpoints_json: JSON array of endpoint objects. Prioritise endpoints that have
+      parameters AND where any of the following apply:
+      - Parameter names suggest shell or system interaction (cmd, exec, command,
+        shell, run, ping, host, ip, addr, query, search, name, input)
+      - Technologies mention CGI, Perl, PHP, or shell-invoking frameworks
+      - URL paths suggest system utilities (/ping, /traceroute, /lookup, /exec,
+        /run, /convert, /render, /preview, /generate)
+      - Error disclosure findings mention exec, popen, system, or shell functions
+      Example: '[{"url": "https://example.com/ping", "parameters": ["host"]}]'
+
+    Detection is in-band only. If no finding is returned on a suspicious endpoint,
+    escalate to manual time-based testing (e.g. sleep 5 with response-time delta).
+    Returns raw findings as dicts.
+    """
+    return [f.model_dump() for f in check_cmd_injection(_parse_endpoints(endpoints_json))]
+
+
 MEMBER = SquadMember(
     slug="penetration_tester",
     dir=Path(__file__).parent,
@@ -693,5 +718,6 @@ MEMBER = SquadMember(
         nosqli_tool,
         prompt_injection_tool,
         ldap_injection_tool,
+        cmd_injection_tool,
     ],
 )

--- a/tests/test_cmd_injection.py
+++ b/tests/test_cmd_injection.py
@@ -1,0 +1,131 @@
+"""tests/test_cmd_injection.py - unit tests for tools/pentest/cmd_injection.py"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from models import Endpoint, Severity
+from tools.pentest.cmd_injection import _CANARY, _PAYLOADS, check_cmd_injection
+
+pytestmark = pytest.mark.unit
+
+
+def _resp(status: int = 200, body: str = "") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.text = body
+    return resp
+
+
+class TestCheckCmdInjection:
+    def test_detects_canary_in_response(self) -> None:
+        ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
+
+        with patch("requests.get", return_value=_resp(body=f"PING output\n{_CANARY}\ndone")):
+            results = check_cmd_injection([ep])
+
+        assert len(results) == 1
+        assert results[0].vuln_class == "CommandInjection"
+        assert results[0].severity_hint == Severity.CRITICAL
+        assert "host" in results[0].evidence
+        assert _CANARY in results[0].evidence
+
+    def test_stops_after_first_matching_payload(self) -> None:
+        ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
+
+        with patch("requests.get", return_value=_resp(body=f"{_CANARY}")) as mock_get:
+            check_cmd_injection([ep])
+
+        assert mock_get.call_count == 1
+
+    def test_no_finding_when_canary_absent(self) -> None:
+        ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
+
+        with patch("requests.get", return_value=_resp(body="PING 127.0.0.1: 56 data bytes")):
+            results = check_cmd_injection([ep])
+
+        assert results == []
+
+    def test_partial_canary_match_is_not_a_finding(self) -> None:
+        # A substring of the canary appearing coincidentally must not trigger.
+        ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
+        partial = _CANARY[:6]
+
+        with patch("requests.get", return_value=_resp(body=f"result: {partial} ok")):
+            results = check_cmd_injection([ep])
+
+        assert results == []
+
+    def test_skips_endpoints_without_parameters(self) -> None:
+        ep = Endpoint(url="https://app.example.com/ping", status_code=200)
+
+        with patch("requests.get") as mock_get:
+            results = check_cmd_injection([ep])
+
+        mock_get.assert_not_called()
+        assert results == []
+
+    def test_skips_server_error_endpoints(self) -> None:
+        ep = Endpoint(url="https://app.example.com/ping", status_code=500, parameters=["host"])
+
+        with patch("requests.get") as mock_get:
+            results = check_cmd_injection([ep])
+
+        mock_get.assert_not_called()
+        assert results == []
+
+    def test_one_finding_per_endpoint_multiple_params(self) -> None:
+        ep = Endpoint(
+            url="https://app.example.com/ping",
+            status_code=200,
+            parameters=["host", "port"],
+        )
+
+        with patch("requests.get", return_value=_resp(body=_CANARY)):
+            results = check_cmd_injection([ep])
+
+        assert len(results) == 1
+
+    def test_deduplicates_same_url(self) -> None:
+        ep1 = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
+        ep2 = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["ip"])
+
+        with patch("requests.get", return_value=_resp(body=_CANARY)):
+            results = check_cmd_injection([ep1, ep2])
+
+        assert len(results) == 1
+
+    def test_multiple_distinct_endpoints_each_get_a_finding(self) -> None:
+        ep1 = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
+        ep2 = Endpoint(url="https://app.example.com/exec", status_code=200, parameters=["cmd"])
+
+        with patch("requests.get", return_value=_resp(body=_CANARY)):
+            results = check_cmd_injection([ep1, ep2])
+
+        assert len(results) == 2
+
+    def test_network_exception_is_swallowed(self) -> None:
+        ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
+
+        with patch("requests.get", side_effect=OSError("connection refused")):
+            results = check_cmd_injection([ep])
+
+        assert results == []
+
+    def test_payload_list_covers_required_separators(self) -> None:
+        payloads = [p for p, _ in _PAYLOADS]
+        joined = " ".join(payloads)
+        assert "; echo" in joined
+        assert "| echo" in joined
+        assert "&& echo" in joined
+        assert "|| echo" in joined
+        assert "`echo" in joined
+        assert "$(echo" in joined
+        assert "%0aecho" in joined
+        assert "& echo" in joined
+
+    def test_canary_is_embedded_in_all_payloads(self) -> None:
+        for payload, label in _PAYLOADS:
+            assert _CANARY in payload, f"canary missing from payload {label!r}"

--- a/tools/pentest/cmd_injection.py
+++ b/tools/pentest/cmd_injection.py
@@ -1,0 +1,117 @@
+"""Command injection detection - inject OS command payloads into parameters
+and match a canary echoed back in the response body."""
+
+from __future__ import annotations
+
+import logging
+
+from config import config
+from models import Endpoint, RawFinding, Severity
+from tools import http
+from tools._helpers import adaptive_sleep
+
+logger = logging.getLogger(__name__)
+
+# A canary that is vanishingly unlikely to appear in a normal response,
+# but will be echoed verbatim by any Unix or Windows shell that evaluates
+# the injected command.
+_CANARY = "CYBERSQUAD7331CMDI"
+
+# (payload, label) pairs. Each separator is appended directly to whatever
+# value the app passes to the shell, so the injected echo runs as a second
+# command. We cover the most common Unix separators, subshell forms, a
+# URL-encoded newline for parsers that split on %0a before exec, and the
+# Windows CMD separator.
+_PAYLOADS: list[tuple[str, str]] = [
+    # Semicolon - the most permissive separator; works in sh/bash/zsh/dash.
+    (f"; echo {_CANARY}", "semicolon"),
+    # Pipe - passes output of the first command to echo; echo ignores stdin.
+    (f"| echo {_CANARY}", "pipe"),
+    # AND - runs only if the preceding command exits 0.
+    (f"&& echo {_CANARY}", "and"),
+    # OR - runs only if the preceding command exits non-zero.
+    (f"|| echo {_CANARY}", "or"),
+    # Backtick subshell - evaluated inside double-quoted strings.
+    (f"`echo {_CANARY}`", "backtick"),
+    # Dollar-paren subshell - POSIX; evaluated in bash/sh/zsh/ksh.
+    (f"$(echo {_CANARY})", "dollar-paren"),
+    # URL-encoded newline - some CGI/PHP apps split on %0a before exec.
+    (f"%0aecho {_CANARY}", "url-newline"),
+    # Windows CMD & separator - echoes on both success and failure.
+    (f"& echo {_CANARY} &", "windows-amp"),
+]
+
+
+def check_cmd_injection(endpoints: list[Endpoint]) -> list[RawFinding]:
+    """
+    Probe parameterised endpoints for OS command injection by appending shell
+    separator payloads to parameter values and looking for a canary string
+    echoed back in the response body.
+
+    Detection is in-band only: the canary must appear in the HTTP response.
+    Blind injection (where command output is not reflected) is out of scope
+    for this tool; escalate to manual time-based testing if no finding is
+    returned on a suspicious endpoint.
+
+    Confirmed echo is reported as CRITICAL - the canary appearing in the
+    response is direct proof of arbitrary OS command execution.
+
+    One finding per endpoint. Stops after the first param+payload that
+    triggers, because confirming the class is enough for triage.
+    """
+    findings: list[RawFinding] = []
+    seen: set[str] = set()
+    _delay = config.scan.request_delay
+
+    for ep in endpoints:
+        if not ep.parameters:
+            continue
+        if ep.status_code and ep.status_code >= 500:
+            continue
+        if ep.url in seen:
+            continue
+
+        triggered = False
+        for param in ep.parameters:
+            if triggered:
+                break
+            for payload, label in _PAYLOADS:
+                try:
+                    test_url = f"{ep.url}?{param}={payload}"
+                    resp = http.get(  # nosemgrep
+                        test_url,
+                        timeout=config.recon.http_timeout,
+                        allow_redirects=False,
+                    )
+                    if _CANARY in resp.text:
+                        findings.append(
+                            RawFinding(
+                                title=f"Command Injection - {ep.url}",
+                                vuln_class="CommandInjection",
+                                target=ep.url,
+                                evidence=(
+                                    f"Parameter: {param}\n"
+                                    f"Payload ({label}): {payload}\n"
+                                    f"Status: {resp.status_code}\n"
+                                    f"Canary matched: {_CANARY!r}\n"
+                                    f"Response snippet: {resp.text[:300]}"
+                                ),
+                                tool="cmd_injection_probe",
+                                severity_hint=Severity.CRITICAL,
+                            )
+                        )
+                        seen.add(ep.url)
+                        triggered = True
+                        break
+                    _delay = adaptive_sleep(_delay, resp.status_code)
+                except Exception as exc:
+                    logger.debug(
+                        "Command injection probe failed for %s param %s payload %s: %s",
+                        ep.url,
+                        param,
+                        label,
+                        exc,
+                    )
+
+    logger.info("Command injection probe found %d findings", len(findings))
+    return findings


### PR DESCRIPTION
## Summary

- Implements #50: echo-based command injection probe for the PT agent
- One-line housekeeping: aligns CLAUDE.md local pytest env vars with CI values (was causing a spurious local test failure unrelated to this feature)

## Design

Detection is in-band only: inject a canary string via eight shell separator payloads, look for it echoed back in the response body. Confirmed echo is reported CRITICAL - it is direct proof of arbitrary OS command execution, not just a hint.

Payloads covered:

| Separator | Target |
|---|---|
| `; echo CANARY` | Unix - most permissive |
| `\| echo CANARY` | Unix/Windows pipe |
| `&& echo CANARY` | Unix AND |
| `\|\| echo CANARY` | Unix OR |
| `` `echo CANARY` `` | Unix backtick subshell |
| `$(echo CANARY)` | POSIX dollar-paren subshell |
| `%0aecho CANARY` | URL-encoded newline (CGI/PHP) |
| `& echo CANARY &` | Windows CMD separator |

The `@tool` docstring explicitly tells the agent to escalate to manual time-based testing if the endpoint looks suspicious but the in-band check draws a blank (blind injection).

## Test plan

- [x] CI lint passes
- [x] CI mypy passes
- [x] CI unit tests pass (12 new tests, 100% coverage on `cmd_injection.py`, 0 pre-existing failures with corrected env vars)
- [x] CI bandit/semgrep passes