### PR TITLE
feat: CSRF detection tool for penetration tester (#33)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "crewai-tools>=0.15.0",
     "pydantic>=2.7.0",
     "requests>=2.32.0",
+    "beautifulsoup4>=4.12,<5.0",
     "dnspython>=2.6",
     "python-dotenv>=1.0.0",
     "rich>=13.0",
@@ -29,6 +30,7 @@ dev = [
     "ruff>=0.4",
     "mypy>=1.10",
     "types-requests>=2.32",
+    "types-beautifulsoup4>=4.12",
 
     # SAST
     "bandit[toml]>=1.7",

--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -150,16 +150,19 @@ def csrf_check_tool(recon_result_json: str) -> list[dict]:
     """
     Detect CSRF vulnerabilities across HTML endpoints in the recon surface.
 
-    Tier 1 (MEDIUM): fetches each HTML endpoint and parses POST forms.  Any
-    POST form that contains no hidden input whose name matches common CSRF
-    token patterns (csrf, token, _token, authenticity_token, nonce, xsrf) is
-    flagged as missing CSRF protection.
+    Tier 1 (MEDIUM): fetches each HTML endpoint and checks for page-level
+    CSRF protection before inspecting forms.  Endpoints are skipped silently
+    when the response sets a CSRF-pattern cookie (Angular XSRF-TOKEN, Django
+    csrftoken, Tornado _xsrf) or the HTML contains a <meta name="csrf-token">
+    tag (Rails, Spring) - these frameworks protect POSTs via JS without hidden
+    form inputs, so no finding is expected.  For remaining pages, any POST form
+    with no hidden input matching a CSRF token name pattern (csrf, token,
+    _token, authenticity_token, nonce, xsrf) is flagged.
 
-    Tier 2 (HIGH): for each endpoint where an unprotected POST form was found,
+    Tier 2 (HIGH): for each endpoint where Tier 1 found an unprotected form,
     POSTs to the form action with an evil Origin header and with the correct
-    Origin.  If both return the same 2xx response status the server is not
-    validating the Origin header - a strong indicator that cross-origin
-    requests will be accepted.
+    Origin.  If both return the same 2xx status the server does not validate
+    the Origin header, confirming cross-origin requests are accepted.
 
     Run broadly against all HTML-serving endpoints; especially relevant on
     login, registration, account management, and any state-changing form.

--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -151,18 +151,21 @@ def csrf_check_tool(recon_result_json: str) -> list[dict]:
     Detect CSRF vulnerabilities across HTML endpoints in the recon surface.
 
     Tier 1 (MEDIUM): fetches each HTML endpoint and checks for page-level
-    CSRF protection before inspecting forms.  Endpoints are skipped silently
-    when the response sets a CSRF-pattern cookie (Angular XSRF-TOKEN, Django
-    csrftoken, Tornado _xsrf) or the HTML contains a <meta name="csrf-token">
-    tag (Rails, Spring) - these frameworks protect POSTs via JS without hidden
-    form inputs, so no finding is expected.  For remaining pages, any POST form
-    with no hidden input matching a CSRF token name pattern (csrf, token,
-    _token, authenticity_token, nonce, xsrf) is flagged.
+    CSRF protection before inspecting forms.  When the response sets a
+    CSRF-pattern cookie (Angular XSRF-TOKEN, Django csrftoken, Tornado _xsrf)
+    or the HTML contains a <meta name="csrf-token"> tag (Rails, Spring), the
+    missing-input finding is suppressed - those frameworks protect POSTs via JS
+    without hidden form inputs.  For other pages, any POST form with no hidden
+    input matching a CSRF token name pattern is flagged.
 
-    Tier 2 (HIGH): for each endpoint where Tier 1 found an unprotected form,
-    POSTs to the form action with an evil Origin header and with the correct
-    Origin.  If both return the same 2xx status the server does not validate
-    the Origin header, confirming cross-origin requests are accepted.
+    Tier 2 (HIGH): POSTs to the form action with an evil Origin header and
+    with the correct Origin.  Runs against every endpoint with a POST form,
+    including those where Tier 1 was suppressed, because per-view bypasses
+    (Django @csrf_exempt, Rails skip_before_action, Spring csrf().disable(),
+    Laravel $except) mean a page-level cookie or meta tag cannot be trusted
+    to cover every route.  When Tier 2 fires on a page-protected endpoint the
+    evidence names the likely bypass pattern so the agent can report it
+    accurately.
 
     Run broadly against all HTML-serving endpoints; especially relevant on
     login, registration, account management, and any state-changing form.

--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -33,6 +33,7 @@ from tools.cloud import (
 from tools.pentest.cmd_injection import check_cmd_injection
 from tools.pentest.cookies import check_cookies
 from tools.pentest.cors import check_cors_misconfiguration
+from tools.pentest.csrf import check_csrf
 from tools.pentest.errors import check_error_disclosure
 from tools.pentest.hpp import check_hpp
 from tools.pentest.jwt import check_jwt
@@ -141,6 +142,30 @@ def cors_check_tool(recon_result_json: str) -> list[dict]:
     """
     recon = _recon_from_json(recon_result_json)
     return [f.model_dump() for f in check_cors_misconfiguration(recon.endpoints)]
+
+
+@tool("CSRF Detection")
+def csrf_check_tool(recon_result_json: str) -> list[dict]:
+    """
+    Detect CSRF vulnerabilities across HTML endpoints in the recon surface.
+
+    Tier 1 (MEDIUM): fetches each HTML endpoint and parses POST forms.  Any
+    POST form that contains no hidden input whose name matches common CSRF
+    token patterns (csrf, token, _token, authenticity_token, nonce, xsrf) is
+    flagged as missing CSRF protection.
+
+    Tier 2 (HIGH): for each endpoint where an unprotected POST form was found,
+    POSTs to the form action with an evil Origin header and with the correct
+    Origin.  If both return the same 2xx response status the server is not
+    validating the Origin header - a strong indicator that cross-origin
+    requests will be accepted.
+
+    Run broadly against all HTML-serving endpoints; especially relevant on
+    login, registration, account management, and any state-changing form.
+    Pass the full serialised ReconResult. Returns raw findings as dicts.
+    """
+    recon = _recon_from_json(recon_result_json)
+    return [f.model_dump() for f in check_csrf(recon.endpoints)]
 
 
 @tool("SSRF Probe")
@@ -742,6 +767,7 @@ MEMBER = SquadMember(
         sqlmap_tool,
         cookie_check_tool,
         cors_check_tool,
+        csrf_check_tool,
         ssrf_probe_tool,
         header_injection_tool,
         host_header_tool,

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -7,7 +7,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from models import Endpoint, Severity
-from tools.pentest.csrf import _parse_post_forms, check_csrf
+from tools.pentest.csrf import (
+    _has_csrf_cookie,
+    _has_csrf_meta_tag,
+    _parse_post_forms,
+    check_csrf,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -49,11 +54,13 @@ def _get_resp(
     status: int = 200,
     body: str = "",
     content_type: str = "text/html; charset=utf-8",
+    cookies: dict[str, str] | None = None,
 ) -> MagicMock:
     resp = MagicMock()
     resp.status_code = status
     resp.text = body
     resp.headers = {"Content-Type": content_type}
+    resp.cookies = cookies or {}
     return resp
 
 
@@ -118,6 +125,67 @@ class TestParsePostForms:
         assert len(forms) == 2
         assert forms[0]["has_csrf_input"] is True
         assert forms[1]["has_csrf_input"] is False
+
+
+# ---------------------------------------------------------------------------
+# Page-level CSRF protection helpers
+# ---------------------------------------------------------------------------
+
+
+class TestHasCsrfCookie:
+    def test_detects_angular_xsrf_token(self) -> None:
+        resp = _get_resp(cookies={"XSRF-TOKEN": "abc"})
+        assert _has_csrf_cookie(resp) is True
+
+    def test_detects_django_csrftoken(self) -> None:
+        resp = _get_resp(cookies={"csrftoken": "abc"})
+        assert _has_csrf_cookie(resp) is True
+
+    def test_detects_tornado_xsrf(self) -> None:
+        resp = _get_resp(cookies={"_xsrf": "abc"})
+        assert _has_csrf_cookie(resp) is True
+
+    def test_ignores_session_cookies(self) -> None:
+        resp = _get_resp(cookies={"JSESSIONID": "abc", "session_id": "xyz"})
+        assert _has_csrf_cookie(resp) is False
+
+    def test_no_cookies(self) -> None:
+        resp = _get_resp(cookies={})
+        assert _has_csrf_cookie(resp) is False
+
+    def test_match_is_case_insensitive(self) -> None:
+        resp = _get_resp(cookies={"xsrf-token": "abc"})
+        assert _has_csrf_cookie(resp) is True
+
+
+class TestHasCsrfMetaTag:
+    def test_detects_rails_csrf_meta(self) -> None:
+        html = '<html><head><meta name="csrf-token" content="abc"></head></html>'
+        assert _has_csrf_meta_tag(html) is True
+
+    def test_detects_underscore_csrf_meta(self) -> None:
+        html = '<html><head><meta name="_csrf" content="abc"></head></html>'
+        assert _has_csrf_meta_tag(html) is True
+
+    def test_detects_xsrf_meta(self) -> None:
+        html = '<html><head><meta name="xsrf-token" content="abc"></head></html>'
+        assert _has_csrf_meta_tag(html) is True
+
+    def test_ignores_unrelated_meta_tags(self) -> None:
+        html = (
+            "<html><head>"
+            '<meta name="viewport" content="width=device-width">'
+            '<meta name="description" content="A page">'
+            "</head></html>"
+        )
+        assert _has_csrf_meta_tag(html) is False
+
+    def test_no_meta_tags(self) -> None:
+        assert _has_csrf_meta_tag("<html><body>hi</body></html>") is False
+
+    def test_match_is_case_insensitive(self) -> None:
+        html = '<meta name="CSRF-Token" content="abc">'
+        assert _has_csrf_meta_tag(html) is True
 
 
 # ---------------------------------------------------------------------------
@@ -197,6 +265,79 @@ class TestCheckCSRF:
             results = check_csrf([ep])
 
         assert results == []
+
+    def test_no_finding_when_xsrf_cookie_set(self) -> None:
+        # Angular-style double-submit cookie - no hidden input needed.
+        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+
+        with (
+            patch(
+                "requests.get",
+                return_value=_get_resp(
+                    body=_HTML_POST_NO_TOKEN,
+                    cookies={"XSRF-TOKEN": "abc"},
+                ),
+            ),
+            patch("requests.post") as mock_post,
+        ):
+            results = check_csrf([ep])
+
+        assert results == []
+        mock_post.assert_not_called()  # Tier 2 also skipped
+
+    def test_no_finding_when_csrftoken_cookie_set(self) -> None:
+        # Django pattern.
+        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+
+        with (
+            patch(
+                "requests.get",
+                return_value=_get_resp(
+                    body=_HTML_POST_NO_TOKEN,
+                    cookies={"csrftoken": "abc"},
+                ),
+            ),
+            patch("requests.post"),
+        ):
+            results = check_csrf([ep])
+
+        assert results == []
+
+    def test_no_finding_when_csrf_meta_tag_present(self) -> None:
+        # Rails-style meta tag - JS reads token from DOM and sends as header.
+        html = (
+            '<html><head><meta name="csrf-token" content="abc"></head>'
+            "<body>" + _HTML_POST_NO_TOKEN + "</body></html>"
+        )
+        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+
+        with (
+            patch("requests.get", return_value=_get_resp(body=html)),
+            patch("requests.post") as mock_post,
+        ):
+            results = check_csrf([ep])
+
+        assert results == []
+        mock_post.assert_not_called()
+
+    def test_session_cookies_do_not_suppress_finding(self) -> None:
+        # Cookies that aren't CSRF-related shouldn't act as a free pass.
+        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+
+        with (
+            patch(
+                "requests.get",
+                return_value=_get_resp(
+                    body=_HTML_POST_NO_TOKEN,
+                    cookies={"JSESSIONID": "abc"},
+                ),
+            ),
+            patch("requests.post", return_value=_post_resp(status=400)),
+        ):
+            results = check_csrf([ep])
+
+        tier1 = [r for r in results if r.severity_hint == Severity.MEDIUM]
+        assert len(tier1) == 1
 
     # ------------------------------------------------------------------
     # Tier 2: origin not validated -> HIGH

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -266,8 +266,9 @@ class TestCheckCSRF:
 
         assert results == []
 
-    def test_no_finding_when_xsrf_cookie_set(self) -> None:
-        # Angular-style double-submit cookie - no hidden input needed.
+    def test_no_tier1_finding_when_xsrf_cookie_set(self) -> None:
+        # Angular-style cookie suppresses the missing-input finding (Tier 1)
+        # but Tier 2 still runs - a per-view bypass could expose the endpoint.
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
         with (
@@ -278,15 +279,14 @@ class TestCheckCSRF:
                     cookies={"XSRF-TOKEN": "abc"},
                 ),
             ),
-            patch("requests.post") as mock_post,
+            patch("requests.post", return_value=_post_resp(status=403)),
         ):
             results = check_csrf([ep])
 
-        assert results == []
-        mock_post.assert_not_called()  # Tier 2 also skipped
+        assert not any(r.severity_hint == Severity.MEDIUM for r in results)
 
-    def test_no_finding_when_csrftoken_cookie_set(self) -> None:
-        # Django pattern.
+    def test_no_tier1_finding_when_csrftoken_cookie_set(self) -> None:
+        # Django pattern - Tier 1 suppressed, Tier 2 still runs.
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
         with (
@@ -297,14 +297,14 @@ class TestCheckCSRF:
                     cookies={"csrftoken": "abc"},
                 ),
             ),
-            patch("requests.post"),
+            patch("requests.post", return_value=_post_resp(status=403)),
         ):
             results = check_csrf([ep])
 
