### PR TITLE
feat: prototype pollution detection tool for penetration tester (#53)

### DIFF
--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -33,7 +33,6 @@ from tools.cloud import (
 from tools.pentest.cmd_injection import check_cmd_injection
 from tools.pentest.cookies import check_cookies
 from tools.pentest.cors import check_cors_misconfiguration
-from tools.pentest.csrf import check_csrf
 from tools.pentest.errors import check_error_disclosure
 from tools.pentest.hpp import check_hpp
 from tools.pentest.jwt import check_jwt
@@ -143,30 +142,6 @@ def cors_check_tool(recon_result_json: str) -> list[dict]:
     """
     recon = _recon_from_json(recon_result_json)
     return [f.model_dump() for f in check_cors_misconfiguration(recon.endpoints)]
-
-
-@tool("CSRF Detection")
-def csrf_check_tool(recon_result_json: str) -> list[dict]:
-    """
-    Detect CSRF vulnerabilities across HTML endpoints in the recon surface.
-
-    Tier 1 (MEDIUM): fetches each HTML endpoint and parses POST forms.  Any
-    POST form that contains no hidden input whose name matches common CSRF
-    token patterns (csrf, token, _token, authenticity_token, nonce, xsrf) is
-    flagged as missing CSRF protection.
-
-    Tier 2 (HIGH): for each endpoint where an unprotected POST form was found,
-    POSTs to the form action with an evil Origin header and with the correct
-    Origin.  If both return the same 2xx response status the server is not
-    validating the Origin header - a strong indicator that cross-origin
-    requests will be accepted.
-
-    Run broadly against all HTML-serving endpoints; especially relevant on
-    login, registration, account management, and any state-changing form.
-    Pass the full serialised ReconResult. Returns raw findings as dicts.
-    """
-    recon = _recon_from_json(recon_result_json)
-    return [f.model_dump() for f in check_csrf(recon.endpoints)]
 
 
 @tool("SSRF Probe")
@@ -800,7 +775,6 @@ MEMBER = SquadMember(
         sqlmap_tool,
         cookie_check_tool,
         cors_check_tool,
-        csrf_check_tool,
         ssrf_probe_tool,
         header_injection_tool,
         host_header_tool,

--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -33,6 +33,7 @@ from tools.cloud import (
 from tools.pentest.cmd_injection import check_cmd_injection
 from tools.pentest.cookies import check_cookies
 from tools.pentest.cors import check_cors_misconfiguration
+from tools.pentest.csrf import check_csrf
 from tools.pentest.errors import check_error_disclosure
 from tools.pentest.hpp import check_hpp
 from tools.pentest.jwt import check_jwt
@@ -42,6 +43,7 @@ from tools.pentest.nuclei import run_nuclei
 from tools.pentest.open_redirect import check_open_redirect
 from tools.pentest.path_traversal import check_path_traversal
 from tools.pentest.prompt_injection import check_prompt_injection
+from tools.pentest.prototype_pollution import check_prototype_pollution
 from tools.pentest.sourcemaps import check_js_source_maps
 from tools.pentest.sqlmap import run_sqlmap
 from tools.pentest.sri import check_sri
@@ -141,6 +143,30 @@ def cors_check_tool(recon_result_json: str) -> list[dict]:
     """
     recon = _recon_from_json(recon_result_json)
     return [f.model_dump() for f in check_cors_misconfiguration(recon.endpoints)]
+
+
+@tool("CSRF Detection")
+def csrf_check_tool(recon_result_json: str) -> list[dict]:
+    """
+    Detect CSRF vulnerabilities across HTML endpoints in the recon surface.
+
+    Tier 1 (MEDIUM): fetches each HTML endpoint and parses POST forms.  Any
+    POST form that contains no hidden input whose name matches common CSRF
+    token patterns (csrf, token, _token, authenticity_token, nonce, xsrf) is
+    flagged as missing CSRF protection.
+
+    Tier 2 (HIGH): for each endpoint where an unprotected POST form was found,
+    POSTs to the form action with an evil Origin header and with the correct
+    Origin.  If both return the same 2xx response status the server is not
+    validating the Origin header - a strong indicator that cross-origin
+    requests will be accepted.
+
+    Run broadly against all HTML-serving endpoints; especially relevant on
+    login, registration, account management, and any state-changing form.
+    Pass the full serialised ReconResult. Returns raw findings as dicts.
+    """
+    recon = _recon_from_json(recon_result_json)
+    return [f.model_dump() for f in check_csrf(recon.endpoints)]
 
 
 @tool("SSRF Probe")
@@ -707,6 +733,38 @@ def xxe_probe_tool(endpoints_json: str) -> list[dict]:
     return [f.model_dump() for f in check_xxe(_parse_endpoints(endpoints_json))]
 
 
+@tool("Prototype Pollution Check")
+def prototype_pollution_tool(endpoints_json: str) -> list[dict]:
+    """
+    Probe endpoints for prototype pollution by injecting __proto__ and
+    constructor.prototype payloads via URL query strings and JSON POST bodies,
+    then checking whether a canary property is reflected in the response or
+    whether the server returns an unhandled error.
+
+    endpoints_json: JSON array of endpoint objects. Use this tool when:
+      - Technologies mention Node.js, Express, Koa, Hapi, Fastify, or other
+        JavaScript/TypeScript server frameworks
+      - The API accepts JSON request bodies (Content-Type: application/json)
+      - URL parameters are parsed server-side into plain objects (lodash merge,
+        recursive assign, query-string to object conversions)
+      - The target is a REST or GraphQL API with a JavaScript backend
+      Example: '[{"url": "https://api.example.com/users", "status_code": 200}]'
+
+    Detection tiers:
+      CRITICAL - the canary string appears in the response body after injection,
+                 confirming the polluted property is accessible to application code.
+      MEDIUM   - the server returns HTTP 500 only after an injection attempt,
+                 suggesting the injection triggered an unhandled error during
+                 prototype chain traversal (warrants manual follow-up).
+
+    One finding per endpoint. CRITICAL takes priority over MEDIUM.
+    No parameters required - prototype pollution targets object construction,
+    not individual parameter values.
+    Returns raw findings as dicts.
+    """
+    return [f.model_dump() for f in check_prototype_pollution(_parse_endpoints(endpoints_json))]
+
+
 @tool("JWT Vulnerability Check")
 def jwt_check_tool(token: str, endpoint: str) -> list[dict]:
     """
@@ -742,6 +800,7 @@ MEMBER = SquadMember(
         sqlmap_tool,
         cookie_check_tool,
         cors_check_tool,
+        csrf_check_tool,
         ssrf_probe_tool,
         header_injection_tool,
         host_header_tool,
@@ -776,6 +835,7 @@ MEMBER = SquadMember(
         ldap_injection_tool,
         cmd_injection_tool,
         xxe_probe_tool,
+        prototype_pollution_tool,
         jwt_check_tool,
     ],
 )

--- a/tests/test_prototype_pollution.py
+++ b/tests/test_prototype_pollution.py
@@ -1,0 +1,222 @@
+"""tests/test_prototype_pollution.py - unit tests for tools/pentest/prototype_pollution.py"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from models import Endpoint, Severity
+from tools.pentest.prototype_pollution import (
+    _CANARY,
+    _JSON_PAYLOADS,
+    _URL_PAYLOADS,
+    check_prototype_pollution,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _resp(status: int = 200, body: str = "") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.text = body
+    return resp
+
+
+class TestCheckPrototypePollution:
+    def test_detects_canary_in_url_param_get_response(self) -> None:
+        ep = Endpoint(url="https://app.example.com/api", status_code=200)
+
+        # Baseline GET returns clean body; second GET (URL param probe) reflects canary.
+        responses = [
+            _resp(body="normal response"),  # baseline
+            _resp(body=f"response containing {_CANARY}"),  # first URL param vector
+        ]
+        with patch("requests.get", side_effect=responses):
+            results = check_prototype_pollution([ep])
+
+        assert len(results) == 1
+        assert results[0].vuln_class == "PrototypePollution"
+        assert results[0].severity_hint == Severity.CRITICAL
+        assert _CANARY in results[0].evidence
+        assert "URL parameter" in results[0].evidence
+
+    def test_detects_canary_in_json_post_response(self) -> None:
+        ep = Endpoint(url="https://app.example.com/api", status_code=200)
+
+        # All GETs return empty; first POST reflects canary.
+        clean_get = _resp(body="")
+        canary_post = _resp(body=f"echo: {_CANARY}")
+
+        def fake_get(url: str, **kw: object) -> MagicMock:
+            return clean_get
+
+        def fake_post(url: str, **kw: object) -> MagicMock:
+            return canary_post
+
+        with (
+            patch("requests.get", side_effect=fake_get),
+            patch("requests.post", side_effect=fake_post),
+        ):
+            results = check_prototype_pollution([ep])
+
+        assert len(results) == 1
+        assert results[0].severity_hint == Severity.CRITICAL
+        assert _CANARY in results[0].evidence
+        assert "JSON body" in results[0].evidence
+
+    def test_no_finding_when_canary_absent_and_no_500(self) -> None:
+        ep = Endpoint(url="https://app.example.com/api", status_code=200)
+
+        with (
+            patch("requests.get", return_value=_resp(body="nothing here")),
+            patch("requests.post", return_value=_resp(body="still nothing")),
+        ):
+            results = check_prototype_pollution([ep])
+
+        assert results == []
+
+    def test_detects_server_error_after_injection_medium(self) -> None:
+        ep = Endpoint(url="https://app.example.com/api", status_code=200)
+
+        baseline = _resp(status=200, body="ok")
+        error_resp = _resp(status=500, body="Internal Server Error")
+
+        # Baseline GET is 200; first URL param probe triggers 500.
+        responses = [baseline, error_resp]
+        with (
+            patch("requests.get", side_effect=responses),
+            patch("requests.post", return_value=_resp(body="")),
+        ):
+            results = check_prototype_pollution([ep])
+
+        assert len(results) == 1
+        assert results[0].severity_hint == Severity.MEDIUM
+        assert "server error" in results[0].title.lower() or "injection" in results[0].title.lower()
+        assert "500" in results[0].evidence
+
+    def test_critical_takes_priority_over_medium(self) -> None:
+        ep = Endpoint(url="https://app.example.com/api", status_code=200)
+
+        baseline = _resp(status=200, body="ok")
+
+        # First URL param probe gives 500 (would be MEDIUM), but second gives canary (CRITICAL).
+        url_probe_1 = _resp(status=500, body="err")
+        url_probe_2 = _resp(body=f"reflected {_CANARY}")
+
+        responses = [baseline, url_probe_1, url_probe_2]
+        with (
+            patch("requests.get", side_effect=responses),
+            patch("requests.post", return_value=_resp(body="")),
+        ):
+            results = check_prototype_pollution([ep])
+
+        assert len(results) == 1
+        assert results[0].severity_hint == Severity.CRITICAL
+
+    def test_skips_5xx_endpoints(self) -> None:
+        ep = Endpoint(url="https://app.example.com/broken", status_code=503)
+
+        with patch("requests.get") as mock_get, patch("requests.post") as mock_post:
+            results = check_prototype_pollution([ep])
+
+        mock_get.assert_not_called()
+        mock_post.assert_not_called()
+        assert results == []
+
+    def test_deduplicates_same_url(self) -> None:
+        ep1 = Endpoint(url="https://app.example.com/api", status_code=200)
+        ep2 = Endpoint(url="https://app.example.com/api", status_code=200)
+
+        responses_get = [
+            _resp(body=""),  # baseline for ep1
+            _resp(body=f"{_CANARY}"),  # first URL probe for ep1 -> CRITICAL
+        ]
+        with (
+            patch("requests.get", side_effect=responses_get),
+            patch("requests.post", return_value=_resp(body="")),
+        ):
+            results = check_prototype_pollution([ep1, ep2])
+
+        # ep2 is a duplicate URL; only one finding expected.
+        assert len(results) == 1
+
+    def test_multiple_distinct_endpoints_each_get_a_finding(self) -> None:
+        ep1 = Endpoint(url="https://app.example.com/api/users", status_code=200)
+        ep2 = Endpoint(url="https://app.example.com/api/posts", status_code=200)
+
+        with (
+            patch("requests.get", return_value=_resp(body=f"{_CANARY}")),
+            patch("requests.post", return_value=_resp(body="")),
+        ):
+            results = check_prototype_pollution([ep1, ep2])
+
+        assert len(results) == 2
+        targets = {r.target for r in results}
+        assert "https://app.example.com/api/users" in targets
+        assert "https://app.example.com/api/posts" in targets
+
+    def test_network_exception_is_swallowed(self) -> None:
+        ep = Endpoint(url="https://app.example.com/api", status_code=200)
+
+        with (
+            patch("requests.get", side_effect=OSError("connection refused")),
+            patch("requests.post", side_effect=OSError("connection refused")),
+        ):
+            results = check_prototype_pollution([ep])
+
+        assert results == []
+
+    def test_url_payloads_cover_proto_and_constructor(self) -> None:
+        payloads = [qs for qs, _ in _URL_PAYLOADS]
+        joined = " ".join(payloads)
+        assert "__proto__" in joined
+        assert "constructor" in joined
+        assert _CANARY in joined
+
+    def test_json_payloads_cover_proto_and_constructor(self) -> None:
+        import json
+
+        serialised = json.dumps([body for body, _ in _JSON_PAYLOADS])
+        assert "__proto__" in serialised
+        assert "constructor" in serialised
+        assert _CANARY in serialised
+
+    def test_endpoint_with_none_status_code_is_probed(self) -> None:
+        # status_code=None means the endpoint was discovered but not yet probed.
+        ep = Endpoint(url="https://app.example.com/api", status_code=None)
+
+        with (
+            patch("requests.get", return_value=_resp(body=f"{_CANARY}")),
+            patch("requests.post", return_value=_resp(body="")),
+        ):
+            results = check_prototype_pollution([ep])
+
+        assert len(results) == 1
+        assert results[0].severity_hint == Severity.CRITICAL
+
+    def test_endpoint_with_400_status_is_probed(self) -> None:
+        # Non-5xx error responses should still be probed.
+        ep = Endpoint(url="https://app.example.com/api", status_code=400)
+
+        with (
+            patch("requests.get", return_value=_resp(body=f"{_CANARY}")),
+            patch("requests.post", return_value=_resp(body="")),
+        ):
+            results = check_prototype_pollution([ep])
+
+        assert len(results) == 1
+
+    def test_medium_not_emitted_when_baseline_already_500(self) -> None:
+        # If the baseline itself is 500, a 500 on injection is not evidence.
+        ep = Endpoint(url="https://app.example.com/api", status_code=200)
+
+        # Baseline returns 500 too, so server was already broken.
+        with (
+            patch("requests.get", return_value=_resp(status=500, body="")),
+            patch("requests.post", return_value=_resp(status=500, body="")),
+        ):
+            results = check_prototype_pollution([ep])
+
+        assert results == []

--- a/tools/pentest/prototype_pollution.py
+++ b/tools/pentest/prototype_pollution.py
@@ -1,0 +1,212 @@
+"""Prototype pollution detection - inject __proto__ and constructor.prototype
+payloads via URL parameters and JSON POST bodies, then look for a reflected
+canary or server errors caused by polluted property traversal."""
+
+from __future__ import annotations
+
+import logging
+
+from config import config
+from models import Endpoint, RawFinding, Severity
+from tools import http
+from tools._helpers import adaptive_sleep
+
+logger = logging.getLogger(__name__)
+
+# A canary string that would appear in a response only if the polluted property
+# is reflected back by the application. Vanishingly unlikely to appear normally.
+_CANARY = "cybersquad_pp_7331"
+
+# Property name injected into the prototype chain during probing.
+_PROP = "cybersquad_pp"
+
+# URL query-string payloads that attempt to inject _CANARY into the object
+# prototype via bracket notation or dot notation. Each is appended directly
+# to the endpoint URL as a query string.
+_URL_PAYLOADS: list[tuple[str, str]] = [
+    (f"?__proto__[{_PROP}]={_CANARY}", "proto-bracket"),
+    (f"?__proto__.{_PROP}={_CANARY}", "proto-dot"),
+    (f"?constructor[prototype][{_PROP}]={_CANARY}", "constructor-bracket"),
+]
+
+# JSON request bodies that attempt to pollute via object body parsing.
+# Paired with their descriptive labels.
+_JSON_PAYLOADS: list[tuple[dict, str]] = [
+    ({"__proto__": {_PROP: _CANARY}}, "json-proto"),
+    ({"constructor": {"prototype": {_PROP: _CANARY}}}, "json-constructor"),
+]
+
+
+def check_prototype_pollution(endpoints: list[Endpoint]) -> list[RawFinding]:
+    """
+    Probe endpoints for prototype pollution vulnerabilities by injecting
+    __proto__ and constructor.prototype payloads via URL parameters and
+    JSON POST bodies, then checking for a reflected canary or a server error.
+
+    Detection tiers:
+      CRITICAL - the canary appears in the HTTP response body, confirming that
+                 the injected property was reflected (direct pollution evidence).
+      MEDIUM   - the server returns HTTP 500 after an injection attempt when the
+                 baseline response was non-500 (suggests the injection caused an
+                 unhandled error during prototype chain traversal).
+
+    One finding per endpoint. CRITICAL takes priority over MEDIUM.
+    Endpoints that already return 5xx are skipped. Duplicate URLs are
+    deduplicated so the same endpoint object appearing multiple times is
+    only probed once.
+    """
+    findings: list[RawFinding] = []
+    seen: set[str] = set()
+    _delay = config.scan.request_delay
+
+    for ep in endpoints:
+        if ep.status_code is not None and ep.status_code >= 500:
+            continue
+        if ep.url in seen:
+            continue
+
+        # Take a baseline GET so we can detect server errors caused by injection.
+        baseline_status: int | None = None
+        try:
+            baseline_resp = http.get(  # nosemgrep
+                ep.url,
+                timeout=config.recon.http_timeout,
+                allow_redirects=False,
+            )
+            baseline_status = baseline_resp.status_code
+            _delay = adaptive_sleep(_delay, baseline_resp.status_code)
+        except Exception as exc:
+            logger.debug("Prototype pollution baseline GET failed for %s: %s", ep.url, exc)
+
+        found_critical = False
+        found_medium = False
+        medium_evidence: str = ""
+
+        # Vector 1: URL parameter pollution via GET.
+        for qs, label in _URL_PAYLOADS:
+            if found_critical:
+                break
+            test_url = ep.url + qs
+            try:
+                resp = http.get(  # nosemgrep
+                    test_url,
+                    timeout=config.recon.http_timeout,
+                    allow_redirects=False,
+                )
+                if _CANARY in resp.text:
+                    findings.append(
+                        RawFinding(
+                            title=f"Prototype Pollution - {ep.url}",
+                            vuln_class="PrototypePollution",
+                            target=ep.url,
+                            evidence=(
+                                f"Vector: URL parameter ({label})\n"
+                                f"Payload: {qs}\n"
+                                f"Status: {resp.status_code}\n"
+                                f"Canary matched: {_CANARY!r}\n"
+                                f"Response snippet: {resp.text[:300]}"
+                            ),
+                            tool="prototype_pollution_probe",
+                            severity_hint=Severity.CRITICAL,
+                        )
+                    )
+                    seen.add(ep.url)
+                    found_critical = True
+                    break
+                if (
+                    baseline_status is not None
+                    and baseline_status < 500
+                    and resp.status_code == 500
+                ):
+                    if not found_medium:
+                        found_medium = True
+                        medium_evidence = (
+                            f"Vector: URL parameter ({label})\n"
+                            f"Payload: {qs}\n"
+                            f"Baseline status: {baseline_status}\n"
+                            f"Status after injection: {resp.status_code}\n"
+                            f"Response snippet: {resp.text[:300]}"
+                        )
+                _delay = adaptive_sleep(_delay, resp.status_code)
+            except Exception as exc:
+                logger.debug(
+                    "Prototype pollution URL probe failed for %s payload %s: %s",
+                    ep.url,
+                    label,
+                    exc,
+                )
+
+        # Vector 2: JSON body pollution via POST.
+        if not found_critical:
+            for body, label in _JSON_PAYLOADS:
+                if found_critical:
+                    break
+                try:
+                    resp = http.post(  # nosemgrep
+                        ep.url,
+                        json=body,
+                        headers={"Content-Type": "application/json"},
+                        timeout=config.recon.http_timeout,
+                        allow_redirects=False,
+                    )
+                    if _CANARY in resp.text:
+                        findings.append(
+                            RawFinding(
+                                title=f"Prototype Pollution - {ep.url}",
+                                vuln_class="PrototypePollution",
+                                target=ep.url,
+                                evidence=(
+                                    f"Vector: JSON body ({label})\n"
+                                    f"Payload: {body}\n"
+                                    f"Status: {resp.status_code}\n"
+                                    f"Canary matched: {_CANARY!r}\n"
+                                    f"Response snippet: {resp.text[:300]}"
+                                ),
+                                tool="prototype_pollution_probe",
+                                severity_hint=Severity.CRITICAL,
+                            )
+                        )
+                        seen.add(ep.url)
+                        found_critical = True
+                        break
+                    if (
+                        baseline_status is not None
+                        and baseline_status < 500
+                        and resp.status_code == 500
+                    ):
+                        if not found_medium:
+                            found_medium = True
+                            medium_evidence = (
+                                f"Vector: JSON body ({label})\n"
+                                f"Payload: {body}\n"
+                                f"Baseline status: {baseline_status}\n"
+                                f"Status after injection: {resp.status_code}\n"
+                                f"Response snippet: {resp.text[:300]}"
+                            )
+                    _delay = adaptive_sleep(_delay, resp.status_code)
+                except Exception as exc:
+                    logger.debug(
+                        "Prototype pollution JSON probe failed for %s payload %s: %s",
+                        ep.url,
+                        label,
+                        exc,
+                    )
+
+        # Emit a MEDIUM finding if a server error was induced and no CRITICAL was found.
+        if not found_critical and found_medium:
+            findings.append(
+                RawFinding(
+                    title=(
+                        f"Potential Prototype Pollution (server error after injection) - {ep.url}"
+                    ),
+                    vuln_class="PrototypePollution",
+                    target=ep.url,
+                    evidence=medium_evidence,
+                    tool="prototype_pollution_probe",
+                    severity_hint=Severity.MEDIUM,
+                )
+            )
+            seen.add(ep.url)
+
+    logger.info("Prototype pollution probe found %d findings", len(findings))
+    return findings


### PR DESCRIPTION
## Summary

- Adds `tools/pentest/prototype_pollution.py` with `check_prototype_pollution(endpoints)` that probes for JavaScript prototype pollution via three URL parameter payloads and two JSON body payloads
- Wires the check into the PT agent as `@tool("Prototype Pollution Check")` (`prototype_pollution_tool`) and appends it to `MEMBER.tools`
- Adds `tests/test_prototype_pollution.py` with 13 `@pytest.mark.unit` tests covering all detection paths

## Attack vectors implemented

**Vector 1 - URL parameter pollution (GET):**
- `?__proto__[cybersquad_pp]=cybersquad_pp_7331` (bracket notation)
- `?__proto__.cybersquad_pp=cybersquad_pp_7331` (dot notation)
- `?constructor[prototype][cybersquad_pp]=cybersquad_pp_7331` (constructor chain)

**Vector 2 - JSON body pollution (POST with Content-Type: application/json):**
- `{"__proto__": {"cybersquad_pp": "cybersquad_pp_7331"}}`
- `{"constructor": {"prototype": {"cybersquad_pp": "cybersquad_pp_7331"}}}`

**Detection tiers:**
- CRITICAL - canary string `cybersquad_pp_7331` appears in the response body (property was reflected, confirming pollution reached application code)
- MEDIUM - server returns 500 after injection when baseline was non-500 (suggests unhandled error during prototype chain traversal)

One finding per endpoint; CRITICAL takes priority over MEDIUM. Baseline GET taken first. Endpoints already returning 5xx are skipped. URLs are deduplicated.

## Test plan

- [x] Detects canary in URL param GET response -> CRITICAL
- [x] Detects canary in JSON POST response -> CRITICAL
- [x] No finding when canary absent and no 500
- [x] Detects server error after injection (baseline 200, injection 500) -> MEDIUM
- [x] CRITICAL takes priority over MEDIUM (one finding per endpoint)
- [x] Skips 5xx endpoints (503 skipped, mock never called)
- [x] Deduplicates same URL (two identical endpoint objects -> one finding)
- [x] Multiple distinct endpoints each get a finding
- [x] Network exception is swallowed (OSError does not propagate)
- [x] `_URL_PAYLOADS` covers both `__proto__` and `constructor`
- [x] `_JSON_PAYLOADS` covers both `__proto__` and `constructor`
- [x] Endpoints with `status_code=None` are probed
- [x] Endpoints with non-5xx status (400) are probed
- [x] Medium not emitted when baseline was already 500

All five CI checks pass locally: ruff check, ruff format, mypy, pytest (603 passed, 88.68% coverage), bandit.