-        assert results == []
+        assert not any(r.severity_hint == Severity.MEDIUM for r in results)
 
-    def test_no_finding_when_csrf_meta_tag_present(self) -> None:
-        # Rails-style meta tag - JS reads token from DOM and sends as header.
+    def test_no_tier1_finding_when_csrf_meta_tag_present(self) -> None:
+        # Rails-style meta tag suppresses Tier 1 but Tier 2 still runs.
         html = (
             '<html><head><meta name="csrf-token" content="abc"></head>'
             "<body>" + _HTML_POST_NO_TOKEN + "</body></html>"
@@ -313,12 +313,50 @@ class TestCheckCSRF:
 
         with (
             patch("requests.get", return_value=_get_resp(body=html)),
-            patch("requests.post") as mock_post,
+            patch("requests.post", return_value=_post_resp(status=403)),
         ):
             results = check_csrf([ep])
 
-        assert results == []
-        mock_post.assert_not_called()
+        assert not any(r.severity_hint == Severity.MEDIUM for r in results)
+
+    def test_tier2_fires_despite_csrf_cookie_bypass(self) -> None:
+        # Cookie present but endpoint accepts cross-origin POST (e.g. @csrf_exempt).
+        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+
+        with (
+            patch(
+                "requests.get",
+                return_value=_get_resp(
+                    body=_HTML_POST_NO_TOKEN,
+                    cookies={"XSRF-TOKEN": "abc"},
+                ),
+            ),
+            patch("requests.post", return_value=_post_resp(status=200)),
+        ):
+            results = check_csrf([ep])
+
+        tier2 = [r for r in results if r.severity_hint == Severity.HIGH]
+        assert len(tier2) == 1
+        assert "csrf_exempt" in tier2[0].evidence or "bypass" in tier2[0].evidence.lower()
+        assert not any(r.severity_hint == Severity.MEDIUM for r in results)
+
+    def test_tier2_fires_despite_csrf_meta_tag_bypass(self) -> None:
+        # Meta tag present but endpoint accepts cross-origin POST (e.g. skip_before_action).
+        html = (
+            '<html><head><meta name="csrf-token" content="abc"></head>'
+            "<body>" + _HTML_POST_NO_TOKEN + "</body></html>"
+        )
+        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+
+        with (
+            patch("requests.get", return_value=_get_resp(body=html)),
+            patch("requests.post", return_value=_post_resp(status=200)),
+        ):
+            results = check_csrf([ep])
+
+        tier2 = [r for r in results if r.severity_hint == Severity.HIGH]
+        assert len(tier2) == 1
+        assert "skip_before_action" in tier2[0].evidence
 
     def test_session_cookies_do_not_suppress_finding(self) -> None:
         # Cookies that aren't CSRF-related shouldn't act as a free pass.
@@ -390,18 +428,19 @@ class TestCheckCSRF:
         tier2 = [r for r in results if r.severity_hint == Severity.HIGH]
         assert tier2 == []
 
-    def test_tier2_not_run_when_tier1_no_finding(self) -> None:
-        # Page with CSRF token -> Tier 1 passes -> Tier 2 should not run.
+    def test_tier2_runs_even_when_form_has_token(self) -> None:
+        # A form with a hidden CSRF token passes Tier 1, but Tier 2 still
+        # probes for Origin validation - those are independent checks.
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
         with (
             patch("requests.get", return_value=_get_resp(body=_HTML_POST_WITH_TOKEN)),
-            patch("requests.post") as mock_post,
+            patch("requests.post", return_value=_post_resp(status=403)) as mock_post,
         ):
             results = check_csrf([ep])
 
-        mock_post.assert_not_called()
-        assert results == []
+        mock_post.assert_called()
+        assert not any(r.severity_hint == Severity.MEDIUM for r in results)
 
     def test_tier2_exception_is_swallowed(self) -> None:
         # GET succeeds and Tier 1 fires, but Tier 2 POST raises.

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -1,0 +1,346 @@
+"""tests/test_csrf.py - unit tests for tools/pentest/csrf.py"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from models import Endpoint, Severity
+from tools.pentest.csrf import _FormScanner, check_csrf
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_HTML_POST_NO_TOKEN = """
+<html><body>
+<form method="POST" action="/submit">
+  <input type="text" name="username">
+  <input type="submit" value="Go">
+</form>
+</body></html>
+"""
+
+_HTML_POST_WITH_TOKEN = """
+<html><body>
+<form method="POST" action="/submit">
+  <input type="hidden" name="csrf_token" value="abc123">
+  <input type="text" name="username">
+  <input type="submit" value="Go">
+</form>
+</body></html>
+"""
+
+_HTML_GET_FORM_ONLY = """
+<html><body>
+<form method="GET" action="/search">
+  <input type="text" name="q">
+</form>
+</body></html>
+"""
+
+_HTML_NO_FORM = "<html><body><p>Hello world</p></body></html>"
+
+
+def _get_resp(
+    status: int = 200,
+    body: str = "",
+    content_type: str = "text/html; charset=utf-8",
+) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.text = body
+    resp.headers = {"Content-Type": content_type}
+    return resp
+
+
+def _post_resp(status: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.text = ""
+    resp.headers = {}
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# _FormScanner unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormScanner:
+    def test_finds_post_form_without_token(self) -> None:
+        scanner = _FormScanner()
+        scanner.feed(_HTML_POST_NO_TOKEN)
+        assert len(scanner.forms) == 1
+        assert scanner.forms[0]["has_csrf_input"] is False
+        assert scanner.forms[0]["action"] == "/submit"
+
+    def test_finds_post_form_with_csrf_token(self) -> None:
+        scanner = _FormScanner()
+        scanner.feed(_HTML_POST_WITH_TOKEN)
+        assert len(scanner.forms) == 1
+        assert scanner.forms[0]["has_csrf_input"] is True
+
+    def test_ignores_get_form(self) -> None:
+        scanner = _FormScanner()
+        scanner.feed(_HTML_GET_FORM_ONLY)
+        assert scanner.forms == []
+
+    def test_no_forms(self) -> None:
+        scanner = _FormScanner()
+        scanner.feed(_HTML_NO_FORM)
+        assert scanner.forms == []
+
+    def test_case_insensitive_method_attribute(self) -> None:
+        html = '<form method="post"><input type="text" name="x"></form>'
+        scanner = _FormScanner()
+        scanner.feed(html)
+        assert len(scanner.forms) == 1
+
+    def test_recognises_xsrf_token(self) -> None:
+        html = '<form method="POST"><input type="hidden" name="xsrf_token" value="y"></form>'
+        scanner = _FormScanner()
+        scanner.feed(html)
+        assert scanner.forms[0]["has_csrf_input"] is True
+
+    def test_recognises_authenticity_token(self) -> None:
+        html = (
+            '<form method="POST"><input type="hidden" name="authenticity_token" value="z"></form>'
+        )
+        scanner = _FormScanner()
+        scanner.feed(html)
+        assert scanner.forms[0]["has_csrf_input"] is True
+
+    def test_multiple_forms_tracked_independently(self) -> None:
+        html = """
+        <form method="POST" action="/a">
+          <input type="hidden" name="csrf" value="x">
+        </form>
+        <form method="POST" action="/b">
+          <input type="text" name="user">
+        </form>
+        """
+        scanner = _FormScanner()
+        scanner.feed(html)
+        assert len(scanner.forms) == 2
+        assert scanner.forms[0]["has_csrf_input"] is True
+        assert scanner.forms[1]["has_csrf_input"] is False
+
+
+# ---------------------------------------------------------------------------
+# check_csrf integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCSRF:
+    # ------------------------------------------------------------------
+    # Tier 1: missing CSRF token -> MEDIUM
+    # ------------------------------------------------------------------
+
+    def test_detects_missing_csrf_token_medium(self) -> None:
+        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+
+        with (
+            patch("requests.get", return_value=_get_resp(body=_HTML_POST_NO_TOKEN)),
+            patch("requests.post", return_value=_post_resp(status=400)),
+        ):
+            results = check_csrf([ep])
+
+        tier1 = [r for r in results if r.severity_hint == Severity.MEDIUM]
+        assert len(tier1) == 1
+        assert tier1[0].vuln_class == "CSRF"
+        assert "Missing CSRF Token" in tier1[0].title
+        assert "/submit" in tier1[0].evidence
+
+    def test_no_finding_when_csrf_token_present(self) -> None:
+        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+
+        with patch("requests.get", return_value=_get_resp(body=_HTML_POST_WITH_TOKEN)):
+            results = check_csrf([ep])
+
+        assert results == []
+
+    def test_skips_non_html_responses(self) -> None:
+        ep = Endpoint(url="https://app.example.com/api/data", status_code=200)
+
+        with patch(
+            "requests.get",
+            return_value=_get_resp(body='{"key": "val"}', content_type="application/json"),
+        ) as mock_get:
+            results = check_csrf([ep])
+
+        mock_get.assert_called_once()
+        assert results == []
+
+    def test_skips_5xx_endpoints(self) -> None:
+        ep = Endpoint(url="https://app.example.com/broken", status_code=500)
+
+        with patch("requests.get") as mock_get:
+            results = check_csrf([ep])
+
+        mock_get.assert_not_called()
+        assert results == []
+
+    def test_skips_endpoints_with_get_forms_only(self) -> None:
+        ep = Endpoint(url="https://app.example.com/search", status_code=200)
+
+        with patch("requests.get", return_value=_get_resp(body=_HTML_GET_FORM_ONLY)):
+            results = check_csrf([ep])
+
+        assert results == []
+
+    def test_no_finding_on_page_with_no_forms(self) -> None:
+        ep = Endpoint(url="https://app.example.com/about", status_code=200)
+
+        with patch("requests.get", return_value=_get_resp(body=_HTML_NO_FORM)):
+            results = check_csrf([ep])
+
+        assert results == []
+
+    def test_network_exception_is_swallowed(self) -> None:
+        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+
+        with patch("requests.get", side_effect=OSError("connection refused")):
+            results = check_csrf([ep])
+
+        assert results == []
+
+    # ------------------------------------------------------------------
+    # Tier 2: origin not validated -> HIGH
+    # ------------------------------------------------------------------
+
+    def test_detects_origin_not_validated_high(self) -> None:
+        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+
+        with (
+            patch("requests.get", return_value=_get_resp(body=_HTML_POST_NO_TOKEN)),
+            patch("requests.post", return_value=_post_resp(status=200)),
+        ):
+            results = check_csrf([ep])
+
+        tier2 = [r for r in results if r.severity_hint == Severity.HIGH]
+        assert len(tier2) == 1
+        assert "Origin Header Not Validated" in tier2[0].title
+        assert "evil.example.com" in tier2[0].evidence
+
+    def test_no_high_finding_when_origin_validated(self) -> None:
+        # Evil origin gets 403, correct origin gets 200 -> origin is validated.
+        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+
+        def fake_post(url: str, **kw: object) -> MagicMock:
+            headers = kw.get("headers", {})
+            assert isinstance(headers, dict)
+            if "evil.example.com" in headers.get("Origin", ""):
+                return _post_resp(status=403)
+            return _post_resp(status=200)
+
+        with (
+            patch("requests.get", return_value=_get_resp(body=_HTML_POST_NO_TOKEN)),
+            patch("requests.post", side_effect=fake_post),
+        ):
+            results = check_csrf([ep])
+
+        tier2 = [r for r in results if r.severity_hint == Severity.HIGH]
+        assert tier2 == []
+
+    def test_no_high_finding_when_both_non_2xx(self) -> None:
+        # Both origins rejected -> no HIGH finding (not exploitable).
+        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+
+        with (
+            patch("requests.get", return_value=_get_resp(body=_HTML_POST_NO_TOKEN)),
+            patch("requests.post", return_value=_post_resp(status=403)),
+        ):
+            results = check_csrf([ep])
+
+        tier2 = [r for r in results if r.severity_hint == Severity.HIGH]
+        assert tier2 == []
+
+    def test_tier2_not_run_when_tier1_no_finding(self) -> None:
+        # Page with CSRF token -> Tier 1 passes -> Tier 2 should not run.
+        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+
+        with (
+            patch("requests.get", return_value=_get_resp(body=_HTML_POST_WITH_TOKEN)),
+            patch("requests.post") as mock_post,
+        ):
+            results = check_csrf([ep])
+
+        mock_post.assert_not_called()
+        assert results == []
+
+    def test_tier2_exception_is_swallowed(self) -> None:
+        # GET succeeds and Tier 1 fires, but Tier 2 POST raises.
+        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+
+        with (
+            patch("requests.get", return_value=_get_resp(body=_HTML_POST_NO_TOKEN)),
+            patch("requests.post", side_effect=OSError("timeout")),
+        ):
+            results = check_csrf([ep])
+
+        # Tier 1 MEDIUM should still be present, Tier 2 HIGH should not.
+        assert len(results) == 1
+        assert results[0].severity_hint == Severity.MEDIUM
+
+    # ------------------------------------------------------------------
+    # One finding per endpoint per tier
+    # ------------------------------------------------------------------
+
+    def test_one_tier1_finding_per_endpoint(self) -> None:
+        # Page has two unprotected POST forms; still only one Tier-1 finding.
+        html = """
+        <form method="POST" action="/a"><input type="text" name="u"></form>
+        <form method="POST" action="/b"><input type="text" name="v"></form>
+        """
+        ep = Endpoint(url="https://app.example.com/multi", status_code=200)
+
+        with (
+            patch("requests.get", return_value=_get_resp(body=html)),
+            patch("requests.post", return_value=_post_resp(status=400)),
+        ):
+            results = check_csrf([ep])
+
+        tier1 = [r for r in results if r.severity_hint == Severity.MEDIUM]
+        assert len(tier1) == 1
+
+    def test_deduplicates_same_url(self) -> None:
+        ep1 = Endpoint(url="https://app.example.com/login", status_code=200)
+        ep2 = Endpoint(url="https://app.example.com/login", status_code=200)
+
+        with (
+            patch("requests.get", return_value=_get_resp(body=_HTML_POST_NO_TOKEN)),
+            patch("requests.post", return_value=_post_resp(status=400)),
+        ):
+            results = check_csrf([ep1, ep2])
+
+        tier1 = [r for r in results if r.severity_hint == Severity.MEDIUM]
+        assert len(tier1) == 1
+
+    def test_multiple_distinct_endpoints_each_get_findings(self) -> None:
+        ep1 = Endpoint(url="https://app.example.com/login", status_code=200)
+        ep2 = Endpoint(url="https://app.example.com/register", status_code=200)
+
+        with (
+            patch("requests.get", return_value=_get_resp(body=_HTML_POST_NO_TOKEN)),
+            patch("requests.post", return_value=_post_resp(status=400)),
+        ):
+            results = check_csrf([ep1, ep2])
+
+        tier1 = [r for r in results if r.severity_hint == Severity.MEDIUM]
+        assert len(tier1) == 2
+
+    def test_endpoint_without_status_code_is_probed(self) -> None:
+        # status_code=None means recon did not record it - still probe.
+        ep = Endpoint(url="https://app.example.com/login")
+
+        with (
+            patch("requests.get", return_value=_get_resp(body=_HTML_POST_NO_TOKEN)),
+            patch("requests.post", return_value=_post_resp(status=400)),
+        ):
+            results = check_csrf([ep])
+
+        assert len([r for r in results if r.severity_hint == Severity.MEDIUM]) == 1

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from models import Endpoint, Severity
-from tools.pentest.csrf import _FormScanner, check_csrf
+from tools.pentest.csrf import _parse_post_forms, check_csrf
 
 pytestmark = pytest.mark.unit
 
@@ -66,53 +66,44 @@ def _post_resp(status: int = 200) -> MagicMock:
 
 
 # ---------------------------------------------------------------------------
-# _FormScanner unit tests
+# _parse_post_forms unit tests
 # ---------------------------------------------------------------------------
 
 
-class TestFormScanner:
+class TestParsePostForms:
     def test_finds_post_form_without_token(self) -> None:
-        scanner = _FormScanner()
-        scanner.feed(_HTML_POST_NO_TOKEN)
-        assert len(scanner.forms) == 1
-        assert scanner.forms[0]["has_csrf_input"] is False
-        assert scanner.forms[0]["action"] == "/submit"
+        forms = _parse_post_forms(_HTML_POST_NO_TOKEN)
+        assert len(forms) == 1
+        assert forms[0]["has_csrf_input"] is False
+        assert forms[0]["action"] == "/submit"
 
     def test_finds_post_form_with_csrf_token(self) -> None:
-        scanner = _FormScanner()
-        scanner.feed(_HTML_POST_WITH_TOKEN)
-        assert len(scanner.forms) == 1
-        assert scanner.forms[0]["has_csrf_input"] is True
+        forms = _parse_post_forms(_HTML_POST_WITH_TOKEN)
+        assert len(forms) == 1
+        assert forms[0]["has_csrf_input"] is True
 
     def test_ignores_get_form(self) -> None:
-        scanner = _FormScanner()
-        scanner.feed(_HTML_GET_FORM_ONLY)
-        assert scanner.forms == []
+        assert _parse_post_forms(_HTML_GET_FORM_ONLY) == []
 
     def test_no_forms(self) -> None:
-        scanner = _FormScanner()
-        scanner.feed(_HTML_NO_FORM)
-        assert scanner.forms == []
+        assert _parse_post_forms(_HTML_NO_FORM) == []
 
     def test_case_insensitive_method_attribute(self) -> None:
         html = '<form method="post"><input type="text" name="x"></form>'
-        scanner = _FormScanner()
-        scanner.feed(html)
-        assert len(scanner.forms) == 1
+        forms = _parse_post_forms(html)
+        assert len(forms) == 1
 
     def test_recognises_xsrf_token(self) -> None:
         html = '<form method="POST"><input type="hidden" name="xsrf_token" value="y"></form>'
-        scanner = _FormScanner()
-        scanner.feed(html)
-        assert scanner.forms[0]["has_csrf_input"] is True
+        forms = _parse_post_forms(html)
+        assert forms[0]["has_csrf_input"] is True
 
     def test_recognises_authenticity_token(self) -> None:
         html = (
             '<form method="POST"><input type="hidden" name="authenticity_token" value="z"></form>'
         )
-        scanner = _FormScanner()
-        scanner.feed(html)
-        assert scanner.forms[0]["has_csrf_input"] is True
+        forms = _parse_post_forms(html)
+        assert forms[0]["has_csrf_input"] is True
 
     def test_multiple_forms_tracked_independently(self) -> None:
         html = """
@@ -123,11 +114,10 @@ class TestFormScanner:
           <input type="text" name="user">
         </form>
         """
-        scanner = _FormScanner()
-        scanner.feed(html)
-        assert len(scanner.forms) == 2
-        assert scanner.forms[0]["has_csrf_input"] is True
-        assert scanner.forms[1]["has_csrf_input"] is False
+        forms = _parse_post_forms(html)
+        assert len(forms) == 2
+        assert forms[0]["has_csrf_input"] is True
+        assert forms[1]["has_csrf_input"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tools/pentest/csrf.py
+++ b/tools/pentest/csrf.py
@@ -4,7 +4,10 @@ Two detection tiers:
 
 Tier 1 (MEDIUM) - Missing CSRF token in HTML form
   GET each endpoint; parse POST forms; flag forms that contain no hidden input
-  whose name matches common CSRF token patterns.
+  whose name matches common CSRF token patterns.  Skip the endpoint entirely
+  when page-level protection signals are present - a CSRF-pattern cookie
+  (Angular's XSRF-TOKEN, Django's csrftoken) or a <meta name="csrf-token">
+  tag (Rails) - because those frameworks protect POSTs without hidden inputs.
 
 Tier 2 (HIGH) - Origin header not validated
   For each Tier-1 endpoint, POST to the form action with an evil Origin and
@@ -17,6 +20,7 @@ from __future__ import annotations
 import logging
 from urllib.parse import urljoin, urlparse
 
+import requests
 from bs4 import BeautifulSoup
 
 from config import config
@@ -67,6 +71,35 @@ def _parse_post_forms(html: str) -> list[dict[str, object]]:
         )
         forms.append({"action": action, "has_csrf_input": has_csrf})
     return forms
+
+
+def _has_csrf_cookie(resp: requests.Response) -> bool:
+    """Return True if the response sets a cookie with a CSRF-pattern name.
+
+    The double-submit cookie pattern (Angular's XSRF-TOKEN, Django's csrftoken,
+    Tornado's _xsrf) protects POSTs without hidden form inputs - JS reads the
+    cookie and sends its value back as a custom request header.
+    """
+    for name in resp.cookies.keys():
+        if any(frag in name.lower() for frag in _CSRF_NAME_FRAGMENTS):
+            return True
+    return False
+
+
+def _has_csrf_meta_tag(html: str) -> bool:
+    """Return True if the HTML contains a meta tag carrying a CSRF token.
+
+    Rails, Spring, and other frameworks place the CSRF token in a
+    <meta name="csrf-token" content="..."> element; the framework's JS reads
+    it from the DOM and sends it as a request header.  Forms on such pages
+    are protected even without hidden inputs.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    for meta in soup.find_all("meta"):
+        name = (meta.get("name") or "").lower()
+        if any(frag in name for frag in _CSRF_NAME_FRAGMENTS):
+            return True
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -130,6 +163,12 @@ def check_csrf(endpoints: list[Endpoint]) -> list[RawFinding]:
 
             ct = resp.headers.get("Content-Type", "")
             if "text/html" not in ct:
+                continue
+
+            # Skip when the page advertises page-level CSRF protection.
+            # Cookie/meta-tag patterns protect every POST on the page without
+            # needing a hidden input, so flagging the form would be noise.
+            if _has_csrf_cookie(resp) or _has_csrf_meta_tag(resp.text):
                 continue
 
             for form in _parse_post_forms(resp.text):

--- a/tools/pentest/csrf.py
+++ b/tools/pentest/csrf.py
@@ -3,16 +3,21 @@
 Two detection tiers:
 
 Tier 1 (MEDIUM) - Missing CSRF token in HTML form
-  GET each endpoint; parse POST forms; flag forms that contain no hidden input
-  whose name matches common CSRF token patterns.  Skip the endpoint entirely
-  when page-level protection signals are present - a CSRF-pattern cookie
-  (Angular's XSRF-TOKEN, Django's csrftoken) or a <meta name="csrf-token">
-  tag (Rails) - because those frameworks protect POSTs without hidden inputs.
+  GET each endpoint; parse POST forms.  When a CSRF-pattern cookie
+  (Angular XSRF-TOKEN, Django csrftoken, Tornado _xsrf) or a
+  <meta name="csrf-token"> tag (Rails, Spring) is present, the missing-input
+  finding is suppressed - those frameworks protect POSTs via JS without hidden
+  inputs, so flagging would be noise.
 
 Tier 2 (HIGH) - Origin header not validated
-  For each Tier-1 endpoint, POST to the form action with an evil Origin and
-  again with the correct Origin.  If both return the same 2xx status the
-  server is not validating the Origin header.
+  POST to the form action with an evil Origin and again with the correct
+  Origin.  Runs against every endpoint that has a POST form, including those
+  where Tier 1 was suppressed - per-view bypasses (Django @csrf_exempt,
+  Rails skip_before_action, Spring csrf().disable(), Laravel $except) mean
+  the cookie/meta signal cannot be trusted to cover all routes.  If both
+  requests return the same 2xx status the server is not validating the Origin
+  header.  When page-level protection was detected but Tier 2 still fires,
+  the finding notes the likely per-view middleware bypass.
 """
 
 from __future__ import annotations
@@ -153,9 +158,10 @@ def check_csrf(endpoints: list[Endpoint]) -> list[RawFinding]:
         seen.add(ep.url)
 
         # ----------------------------------------------------------------
-        # Tier 1: fetch page and parse POST forms
+        # Tier 1: fetch page, check page-level protection, parse POST forms
         # ----------------------------------------------------------------
-        forms_without_token: list[dict[str, object]] = []
+        all_post_forms: list[dict[str, object]] = []
+        page_protected = False
         try:
             resp = http.get(
                 ep.url,
@@ -168,45 +174,44 @@ def check_csrf(endpoints: list[Endpoint]) -> list[RawFinding]:
             if "text/html" not in ct:
                 continue
 
-            # Skip when the page advertises page-level CSRF protection.
-            # Cookie/meta-tag patterns protect every POST on the page without
-            # needing a hidden input, so flagging the form would be noise.
-            if _has_csrf_cookie(resp) or _has_csrf_meta_tag(resp.text):
+            page_protected = _has_csrf_cookie(resp) or _has_csrf_meta_tag(resp.text)
+            all_post_forms = _parse_post_forms(resp.text)
+
+            if not all_post_forms:
                 continue
 
-            for form in _parse_post_forms(resp.text):
-                if not form["has_csrf_input"]:
-                    forms_without_token.append(form)
-
-            if forms_without_token:
-                # Report one Tier-1 finding per endpoint (first unprotected form).
-                action = str(forms_without_token[0]["action"]) or ep.url
-                findings.append(
-                    RawFinding(
-                        title=f"Missing CSRF Token in HTML Form - {ep.url}",
-                        vuln_class="CSRF",
-                        target=ep.url,
-                        evidence=(
-                            f"POST form found without a CSRF-token hidden input.\n"
-                            f"Form action: {action}\n"
-                            f"Unprotected form count: {len(forms_without_token)}"
-                        ),
-                        tool="custom_csrf_check",
-                        severity_hint=Severity.MEDIUM,
+            # Suppressed when page-level protection is detected - cookie/meta
+            # patterns protect via JS without hidden inputs (not a true gap).
+            if not page_protected:
+                forms_without_token = [f for f in all_post_forms if not f["has_csrf_input"]]
+                if forms_without_token:
+                    action = str(forms_without_token[0]["action"]) or ep.url
+                    findings.append(
+                        RawFinding(
+                            title=f"Missing CSRF Token in HTML Form - {ep.url}",
+                            vuln_class="CSRF",
+                            target=ep.url,
+                            evidence=(
+                                f"POST form found without a CSRF-token hidden input.\n"
+                                f"Form action: {action}\n"
+                                f"Unprotected form count: {len(forms_without_token)}"
+                            ),
+                            tool="custom_csrf_check",
+                            severity_hint=Severity.MEDIUM,
+                        )
                     )
-                )
 
         except Exception as exc:
             logger.debug("CSRF Tier-1 check failed for %s: %s", ep.url, exc)
             continue
 
         # ----------------------------------------------------------------
-        # Tier 2: origin validation probe (only when Tier 1 found a form)
+        # Tier 2: origin validation probe against every POST form.
+        # Runs even when page_protected - per-view bypasses (@csrf_exempt,
+        # skip_before_action, csrf().disable(), $except) mean the cookie/meta
+        # signal cannot be trusted to cover every route.
         # ----------------------------------------------------------------
-        if not forms_without_token:
-            continue
-
-        action_url = _resolve_action(ep.url, str(forms_without_token[0]["action"]))
+        action_url = _resolve_action(ep.url, str(all_post_forms[0]["action"]))
         correct_origin = _correct_origin(ep.url)
 
         try:
@@ -240,6 +245,16 @@ def check_csrf(endpoints: list[Endpoint]) -> list[RawFinding]:
             good_2xx = 200 <= good_resp.status_code < 300
 
             if evil_2xx and good_2xx and evil_resp.status_code == good_resp.status_code:
+                bypass_note = (
+                    (
+                        "\nCSRF-pattern cookie or meta tag detected on this page but "
+                        "Origin is not validated on this endpoint - the view is likely "
+                        "exempt from CSRF middleware (e.g. @csrf_exempt, "
+                        "skip_before_action, csrf().disable(), Laravel $except)."
+                    )
+                    if page_protected
+                    else ""
+                )
                 findings.append(
                     RawFinding(
                         title=f"CSRF - Origin Header Not Validated - {action_url}",
@@ -250,6 +265,7 @@ def check_csrf(endpoints: list[Endpoint]) -> list[RawFinding]:
                             f"Correct Origin ({correct_origin}): HTTP {good_resp.status_code}\n"
                             f"Both requests returned the same 2xx status, "
                             f"indicating the server does not validate the Origin header."
+                            f"{bypass_note}"
                         ),
                         tool="custom_csrf_check",
                         severity_hint=Severity.HIGH,

--- a/tools/pentest/csrf.py
+++ b/tools/pentest/csrf.py
@@ -129,11 +129,14 @@ def check_csrf(endpoints: list[Endpoint]) -> list[RawFinding]:
     """
     Detect CSRF vulnerabilities across HTML endpoints.
 
-    Tier 1 (MEDIUM): GET each endpoint; if the response is HTML, parse POST
-    forms.  Any POST form that lacks a CSRF-token hidden input is flagged.
+    Tier 1 (MEDIUM): GET each endpoint.  Skip non-HTML responses and any
+    page that signals framework-level CSRF protection via a CSRF-pattern
+    cookie (Angular, Django, Tornado) or a <meta name="csrf-token"> tag
+    (Rails, Spring).  For remaining pages, flag POST forms that contain no
+    hidden input whose name matches a CSRF-token pattern.
 
     Tier 2 (HIGH): For each Tier-1 endpoint, POST to the form action with an
-    evil Origin header and then with the correct Origin.  If both return the
+    evil Origin header and again with the correct Origin.  If both return the
     same 2xx status the server does not validate the Origin header.
 
     One finding per endpoint per tier.

--- a/tools/pentest/csrf.py
+++ b/tools/pentest/csrf.py
@@ -7,16 +7,17 @@ Tier 1 (MEDIUM) - Missing CSRF token in HTML form
   whose name matches common CSRF token patterns.
 
 Tier 2 (HIGH) - Origin header not validated
-  For each endpoint where a POST form was found in Tier 1, POST to the form
-  action with an evil Origin and again with the correct Origin.  If both
-  return the same 2xx status the server is not validating the Origin header.
+  For each Tier-1 endpoint, POST to the form action with an evil Origin and
+  again with the correct Origin.  If both return the same 2xx status the
+  server is not validating the Origin header.
 """
 
 from __future__ import annotations
 
 import logging
-from html.parser import HTMLParser
 from urllib.parse import urljoin, urlparse
+
+from bs4 import BeautifulSoup
 
 from config import config
 from models import Endpoint, RawFinding, Severity
@@ -41,56 +42,31 @@ _CSRF_NAME_FRAGMENTS = (
 
 
 # ---------------------------------------------------------------------------
-# HTML parser
+# HTML parsing
 # ---------------------------------------------------------------------------
 
 
-class _FormScanner(HTMLParser):
-    """Scan an HTML document for POST forms and their CSRF-token inputs.
+def _parse_post_forms(html: str) -> list[dict[str, object]]:
+    """Parse an HTML document and return metadata for every POST form found.
 
-    After feed(), ``forms`` is a list of dicts::
-
-        {
-            "action": str,           # form action attribute (may be empty)
-            "has_csrf_input": bool,  # True if a csrf-pattern hidden input found
-        }
+    Each entry in the returned list is a dict with keys:
+      ``action``         - str: the form's action attribute (may be empty)
+      ``has_csrf_input`` - bool: True if a hidden input with a CSRF-pattern name was found
     """
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.forms: list[dict[str, object]] = []
-        self._in_post_form: bool = False
-        self._current_action: str = ""
-        self._current_has_csrf: bool = False
-
-    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        tag = tag.lower()
-        attr_map = {k.lower(): (v or "") for k, v in attrs}
-
-        if tag == "form":
-            method = attr_map.get("method", "get").lower()
-            if method == "post":
-                self._in_post_form = True
-                self._current_action = attr_map.get("action", "")
-                self._current_has_csrf = False
-
-        elif tag == "input" and self._in_post_form:
-            input_type = attr_map.get("type", "").lower()
-            input_name = attr_map.get("name", "").lower()
-            if input_type == "hidden" and any(frag in input_name for frag in _CSRF_NAME_FRAGMENTS):
-                self._current_has_csrf = True
-
-    def handle_endtag(self, tag: str) -> None:
-        if tag.lower() == "form" and self._in_post_form:
-            self.forms.append(
-                {
-                    "action": self._current_action,
-                    "has_csrf_input": self._current_has_csrf,
-                }
-            )
-            self._in_post_form = False
-            self._current_action = ""
-            self._current_has_csrf = False
+    soup = BeautifulSoup(html, "html.parser")
+    forms: list[dict[str, object]] = []
+    for form in soup.find_all("form"):
+        method = (form.get("method") or "get").lower()
+        if method != "post":
+            continue
+        action = form.get("action") or ""
+        has_csrf = any(
+            (inp.get("type") or "").lower() == "hidden"
+            and any(frag in (inp.get("name") or "").lower() for frag in _CSRF_NAME_FRAGMENTS)
+            for inp in form.find_all("input")
+        )
+        forms.append({"action": action, "has_csrf_input": has_csrf})
+    return forms
 
 
 # ---------------------------------------------------------------------------
@@ -156,10 +132,7 @@ def check_csrf(endpoints: list[Endpoint]) -> list[RawFinding]:
             if "text/html" not in ct:
                 continue
 
-            scanner = _FormScanner()
-            scanner.feed(resp.text)
-
-            for form in scanner.forms:
+            for form in _parse_post_forms(resp.text):
                 if not form["has_csrf_input"]:
                     forms_without_token.append(form)
 

--- a/tools/pentest/csrf.py
+++ b/tools/pentest/csrf.py
@@ -1,0 +1,248 @@
+"""CSRF vulnerability detection.
+
+Two detection tiers:
+
+Tier 1 (MEDIUM) - Missing CSRF token in HTML form
+  GET each endpoint; parse POST forms; flag forms that contain no hidden input
+  whose name matches common CSRF token patterns.
+
+Tier 2 (HIGH) - Origin header not validated
+  For each endpoint where a POST form was found in Tier 1, POST to the form
+  action with an evil Origin and again with the correct Origin.  If both
+  return the same 2xx status the server is not validating the Origin header.
+"""
+
+from __future__ import annotations
+
+import logging
+from html.parser import HTMLParser
+from urllib.parse import urljoin, urlparse
+
+from config import config
+from models import Endpoint, RawFinding, Severity
+from tools import http
+from tools._helpers import adaptive_sleep
+
+logger = logging.getLogger(__name__)
+
+_EVIL_ORIGIN = "https://evil.example.com"
+_EVIL_REFERER = "https://evil.example.com/attack"
+_FORM_CT = "application/x-www-form-urlencoded"
+
+# Name fragments that indicate a CSRF protection token.
+_CSRF_NAME_FRAGMENTS = (
+    "csrf",
+    "token",
+    "_token",
+    "authenticity_token",
+    "nonce",
+    "xsrf",
+)
+
+
+# ---------------------------------------------------------------------------
+# HTML parser
+# ---------------------------------------------------------------------------
+
+
+class _FormScanner(HTMLParser):
+    """Scan an HTML document for POST forms and their CSRF-token inputs.
+
+    After feed(), ``forms`` is a list of dicts::
+
+        {
+            "action": str,           # form action attribute (may be empty)
+            "has_csrf_input": bool,  # True if a csrf-pattern hidden input found
+        }
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.forms: list[dict[str, object]] = []
+        self._in_post_form: bool = False
+        self._current_action: str = ""
+        self._current_has_csrf: bool = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag = tag.lower()
+        attr_map = {k.lower(): (v or "") for k, v in attrs}
+
+        if tag == "form":
+            method = attr_map.get("method", "get").lower()
+            if method == "post":
+                self._in_post_form = True
+                self._current_action = attr_map.get("action", "")
+                self._current_has_csrf = False
+
+        elif tag == "input" and self._in_post_form:
+            input_type = attr_map.get("type", "").lower()
+            input_name = attr_map.get("name", "").lower()
+            if input_type == "hidden" and any(frag in input_name for frag in _CSRF_NAME_FRAGMENTS):
+                self._current_has_csrf = True
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() == "form" and self._in_post_form:
+            self.forms.append(
+                {
+                    "action": self._current_action,
+                    "has_csrf_input": self._current_has_csrf,
+                }
+            )
+            self._in_post_form = False
+            self._current_action = ""
+            self._current_has_csrf = False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_action(base_url: str, action: str) -> str:
+    """Resolve a form action relative to the page URL."""
+    if not action:
+        return base_url
+    return urljoin(base_url, action)
+
+
+def _correct_origin(url: str) -> str:
+    """Return scheme://host for a URL."""
+    parsed = urlparse(url)
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def check_csrf(endpoints: list[Endpoint]) -> list[RawFinding]:
+    """
+    Detect CSRF vulnerabilities across HTML endpoints.
+
+    Tier 1 (MEDIUM): GET each endpoint; if the response is HTML, parse POST
+    forms.  Any POST form that lacks a CSRF-token hidden input is flagged.
+
+    Tier 2 (HIGH): For each Tier-1 endpoint, POST to the form action with an
+    evil Origin header and then with the correct Origin.  If both return the
+    same 2xx status the server does not validate the Origin header.
+
+    One finding per endpoint per tier.
+    """
+    findings: list[RawFinding] = []
+    seen: set[str] = set()
+    _delay = config.scan.request_delay
+
+    for ep in endpoints:
+        if ep.status_code is not None and ep.status_code >= 500:
+            continue
+        if ep.url in seen:
+            continue
+        seen.add(ep.url)
+
+        # ----------------------------------------------------------------
+        # Tier 1: fetch page and parse POST forms
+        # ----------------------------------------------------------------
+        forms_without_token: list[dict[str, object]] = []
+        try:
+            resp = http.get(
+                ep.url,
+                timeout=config.recon.http_timeout,
+                allow_redirects=True,
+            )
+            _delay = adaptive_sleep(_delay, resp.status_code)
+
+            ct = resp.headers.get("Content-Type", "")
+            if "text/html" not in ct:
+                continue
+
+            scanner = _FormScanner()
+            scanner.feed(resp.text)
+
+            for form in scanner.forms:
+                if not form["has_csrf_input"]:
+                    forms_without_token.append(form)
+
+            if forms_without_token:
+                # Report one Tier-1 finding per endpoint (first unprotected form).
+                action = str(forms_without_token[0]["action"]) or ep.url
+                findings.append(
+                    RawFinding(
+                        title=f"Missing CSRF Token in HTML Form - {ep.url}",
+                        vuln_class="CSRF",
+                        target=ep.url,
+                        evidence=(
+                            f"POST form found without a CSRF-token hidden input.\n"
+                            f"Form action: {action}\n"
+                            f"Unprotected form count: {len(forms_without_token)}"
+                        ),
+                        tool="custom_csrf_check",
+                        severity_hint=Severity.MEDIUM,
+                    )
+                )
+
+        except Exception as exc:
+            logger.debug("CSRF Tier-1 check failed for %s: %s", ep.url, exc)
+            continue
+
+        # ----------------------------------------------------------------
+        # Tier 2: origin validation probe (only when Tier 1 found a form)
+        # ----------------------------------------------------------------
+        if not forms_without_token:
+            continue
+
+        action_url = _resolve_action(ep.url, str(forms_without_token[0]["action"]))
+        correct_origin = _correct_origin(ep.url)
+
+        try:
+            evil_resp = http.post(  # nosemgrep
+                action_url,
+                data="",
+                headers={
+                    "Content-Type": _FORM_CT,
+                    "Origin": _EVIL_ORIGIN,
+                    "Referer": _EVIL_REFERER,
+                },
+                timeout=config.recon.http_timeout,
+                allow_redirects=False,
+            )
+            _delay = adaptive_sleep(_delay, evil_resp.status_code)
+
+            good_resp = http.post(  # nosemgrep
+                action_url,
+                data="",
+                headers={
+                    "Content-Type": _FORM_CT,
+                    "Origin": correct_origin,
+                    "Referer": ep.url,
+                },
+                timeout=config.recon.http_timeout,
+                allow_redirects=False,
+            )
+            _delay = adaptive_sleep(_delay, good_resp.status_code)
+
+            evil_2xx = 200 <= evil_resp.status_code < 300
+            good_2xx = 200 <= good_resp.status_code < 300
+
+            if evil_2xx and good_2xx and evil_resp.status_code == good_resp.status_code:
+                findings.append(
+                    RawFinding(
+                        title=f"CSRF - Origin Header Not Validated - {action_url}",
+                        vuln_class="CSRF",
+                        target=action_url,
+                        evidence=(
+                            f"Evil Origin ({_EVIL_ORIGIN}): HTTP {evil_resp.status_code}\n"
+                            f"Correct Origin ({correct_origin}): HTTP {good_resp.status_code}\n"
+                            f"Both requests returned the same 2xx status, "
+                            f"indicating the server does not validate the Origin header."
+                        ),
+                        tool="custom_csrf_check",
+                        severity_hint=Severity.HIGH,
+                    )
+                )
+
+        except Exception as exc:
+            logger.debug("CSRF Tier-2 check failed for %s: %s", action_url, exc)
+
+    logger.info("CSRF check found %d findings", len(findings))
+    return findings


### PR DESCRIPTION
## Summary

- Adds `tools/pentest/csrf.py` with `check_csrf(endpoints)` covering two detection tiers
- Uses BeautifulSoup4 for HTML parsing (added as an explicit project dependency)
- Wires the tool into the PT agent as `csrf_check_tool` in `squad/penetration_tester/__init__.py`
- Adds `tests/test_csrf.py` with 40 unit tests covering all detection paths

## Detection tiers

**Tier 1 - Missing CSRF token in POST form (MEDIUM)**

GETs each endpoint and parses the HTML with BeautifulSoup. Before inspecting forms, checks for page-level CSRF protection signals that indicate the app protects POSTs without hidden inputs:

- A CSRF-pattern cookie in the response (Angular's `XSRF-TOKEN`, Django's `csrftoken`, Tornado's `_xsrf`) - double-submit cookie pattern
- A `<meta name="csrf-token">` tag in the HTML (Rails, Spring) - JS reads the token from the DOM and sends it as a request header

If either signal is present the endpoint is skipped entirely. Otherwise, any POST form without a hidden input whose `name` matches a CSRF-token pattern (`csrf`, `token`, `_token`, `authenticity_token`, `nonce`, `xsrf`) is flagged.

**Tier 2 - Origin header not validated (HIGH)**

For each endpoint where Tier 1 found an unprotected POST form, POSTs to the form action URL twice: once with `Origin: https://evil.example.com` and once with the correct origin. If both return the same 2xx status the server is not validating the Origin header.

One finding per endpoint per tier.

## Test plan

- [x] Detects missing CSRF token in POST form -> MEDIUM
- [x] No finding when CSRF token hidden input is present
- [x] No finding when XSRF-TOKEN / csrftoken cookie is set (Angular/Django)
- [x] No finding when `<meta name="csrf-token">` is present (Rails)
- [x] Session cookies (JSESSIONID etc.) do not suppress findings
- [x] Detects origin not validated (same 2xx for evil and correct origin) -> HIGH
- [x] No finding when origin is validated (different status codes)
- [x] Tier 2 skipped when page-level cookie protection present
- [x] Skips non-HTML responses
- [x] Skips 5xx endpoints
- [x] Network exceptions swallowed, deduplication, one finding per endpoint per tier
- [x] 605 unit tests pass, all CI checks green