### PR TITLE
test: shared make_response fixture, remove all per-file mock helpers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -210,3 +210,32 @@ def clean_response_body() -> str:
         )
 
     return body
+
+
+@pytest.fixture
+def make_response():
+    """Factory for building MagicMock objects shaped like requests.Response.
+
+    Use this instead of local _resp/_mock_resp helpers in individual test files.
+    Tool-specific builders (e.g. _post_resp in test_csrf.py, the cookie-aware
+    _resp in test_cookies.py) stay local - they are not generic response mocks.
+    """
+    from unittest.mock import MagicMock
+
+    def _make(
+        status: int = 200,
+        body: str = "",
+        headers: dict | None = None,
+        cookies: dict | None = None,
+        json: object = None,
+    ) -> MagicMock:
+        resp = MagicMock()
+        resp.status_code = status
+        resp.text = body
+        resp.headers = headers or {}
+        resp.cookies = cookies or {}
+        if json is not None:
+            resp.json.return_value = json
+        return resp
+
+    return _make

--- a/tests/test_cmd_injection.py
+++ b/tests/test_cmd_injection.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -16,7 +16,9 @@ class TestCheckCmdInjection:
     def test_detects_canary_in_response(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
 
-        with patch("requests.get", return_value=make_response(body=f"PING output\n{_CANARY}\ndone")):
+        with patch(
+            "requests.get", return_value=make_response(body=f"PING output\n{_CANARY}\ndone")
+        ):
             results = check_cmd_injection([ep])
 
         assert len(results) == 1
@@ -36,7 +38,9 @@ class TestCheckCmdInjection:
     def test_no_finding_when_canary_absent(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
 
-        with patch("requests.get", return_value=make_response(body="PING 127.0.0.1: 56 data bytes")):
+        with patch(
+            "requests.get", return_value=make_response(body="PING 127.0.0.1: 56 data bytes")
+        ):
             results = check_cmd_injection([ep])
 
         assert results == []
@@ -130,7 +134,7 @@ class TestCheckCmdInjection:
 
         seen_urls: list[str] = []
 
-        def record(url: str, **_: object) -> MagicMock:
+        def record(url: str, **_: object):
             seen_urls.append(url)
             return make_response(body="no canary here")
 
@@ -173,7 +177,7 @@ class TestCheckCmdInjection:
 
         seen_urls: list[str] = []
 
-        def record(url: str, **_: object) -> MagicMock:
+        def record(url: str, **_: object):
             seen_urls.append(url)
             return make_response(body="no canary here")
 

--- a/tests/test_cmd_injection.py
+++ b/tests/test_cmd_injection.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from collections.abc import Callable
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -13,7 +14,7 @@ pytestmark = pytest.mark.unit
 
 
 class TestCheckCmdInjection:
-    def test_detects_canary_in_response(self, make_response) -> None:
+    def test_detects_canary_in_response(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
 
         with patch(
@@ -27,7 +28,9 @@ class TestCheckCmdInjection:
         assert "host" in results[0].evidence
         assert _CANARY in results[0].evidence
 
-    def test_stops_after_first_matching_payload(self, make_response) -> None:
+    def test_stops_after_first_matching_payload(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
 
         with patch("requests.get", return_value=make_response(body=f"{_CANARY}")) as mock_get:
@@ -35,7 +38,7 @@ class TestCheckCmdInjection:
 
         assert mock_get.call_count == 1
 
-    def test_no_finding_when_canary_absent(self, make_response) -> None:
+    def test_no_finding_when_canary_absent(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
 
         with patch(
@@ -45,7 +48,9 @@ class TestCheckCmdInjection:
 
         assert results == []
 
-    def test_partial_canary_match_is_not_a_finding(self, make_response) -> None:
+    def test_partial_canary_match_is_not_a_finding(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # A substring of the canary appearing coincidentally must not trigger.
         ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
         partial = _CANARY[:6]
@@ -73,7 +78,9 @@ class TestCheckCmdInjection:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_one_finding_per_endpoint_multiple_params(self, make_response) -> None:
+    def test_one_finding_per_endpoint_multiple_params(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(
             url="https://app.example.com/ping",
             status_code=200,
@@ -85,7 +92,7 @@ class TestCheckCmdInjection:
 
         assert len(results) == 1
 
-    def test_deduplicates_same_url(self, make_response) -> None:
+    def test_deduplicates_same_url(self, make_response: Callable[..., MagicMock]) -> None:
         ep1 = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
         ep2 = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["ip"])
 
@@ -94,7 +101,9 @@ class TestCheckCmdInjection:
 
         assert len(results) == 1
 
-    def test_multiple_distinct_endpoints_each_get_a_finding(self, make_response) -> None:
+    def test_multiple_distinct_endpoints_each_get_a_finding(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep1 = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
         ep2 = Endpoint(url="https://app.example.com/exec", status_code=200, parameters=["cmd"])
 
@@ -126,7 +135,9 @@ class TestCheckCmdInjection:
         for label, payload in _PAYLOADS.items():
             assert _CANARY in payload, f"canary missing from payload {label!r}"
 
-    def test_payload_filter_runs_only_named_variants(self, make_response) -> None:
+    def test_payload_filter_runs_only_named_variants(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # When the agent passes a single payload name we should issue exactly
         # one request per parameter and use only that variant. This is the
         # core "be surgical" affordance for stealth and chained probes.
@@ -134,7 +145,7 @@ class TestCheckCmdInjection:
 
         seen_urls: list[str] = []
 
-        def record(url: str, **_: object):
+        def record(url: str, **_: object) -> MagicMock:
             seen_urls.append(url)
             return make_response(body="no canary here")
 
@@ -159,7 +170,9 @@ class TestCheckCmdInjection:
         assert results == []
         mock_get.assert_not_called()
 
-    def test_payload_filter_finding_evidence_names_the_variant(self, make_response) -> None:
+    def test_payload_filter_finding_evidence_names_the_variant(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # When a filtered probe fires, the evidence must name which variant
         # triggered - the agent needs that to chain follow-up requests.
         ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
@@ -170,14 +183,16 @@ class TestCheckCmdInjection:
         assert len(results) == 1
         assert "dollar-paren" in results[0].evidence
 
-    def test_payload_filter_none_runs_all_variants(self, make_response) -> None:
+    def test_payload_filter_none_runs_all_variants(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Explicit None (the default) preserves the original behaviour:
         # every payload is tried until one matches.
         ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
 
         seen_urls: list[str] = []
 
-        def record(url: str, **_: object):
+        def record(url: str, **_: object) -> MagicMock:
             seen_urls.append(url)
             return make_response(body="no canary here")
 

--- a/tests/test_cmd_injection.py
+++ b/tests/test_cmd_injection.py
@@ -12,18 +12,11 @@ from tools.pentest.cmd_injection import _CANARY, _PAYLOADS, CmdPayload, check_cm
 pytestmark = pytest.mark.unit
 
 
-def _resp(status: int = 200, body: str = "") -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = status
-    resp.text = body
-    return resp
-
-
 class TestCheckCmdInjection:
-    def test_detects_canary_in_response(self) -> None:
+    def test_detects_canary_in_response(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
 
-        with patch("requests.get", return_value=_resp(body=f"PING output\n{_CANARY}\ndone")):
+        with patch("requests.get", return_value=make_response(body=f"PING output\n{_CANARY}\ndone")):
             results = check_cmd_injection([ep])
 
         assert len(results) == 1
@@ -32,28 +25,28 @@ class TestCheckCmdInjection:
         assert "host" in results[0].evidence
         assert _CANARY in results[0].evidence
 
-    def test_stops_after_first_matching_payload(self) -> None:
+    def test_stops_after_first_matching_payload(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
 
-        with patch("requests.get", return_value=_resp(body=f"{_CANARY}")) as mock_get:
+        with patch("requests.get", return_value=make_response(body=f"{_CANARY}")) as mock_get:
             check_cmd_injection([ep])
 
         assert mock_get.call_count == 1
 
-    def test_no_finding_when_canary_absent(self) -> None:
+    def test_no_finding_when_canary_absent(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
 
-        with patch("requests.get", return_value=_resp(body="PING 127.0.0.1: 56 data bytes")):
+        with patch("requests.get", return_value=make_response(body="PING 127.0.0.1: 56 data bytes")):
             results = check_cmd_injection([ep])
 
         assert results == []
 
-    def test_partial_canary_match_is_not_a_finding(self) -> None:
+    def test_partial_canary_match_is_not_a_finding(self, make_response) -> None:
         # A substring of the canary appearing coincidentally must not trigger.
         ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
         partial = _CANARY[:6]
 
-        with patch("requests.get", return_value=_resp(body=f"result: {partial} ok")):
+        with patch("requests.get", return_value=make_response(body=f"result: {partial} ok")):
             results = check_cmd_injection([ep])
 
         assert results == []
@@ -76,32 +69,32 @@ class TestCheckCmdInjection:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_one_finding_per_endpoint_multiple_params(self) -> None:
+    def test_one_finding_per_endpoint_multiple_params(self, make_response) -> None:
         ep = Endpoint(
             url="https://app.example.com/ping",
             status_code=200,
             parameters=["host", "port"],
         )
 
-        with patch("requests.get", return_value=_resp(body=_CANARY)):
+        with patch("requests.get", return_value=make_response(body=_CANARY)):
             results = check_cmd_injection([ep])
 
         assert len(results) == 1
 
-    def test_deduplicates_same_url(self) -> None:
+    def test_deduplicates_same_url(self, make_response) -> None:
         ep1 = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
         ep2 = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["ip"])
 
-        with patch("requests.get", return_value=_resp(body=_CANARY)):
+        with patch("requests.get", return_value=make_response(body=_CANARY)):
             results = check_cmd_injection([ep1, ep2])
 
         assert len(results) == 1
 
-    def test_multiple_distinct_endpoints_each_get_a_finding(self) -> None:
+    def test_multiple_distinct_endpoints_each_get_a_finding(self, make_response) -> None:
         ep1 = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
         ep2 = Endpoint(url="https://app.example.com/exec", status_code=200, parameters=["cmd"])
 
-        with patch("requests.get", return_value=_resp(body=_CANARY)):
+        with patch("requests.get", return_value=make_response(body=_CANARY)):
             results = check_cmd_injection([ep1, ep2])
 
         assert len(results) == 2
@@ -129,7 +122,7 @@ class TestCheckCmdInjection:
         for label, payload in _PAYLOADS.items():
             assert _CANARY in payload, f"canary missing from payload {label!r}"
 
-    def test_payload_filter_runs_only_named_variants(self) -> None:
+    def test_payload_filter_runs_only_named_variants(self, make_response) -> None:
         # When the agent passes a single payload name we should issue exactly
         # one request per parameter and use only that variant. This is the
         # core "be surgical" affordance for stealth and chained probes.
@@ -139,7 +132,7 @@ class TestCheckCmdInjection:
 
         def record(url: str, **_: object) -> MagicMock:
             seen_urls.append(url)
-            return _resp(body="no canary here")
+            return make_response(body="no canary here")
 
         with patch("requests.get", side_effect=record):
             results = check_cmd_injection([ep], payload_names=[CmdPayload.semicolon])
@@ -162,18 +155,18 @@ class TestCheckCmdInjection:
         assert results == []
         mock_get.assert_not_called()
 
-    def test_payload_filter_finding_evidence_names_the_variant(self) -> None:
+    def test_payload_filter_finding_evidence_names_the_variant(self, make_response) -> None:
         # When a filtered probe fires, the evidence must name which variant
         # triggered - the agent needs that to chain follow-up requests.
         ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
 
-        with patch("requests.get", return_value=_resp(body=_CANARY)):
+        with patch("requests.get", return_value=make_response(body=_CANARY)):
             results = check_cmd_injection([ep], payload_names=[CmdPayload.dollar_paren])
 
         assert len(results) == 1
         assert "dollar-paren" in results[0].evidence
 
-    def test_payload_filter_none_runs_all_variants(self) -> None:
+    def test_payload_filter_none_runs_all_variants(self, make_response) -> None:
         # Explicit None (the default) preserves the original behaviour:
         # every payload is tried until one matches.
         ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
@@ -182,7 +175,7 @@ class TestCheckCmdInjection:
 
         def record(url: str, **_: object) -> MagicMock:
             seen_urls.append(url)
-            return _resp(body="no canary here")
+            return make_response(body="no canary here")
 
         with patch("requests.get", side_effect=record):
             check_cmd_injection([ep], payload_names=None)

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -50,20 +50,6 @@ _HTML_GET_FORM_ONLY = """
 _HTML_NO_FORM = "<html><body><p>Hello world</p></body></html>"
 
 
-def _get_resp(
-    status: int = 200,
-    body: str = "",
-    content_type: str = "text/html; charset=utf-8",
-    cookies: dict[str, str] | None = None,
-) -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = status
-    resp.text = body
-    resp.headers = {"Content-Type": content_type}
-    resp.cookies = cookies or {}
-    return resp
-
-
 def _post_resp(status: int = 200) -> MagicMock:
     resp = MagicMock()
     resp.status_code = status
@@ -133,28 +119,39 @@ class TestParsePostForms:
 
 
 class TestHasCsrfCookie:
-    def test_detects_angular_xsrf_token(self) -> None:
-        resp = _get_resp(cookies={"XSRF-TOKEN": "abc"})
+    def test_detects_angular_xsrf_token(self, make_response) -> None:
+        resp = make_response(
+            headers={"Content-Type": "text/html; charset=utf-8"}, cookies={"XSRF-TOKEN": "abc"}
+        )
         assert _has_csrf_cookie(resp) is True
 
-    def test_detects_django_csrftoken(self) -> None:
-        resp = _get_resp(cookies={"csrftoken": "abc"})
+    def test_detects_django_csrftoken(self, make_response) -> None:
+        resp = make_response(
+            headers={"Content-Type": "text/html; charset=utf-8"}, cookies={"csrftoken": "abc"}
+        )
         assert _has_csrf_cookie(resp) is True
 
-    def test_detects_tornado_xsrf(self) -> None:
-        resp = _get_resp(cookies={"_xsrf": "abc"})
+    def test_detects_tornado_xsrf(self, make_response) -> None:
+        resp = make_response(
+            headers={"Content-Type": "text/html; charset=utf-8"}, cookies={"_xsrf": "abc"}
+        )
         assert _has_csrf_cookie(resp) is True
 
-    def test_ignores_session_cookies(self) -> None:
-        resp = _get_resp(cookies={"JSESSIONID": "abc", "session_id": "xyz"})
+    def test_ignores_session_cookies(self, make_response) -> None:
+        resp = make_response(
+            headers={"Content-Type": "text/html; charset=utf-8"},
+            cookies={"JSESSIONID": "abc", "session_id": "xyz"},
+        )
         assert _has_csrf_cookie(resp) is False
 
-    def test_no_cookies(self) -> None:
-        resp = _get_resp(cookies={})
+    def test_no_cookies(self, make_response) -> None:
+        resp = make_response(headers={"Content-Type": "text/html; charset=utf-8"})
         assert _has_csrf_cookie(resp) is False
 
-    def test_match_is_case_insensitive(self) -> None:
-        resp = _get_resp(cookies={"xsrf-token": "abc"})
+    def test_match_is_case_insensitive(self, make_response) -> None:
+        resp = make_response(
+            headers={"Content-Type": "text/html; charset=utf-8"}, cookies={"xsrf-token": "abc"}
+        )
         assert _has_csrf_cookie(resp) is True
 
 
@@ -198,11 +195,16 @@ class TestCheckCSRF:
     # Tier 1: missing CSRF token -> MEDIUM
     # ------------------------------------------------------------------
 
-    def test_detects_missing_csrf_token_medium(self) -> None:
+    def test_detects_missing_csrf_token_medium(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
         with (
-            patch("requests.get", return_value=_get_resp(body=_HTML_POST_NO_TOKEN)),
+            patch(
+                "requests.get",
+                return_value=make_response(
+                    body=_HTML_POST_NO_TOKEN, headers={"Content-Type": "text/html; charset=utf-8"}
+                ),
+            ),
             patch("requests.post", return_value=_post_resp(status=400)),
         ):
             results = check_csrf([ep])
@@ -213,20 +215,27 @@ class TestCheckCSRF:
         assert "Missing CSRF Token" in tier1[0].title
         assert "/submit" in tier1[0].evidence
 
-    def test_no_finding_when_csrf_token_present(self) -> None:
+    def test_no_finding_when_csrf_token_present(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
-        with patch("requests.get", return_value=_get_resp(body=_HTML_POST_WITH_TOKEN)):
+        with patch(
+            "requests.get",
+            return_value=make_response(
+                body=_HTML_POST_WITH_TOKEN, headers={"Content-Type": "text/html; charset=utf-8"}
+            ),
+        ):
             results = check_csrf([ep])
 
         assert results == []
 
-    def test_skips_non_html_responses(self) -> None:
+    def test_skips_non_html_responses(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/api/data", status_code=200)
 
         with patch(
             "requests.get",
-            return_value=_get_resp(body='{"key": "val"}', content_type="application/json"),
+            return_value=make_response(
+                body='{"key": "val"}', headers={"Content-Type": "application/json"}
+            ),
         ) as mock_get:
             results = check_csrf([ep])
 
@@ -242,18 +251,28 @@ class TestCheckCSRF:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_skips_endpoints_with_get_forms_only(self) -> None:
+    def test_skips_endpoints_with_get_forms_only(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/search", status_code=200)
 
-        with patch("requests.get", return_value=_get_resp(body=_HTML_GET_FORM_ONLY)):
+        with patch(
+            "requests.get",
+            return_value=make_response(
+                body=_HTML_GET_FORM_ONLY, headers={"Content-Type": "text/html; charset=utf-8"}
+            ),
+        ):
             results = check_csrf([ep])
 
         assert results == []
 
-    def test_no_finding_on_page_with_no_forms(self) -> None:
+    def test_no_finding_on_page_with_no_forms(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/about", status_code=200)
 
-        with patch("requests.get", return_value=_get_resp(body=_HTML_NO_FORM)):
+        with patch(
+            "requests.get",
+            return_value=make_response(
+                body=_HTML_NO_FORM, headers={"Content-Type": "text/html; charset=utf-8"}
+            ),
+        ):
             results = check_csrf([ep])
 
         assert results == []
@@ -266,7 +285,7 @@ class TestCheckCSRF:
 
         assert results == []
 
-    def test_no_tier1_finding_when_xsrf_cookie_set(self) -> None:
+    def test_no_tier1_finding_when_xsrf_cookie_set(self, make_response) -> None:
         # Angular-style cookie suppresses the missing-input finding (Tier 1)
         # but Tier 2 still runs - a per-view bypass could expose the endpoint.
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
@@ -274,8 +293,9 @@ class TestCheckCSRF:
         with (
             patch(
                 "requests.get",
-                return_value=_get_resp(
+                return_value=make_response(
                     body=_HTML_POST_NO_TOKEN,
+                    headers={"Content-Type": "text/html; charset=utf-8"},
                     cookies={"XSRF-TOKEN": "abc"},
                 ),
             ),
@@ -285,15 +305,16 @@ class TestCheckCSRF:
 
         assert not any(r.severity_hint == Severity.MEDIUM for r in results)
 
-    def test_no_tier1_finding_when_csrftoken_cookie_set(self) -> None:
+    def test_no_tier1_finding_when_csrftoken_cookie_set(self, make_response) -> None:
         # Django pattern - Tier 1 suppressed, Tier 2 still runs.
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
         with (
             patch(
                 "requests.get",
-                return_value=_get_resp(
+                return_value=make_response(
                     body=_HTML_POST_NO_TOKEN,
+                    headers={"Content-Type": "text/html; charset=utf-8"},
                     cookies={"csrftoken": "abc"},
                 ),
             ),
@@ -303,7 +324,7 @@ class TestCheckCSRF:
 
         assert not any(r.severity_hint == Severity.MEDIUM for r in results)
 
-    def test_no_tier1_finding_when_csrf_meta_tag_present(self) -> None:
+    def test_no_tier1_finding_when_csrf_meta_tag_present(self, make_response) -> None:
         # Rails-style meta tag suppresses Tier 1 but Tier 2 still runs.
         html = (
             '<html><head><meta name="csrf-token" content="abc"></head>'
@@ -312,22 +333,28 @@ class TestCheckCSRF:
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
         with (
-            patch("requests.get", return_value=_get_resp(body=html)),
+            patch(
+                "requests.get",
+                return_value=make_response(
+                    body=html, headers={"Content-Type": "text/html; charset=utf-8"}
+                ),
+            ),
             patch("requests.post", return_value=_post_resp(status=403)),
         ):
             results = check_csrf([ep])
 
         assert not any(r.severity_hint == Severity.MEDIUM for r in results)
 
-    def test_tier2_fires_despite_csrf_cookie_bypass(self) -> None:
+    def test_tier2_fires_despite_csrf_cookie_bypass(self, make_response) -> None:
         # Cookie present but endpoint accepts cross-origin POST (e.g. @csrf_exempt).
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
         with (
             patch(
                 "requests.get",
-                return_value=_get_resp(
+                return_value=make_response(
                     body=_HTML_POST_NO_TOKEN,
+                    headers={"Content-Type": "text/html; charset=utf-8"},
                     cookies={"XSRF-TOKEN": "abc"},
                 ),
             ),
@@ -340,7 +367,7 @@ class TestCheckCSRF:
         assert "csrf_exempt" in tier2[0].evidence or "bypass" in tier2[0].evidence.lower()
         assert not any(r.severity_hint == Severity.MEDIUM for r in results)
 
-    def test_tier2_fires_despite_csrf_meta_tag_bypass(self) -> None:
+    def test_tier2_fires_despite_csrf_meta_tag_bypass(self, make_response) -> None:
         # Meta tag present but endpoint accepts cross-origin POST (e.g. skip_before_action).
         html = (
             '<html><head><meta name="csrf-token" content="abc"></head>'
@@ -349,7 +376,12 @@ class TestCheckCSRF:
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
         with (
-            patch("requests.get", return_value=_get_resp(body=html)),
+            patch(
+                "requests.get",
+                return_value=make_response(
+                    body=html, headers={"Content-Type": "text/html; charset=utf-8"}
+                ),
+            ),
             patch("requests.post", return_value=_post_resp(status=200)),
         ):
             results = check_csrf([ep])
@@ -358,15 +390,16 @@ class TestCheckCSRF:
         assert len(tier2) == 1
         assert "skip_before_action" in tier2[0].evidence
 
-    def test_session_cookies_do_not_suppress_finding(self) -> None:
+    def test_session_cookies_do_not_suppress_finding(self, make_response) -> None:
         # Cookies that aren't CSRF-related shouldn't act as a free pass.
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
         with (
             patch(
                 "requests.get",
-                return_value=_get_resp(
+                return_value=make_response(
                     body=_HTML_POST_NO_TOKEN,
+                    headers={"Content-Type": "text/html; charset=utf-8"},
                     cookies={"JSESSIONID": "abc"},
                 ),
             ),
@@ -381,11 +414,16 @@ class TestCheckCSRF:
     # Tier 2: origin not validated -> HIGH
     # ------------------------------------------------------------------
 
-    def test_detects_origin_not_validated_high(self) -> None:
+    def test_detects_origin_not_validated_high(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
         with (
-            patch("requests.get", return_value=_get_resp(body=_HTML_POST_NO_TOKEN)),
+            patch(
+                "requests.get",
+                return_value=make_response(
+                    body=_HTML_POST_NO_TOKEN, headers={"Content-Type": "text/html; charset=utf-8"}
+                ),
+            ),
             patch("requests.post", return_value=_post_resp(status=200)),
         ):
             results = check_csrf([ep])
@@ -395,7 +433,7 @@ class TestCheckCSRF:
         assert "Origin Header Not Validated" in tier2[0].title
         assert "evil.example.com" in tier2[0].evidence
 
-    def test_no_high_finding_when_origin_validated(self) -> None:
+    def test_no_high_finding_when_origin_validated(self, make_response) -> None:
         # Evil origin gets 403, correct origin gets 200 -> origin is validated.
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
@@ -407,7 +445,12 @@ class TestCheckCSRF:
             return _post_resp(status=200)
 
         with (
-            patch("requests.get", return_value=_get_resp(body=_HTML_POST_NO_TOKEN)),
+            patch(
+                "requests.get",
+                return_value=make_response(
+                    body=_HTML_POST_NO_TOKEN, headers={"Content-Type": "text/html; charset=utf-8"}
+                ),
+            ),
             patch("requests.post", side_effect=fake_post),
         ):
             results = check_csrf([ep])
@@ -415,12 +458,17 @@ class TestCheckCSRF:
         tier2 = [r for r in results if r.severity_hint == Severity.HIGH]
         assert tier2 == []
 
-    def test_no_high_finding_when_both_non_2xx(self) -> None:
+    def test_no_high_finding_when_both_non_2xx(self, make_response) -> None:
         # Both origins rejected -> no HIGH finding (not exploitable).
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
         with (
-            patch("requests.get", return_value=_get_resp(body=_HTML_POST_NO_TOKEN)),
+            patch(
+                "requests.get",
+                return_value=make_response(
+                    body=_HTML_POST_NO_TOKEN, headers={"Content-Type": "text/html; charset=utf-8"}
+                ),
+            ),
             patch("requests.post", return_value=_post_resp(status=403)),
         ):
             results = check_csrf([ep])
@@ -428,13 +476,18 @@ class TestCheckCSRF:
         tier2 = [r for r in results if r.severity_hint == Severity.HIGH]
         assert tier2 == []
 
-    def test_tier2_runs_even_when_form_has_token(self) -> None:
+    def test_tier2_runs_even_when_form_has_token(self, make_response) -> None:
         # A form with a hidden CSRF token passes Tier 1, but Tier 2 still
         # probes for Origin validation - those are independent checks.
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
         with (
-            patch("requests.get", return_value=_get_resp(body=_HTML_POST_WITH_TOKEN)),
+            patch(
+                "requests.get",
+                return_value=make_response(
+                    body=_HTML_POST_WITH_TOKEN, headers={"Content-Type": "text/html; charset=utf-8"}
+                ),
+            ),
             patch("requests.post", return_value=_post_resp(status=403)) as mock_post,
         ):
             results = check_csrf([ep])
@@ -442,12 +495,17 @@ class TestCheckCSRF:
         mock_post.assert_called()
         assert not any(r.severity_hint == Severity.MEDIUM for r in results)
 
-    def test_tier2_exception_is_swallowed(self) -> None:
+    def test_tier2_exception_is_swallowed(self, make_response) -> None:
         # GET succeeds and Tier 1 fires, but Tier 2 POST raises.
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
         with (
-            patch("requests.get", return_value=_get_resp(body=_HTML_POST_NO_TOKEN)),
+            patch(
+                "requests.get",
+                return_value=make_response(
+                    body=_HTML_POST_NO_TOKEN, headers={"Content-Type": "text/html; charset=utf-8"}
+                ),
+            ),
             patch("requests.post", side_effect=OSError("timeout")),
         ):
             results = check_csrf([ep])
@@ -460,7 +518,7 @@ class TestCheckCSRF:
     # One finding per endpoint per tier
     # ------------------------------------------------------------------
 
-    def test_one_tier1_finding_per_endpoint(self) -> None:
+    def test_one_tier1_finding_per_endpoint(self, make_response) -> None:
         # Page has two unprotected POST forms; still only one Tier-1 finding.
         html = """
         <form method="POST" action="/a"><input type="text" name="u"></form>
@@ -469,7 +527,12 @@ class TestCheckCSRF:
         ep = Endpoint(url="https://app.example.com/multi", status_code=200)
 
         with (
-            patch("requests.get", return_value=_get_resp(body=html)),
+            patch(
+                "requests.get",
+                return_value=make_response(
+                    body=html, headers={"Content-Type": "text/html; charset=utf-8"}
+                ),
+            ),
             patch("requests.post", return_value=_post_resp(status=400)),
         ):
             results = check_csrf([ep])
@@ -477,12 +540,17 @@ class TestCheckCSRF:
         tier1 = [r for r in results if r.severity_hint == Severity.MEDIUM]
         assert len(tier1) == 1
 
-    def test_deduplicates_same_url(self) -> None:
+    def test_deduplicates_same_url(self, make_response) -> None:
         ep1 = Endpoint(url="https://app.example.com/login", status_code=200)
         ep2 = Endpoint(url="https://app.example.com/login", status_code=200)
 
         with (
-            patch("requests.get", return_value=_get_resp(body=_HTML_POST_NO_TOKEN)),
+            patch(
+                "requests.get",
+                return_value=make_response(
+                    body=_HTML_POST_NO_TOKEN, headers={"Content-Type": "text/html; charset=utf-8"}
+                ),
+            ),
             patch("requests.post", return_value=_post_resp(status=400)),
         ):
             results = check_csrf([ep1, ep2])
@@ -490,12 +558,17 @@ class TestCheckCSRF:
         tier1 = [r for r in results if r.severity_hint == Severity.MEDIUM]
         assert len(tier1) == 1
 
-    def test_multiple_distinct_endpoints_each_get_findings(self) -> None:
+    def test_multiple_distinct_endpoints_each_get_findings(self, make_response) -> None:
         ep1 = Endpoint(url="https://app.example.com/login", status_code=200)
         ep2 = Endpoint(url="https://app.example.com/register", status_code=200)
 
         with (
-            patch("requests.get", return_value=_get_resp(body=_HTML_POST_NO_TOKEN)),
+            patch(
+                "requests.get",
+                return_value=make_response(
+                    body=_HTML_POST_NO_TOKEN, headers={"Content-Type": "text/html; charset=utf-8"}
+                ),
+            ),
             patch("requests.post", return_value=_post_resp(status=400)),
         ):
             results = check_csrf([ep1, ep2])
@@ -503,12 +576,17 @@ class TestCheckCSRF:
         tier1 = [r for r in results if r.severity_hint == Severity.MEDIUM]
         assert len(tier1) == 2
 
-    def test_endpoint_without_status_code_is_probed(self) -> None:
+    def test_endpoint_without_status_code_is_probed(self, make_response) -> None:
         # status_code=None means recon did not record it - still probe.
         ep = Endpoint(url="https://app.example.com/login")
 
         with (
-            patch("requests.get", return_value=_get_resp(body=_HTML_POST_NO_TOKEN)),
+            patch(
+                "requests.get",
+                return_value=make_response(
+                    body=_HTML_POST_NO_TOKEN, headers={"Content-Type": "text/html; charset=utf-8"}
+                ),
+            ),
             patch("requests.post", return_value=_post_resp(status=400)),
         ):
             results = check_csrf([ep])

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -119,36 +120,36 @@ class TestParsePostForms:
 
 
 class TestHasCsrfCookie:
-    def test_detects_angular_xsrf_token(self, make_response) -> None:
+    def test_detects_angular_xsrf_token(self, make_response: Callable[..., MagicMock]) -> None:
         resp = make_response(
             headers={"Content-Type": "text/html; charset=utf-8"}, cookies={"XSRF-TOKEN": "abc"}
         )
         assert _has_csrf_cookie(resp) is True
 
-    def test_detects_django_csrftoken(self, make_response) -> None:
+    def test_detects_django_csrftoken(self, make_response: Callable[..., MagicMock]) -> None:
         resp = make_response(
             headers={"Content-Type": "text/html; charset=utf-8"}, cookies={"csrftoken": "abc"}
         )
         assert _has_csrf_cookie(resp) is True
 
-    def test_detects_tornado_xsrf(self, make_response) -> None:
+    def test_detects_tornado_xsrf(self, make_response: Callable[..., MagicMock]) -> None:
         resp = make_response(
             headers={"Content-Type": "text/html; charset=utf-8"}, cookies={"_xsrf": "abc"}
         )
         assert _has_csrf_cookie(resp) is True
 
-    def test_ignores_session_cookies(self, make_response) -> None:
+    def test_ignores_session_cookies(self, make_response: Callable[..., MagicMock]) -> None:
         resp = make_response(
             headers={"Content-Type": "text/html; charset=utf-8"},
             cookies={"JSESSIONID": "abc", "session_id": "xyz"},
         )
         assert _has_csrf_cookie(resp) is False
 
-    def test_no_cookies(self, make_response) -> None:
+    def test_no_cookies(self, make_response: Callable[..., MagicMock]) -> None:
         resp = make_response(headers={"Content-Type": "text/html; charset=utf-8"})
         assert _has_csrf_cookie(resp) is False
 
-    def test_match_is_case_insensitive(self, make_response) -> None:
+    def test_match_is_case_insensitive(self, make_response: Callable[..., MagicMock]) -> None:
         resp = make_response(
             headers={"Content-Type": "text/html; charset=utf-8"}, cookies={"xsrf-token": "abc"}
         )
@@ -195,7 +196,9 @@ class TestCheckCSRF:
     # Tier 1: missing CSRF token -> MEDIUM
     # ------------------------------------------------------------------
 
-    def test_detects_missing_csrf_token_medium(self, make_response) -> None:
+    def test_detects_missing_csrf_token_medium(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
         with (
@@ -215,7 +218,9 @@ class TestCheckCSRF:
         assert "Missing CSRF Token" in tier1[0].title
         assert "/submit" in tier1[0].evidence
 
-    def test_no_finding_when_csrf_token_present(self, make_response) -> None:
+    def test_no_finding_when_csrf_token_present(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
         with patch(
@@ -228,7 +233,7 @@ class TestCheckCSRF:
 
         assert results == []
 
-    def test_skips_non_html_responses(self, make_response) -> None:
+    def test_skips_non_html_responses(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/api/data", status_code=200)
 
         with patch(
@@ -251,7 +256,9 @@ class TestCheckCSRF:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_skips_endpoints_with_get_forms_only(self, make_response) -> None:
+    def test_skips_endpoints_with_get_forms_only(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/search", status_code=200)
 
         with patch(
@@ -264,7 +271,9 @@ class TestCheckCSRF:
 
         assert results == []
 
-    def test_no_finding_on_page_with_no_forms(self, make_response) -> None:
+    def test_no_finding_on_page_with_no_forms(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/about", status_code=200)
 
         with patch(
@@ -285,7 +294,9 @@ class TestCheckCSRF:
 
         assert results == []
 
-    def test_no_tier1_finding_when_xsrf_cookie_set(self, make_response) -> None:
+    def test_no_tier1_finding_when_xsrf_cookie_set(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Angular-style cookie suppresses the missing-input finding (Tier 1)
         # but Tier 2 still runs - a per-view bypass could expose the endpoint.
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
@@ -305,7 +316,9 @@ class TestCheckCSRF:
 
         assert not any(r.severity_hint == Severity.MEDIUM for r in results)
 
-    def test_no_tier1_finding_when_csrftoken_cookie_set(self, make_response) -> None:
+    def test_no_tier1_finding_when_csrftoken_cookie_set(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Django pattern - Tier 1 suppressed, Tier 2 still runs.
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
@@ -324,7 +337,9 @@ class TestCheckCSRF:
 
         assert not any(r.severity_hint == Severity.MEDIUM for r in results)
 
-    def test_no_tier1_finding_when_csrf_meta_tag_present(self, make_response) -> None:
+    def test_no_tier1_finding_when_csrf_meta_tag_present(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Rails-style meta tag suppresses Tier 1 but Tier 2 still runs.
         html = (
             '<html><head><meta name="csrf-token" content="abc"></head>'
@@ -345,7 +360,9 @@ class TestCheckCSRF:
 
         assert not any(r.severity_hint == Severity.MEDIUM for r in results)
 
-    def test_tier2_fires_despite_csrf_cookie_bypass(self, make_response) -> None:
+    def test_tier2_fires_despite_csrf_cookie_bypass(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Cookie present but endpoint accepts cross-origin POST (e.g. @csrf_exempt).
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
@@ -367,7 +384,9 @@ class TestCheckCSRF:
         assert "csrf_exempt" in tier2[0].evidence or "bypass" in tier2[0].evidence.lower()
         assert not any(r.severity_hint == Severity.MEDIUM for r in results)
 
-    def test_tier2_fires_despite_csrf_meta_tag_bypass(self, make_response) -> None:
+    def test_tier2_fires_despite_csrf_meta_tag_bypass(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Meta tag present but endpoint accepts cross-origin POST (e.g. skip_before_action).
         html = (
             '<html><head><meta name="csrf-token" content="abc"></head>'
@@ -390,7 +409,9 @@ class TestCheckCSRF:
         assert len(tier2) == 1
         assert "skip_before_action" in tier2[0].evidence
 
-    def test_session_cookies_do_not_suppress_finding(self, make_response) -> None:
+    def test_session_cookies_do_not_suppress_finding(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Cookies that aren't CSRF-related shouldn't act as a free pass.
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
@@ -414,7 +435,9 @@ class TestCheckCSRF:
     # Tier 2: origin not validated -> HIGH
     # ------------------------------------------------------------------
 
-    def test_detects_origin_not_validated_high(self, make_response) -> None:
+    def test_detects_origin_not_validated_high(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
         with (
@@ -433,7 +456,9 @@ class TestCheckCSRF:
         assert "Origin Header Not Validated" in tier2[0].title
         assert "evil.example.com" in tier2[0].evidence
 
-    def test_no_high_finding_when_origin_validated(self, make_response) -> None:
+    def test_no_high_finding_when_origin_validated(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Evil origin gets 403, correct origin gets 200 -> origin is validated.
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
@@ -458,7 +483,9 @@ class TestCheckCSRF:
         tier2 = [r for r in results if r.severity_hint == Severity.HIGH]
         assert tier2 == []
 
-    def test_no_high_finding_when_both_non_2xx(self, make_response) -> None:
+    def test_no_high_finding_when_both_non_2xx(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Both origins rejected -> no HIGH finding (not exploitable).
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
@@ -476,7 +503,9 @@ class TestCheckCSRF:
         tier2 = [r for r in results if r.severity_hint == Severity.HIGH]
         assert tier2 == []
 
-    def test_tier2_runs_even_when_form_has_token(self, make_response) -> None:
+    def test_tier2_runs_even_when_form_has_token(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # A form with a hidden CSRF token passes Tier 1, but Tier 2 still
         # probes for Origin validation - those are independent checks.
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
@@ -495,7 +524,7 @@ class TestCheckCSRF:
         mock_post.assert_called()
         assert not any(r.severity_hint == Severity.MEDIUM for r in results)
 
-    def test_tier2_exception_is_swallowed(self, make_response) -> None:
+    def test_tier2_exception_is_swallowed(self, make_response: Callable[..., MagicMock]) -> None:
         # GET succeeds and Tier 1 fires, but Tier 2 POST raises.
         ep = Endpoint(url="https://app.example.com/login", status_code=200)
 
@@ -518,7 +547,7 @@ class TestCheckCSRF:
     # One finding per endpoint per tier
     # ------------------------------------------------------------------
 
-    def test_one_tier1_finding_per_endpoint(self, make_response) -> None:
+    def test_one_tier1_finding_per_endpoint(self, make_response: Callable[..., MagicMock]) -> None:
         # Page has two unprotected POST forms; still only one Tier-1 finding.
         html = """
         <form method="POST" action="/a"><input type="text" name="u"></form>
@@ -540,7 +569,7 @@ class TestCheckCSRF:
         tier1 = [r for r in results if r.severity_hint == Severity.MEDIUM]
         assert len(tier1) == 1
 
-    def test_deduplicates_same_url(self, make_response) -> None:
+    def test_deduplicates_same_url(self, make_response: Callable[..., MagicMock]) -> None:
         ep1 = Endpoint(url="https://app.example.com/login", status_code=200)
         ep2 = Endpoint(url="https://app.example.com/login", status_code=200)
 
@@ -558,7 +587,9 @@ class TestCheckCSRF:
         tier1 = [r for r in results if r.severity_hint == Severity.MEDIUM]
         assert len(tier1) == 1
 
-    def test_multiple_distinct_endpoints_each_get_findings(self, make_response) -> None:
+    def test_multiple_distinct_endpoints_each_get_findings(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep1 = Endpoint(url="https://app.example.com/login", status_code=200)
         ep2 = Endpoint(url="https://app.example.com/register", status_code=200)
 
@@ -576,7 +607,9 @@ class TestCheckCSRF:
         tier1 = [r for r in results if r.severity_hint == Severity.MEDIUM]
         assert len(tier1) == 2
 
-    def test_endpoint_without_status_code_is_probed(self, make_response) -> None:
+    def test_endpoint_without_status_code_is_probed(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # status_code=None means recon did not record it - still probe.
         ep = Endpoint(url="https://app.example.com/login")
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -21,75 +21,68 @@ _PG_ERROR = "PG::UndefinedTable: ERROR: relation 'users' does not exist"
 _ASPNET_ERROR = "Server Error in '/' Application. Runtime Error"
 
 
-def _resp(body: str, status: int = 200) -> MagicMock:
-    r = MagicMock()
-    r.status_code = status
-    r.text = body
-    return r
-
-
 class TestCheckErrorDisclosure:
-    def test_detects_python_traceback(self):
+    def test_detects_python_traceback(self, make_response):
         ep = Endpoint(url="https://app.example.com/api", status_code=200, parameters=["id"])
-        with patch("requests.get", return_value=_resp(_PYTHON_TRACEBACK)):
+        with patch("requests.get", return_value=make_response(body=_PYTHON_TRACEBACK)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
         assert results[0].vuln_class == "ErrorDisclosure"
         assert results[0].severity_hint == Severity.INFORMATIONAL
         assert "Python traceback" in results[0].evidence
 
-    def test_detects_django_debug(self):
+    def test_detects_django_debug(self, make_response):
         ep = Endpoint(url="https://app.example.com/api", status_code=200, parameters=["id"])
-        with patch("requests.get", return_value=_resp(_DJANGO_ERROR)):
+        with patch("requests.get", return_value=make_response(body=_DJANGO_ERROR)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
         assert "Django debug" in results[0].evidence
 
-    def test_detects_php_fatal_error(self):
+    def test_detects_php_fatal_error(self, make_response):
         ep = Endpoint(url="https://app.example.com/", status_code=200)
-        with patch("requests.get", return_value=_resp(_PHP_ERROR)):
+        with patch("requests.get", return_value=make_response(body=_PHP_ERROR)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
         assert "PHP fatal error" in results[0].evidence
 
-    def test_detects_java_stack_trace(self):
+    def test_detects_java_stack_trace(self, make_response):
         ep = Endpoint(url="https://app.example.com/", status_code=200)
-        with patch("requests.get", return_value=_resp(_JAVA_TRACE)):
+        with patch("requests.get", return_value=make_response(body=_JAVA_TRACE)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
         assert "Java stack trace" in results[0].evidence
 
-    def test_detects_mysql_error(self):
+    def test_detects_mysql_error(self, make_response):
         ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["q"])
-        with patch("requests.get", return_value=_resp(_MYSQL_ERROR)):
+        with patch("requests.get", return_value=make_response(body=_MYSQL_ERROR)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
         assert "MySQL error" in results[0].evidence
 
-    def test_detects_oracle_error(self):
+    def test_detects_oracle_error(self, make_response):
         ep = Endpoint(url="https://app.example.com/", status_code=200)
-        with patch("requests.get", return_value=_resp(_ORACLE_ERROR)):
+        with patch("requests.get", return_value=make_response(body=_ORACLE_ERROR)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
         assert "Oracle SQL error" in results[0].evidence
 
-    def test_detects_postgresql_error(self):
+    def test_detects_postgresql_error(self, make_response):
         ep = Endpoint(url="https://app.example.com/", status_code=200)
-        with patch("requests.get", return_value=_resp(_PG_ERROR)):
+        with patch("requests.get", return_value=make_response(body=_PG_ERROR)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
         assert "PostgreSQL error" in results[0].evidence
 
-    def test_detects_aspnet_error(self):
+    def test_detects_aspnet_error(self, make_response):
         ep = Endpoint(url="https://app.example.com/", status_code=200)
-        with patch("requests.get", return_value=_resp(_ASPNET_ERROR)):
+        with patch("requests.get", return_value=make_response(body=_ASPNET_ERROR)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
         assert "ASP.NET" in results[0].evidence
 
-    def test_no_finding_for_clean_response(self):
+    def test_no_finding_for_clean_response(self, make_response):
         ep = Endpoint(url="https://app.example.com/", status_code=200)
-        with patch("requests.get", return_value=_resp("<html><body>Not Found</body></html>")):
+        with patch("requests.get", return_value=make_response(body="<html><body>Not Found</body></html>")):
             results = check_error_disclosure([ep])
         assert results == []
 
@@ -106,20 +99,20 @@ class TestCheckErrorDisclosure:
             results = check_error_disclosure([ep])
         assert results == []
 
-    def test_deduplicates_multiple_probe_hits(self):
+    def test_deduplicates_multiple_probe_hits(self, make_response):
         """Only one finding per endpoint even if both probe URLs trigger errors."""
         ep = Endpoint(url="https://app.example.com/api", status_code=200, parameters=["id"])
-        with patch("requests.get", return_value=_resp(_PYTHON_TRACEBACK)):
+        with patch("requests.get", return_value=make_response(body=_PYTHON_TRACEBACK)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
 
-    def test_probes_404_path_even_without_parameters(self):
+    def test_probes_404_path_even_without_parameters(self, make_response):
         ep = Endpoint(url="https://app.example.com/", status_code=200)
         seen_urls: list[str] = []
 
         def recording_get(url, **kwargs):
             seen_urls.append(url)
-            return _resp("")
+            return make_response(body="")
 
         with patch("requests.get", side_effect=recording_get):
             check_error_disclosure([ep])

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -82,7 +82,9 @@ class TestCheckErrorDisclosure:
 
     def test_no_finding_for_clean_response(self, make_response):
         ep = Endpoint(url="https://app.example.com/", status_code=200)
-        with patch("requests.get", return_value=make_response(body="<html><body>Not Found</body></html>")):
+        with patch(
+            "requests.get", return_value=make_response(body="<html><body>Not Found</body></html>")
+        ):
             results = check_error_disclosure([ep])
         assert results == []
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from collections.abc import Callable
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -22,7 +23,7 @@ _ASPNET_ERROR = "Server Error in '/' Application. Runtime Error"
 
 
 class TestCheckErrorDisclosure:
-    def test_detects_python_traceback(self, make_response):
+    def test_detects_python_traceback(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/api", status_code=200, parameters=["id"])
         with patch("requests.get", return_value=make_response(body=_PYTHON_TRACEBACK)):
             results = check_error_disclosure([ep])
@@ -31,56 +32,56 @@ class TestCheckErrorDisclosure:
         assert results[0].severity_hint == Severity.INFORMATIONAL
         assert "Python traceback" in results[0].evidence
 
-    def test_detects_django_debug(self, make_response):
+    def test_detects_django_debug(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/api", status_code=200, parameters=["id"])
         with patch("requests.get", return_value=make_response(body=_DJANGO_ERROR)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
         assert "Django debug" in results[0].evidence
 
-    def test_detects_php_fatal_error(self, make_response):
+    def test_detects_php_fatal_error(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/", status_code=200)
         with patch("requests.get", return_value=make_response(body=_PHP_ERROR)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
         assert "PHP fatal error" in results[0].evidence
 
-    def test_detects_java_stack_trace(self, make_response):
+    def test_detects_java_stack_trace(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/", status_code=200)
         with patch("requests.get", return_value=make_response(body=_JAVA_TRACE)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
         assert "Java stack trace" in results[0].evidence
 
-    def test_detects_mysql_error(self, make_response):
+    def test_detects_mysql_error(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["q"])
         with patch("requests.get", return_value=make_response(body=_MYSQL_ERROR)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
         assert "MySQL error" in results[0].evidence
 
-    def test_detects_oracle_error(self, make_response):
+    def test_detects_oracle_error(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/", status_code=200)
         with patch("requests.get", return_value=make_response(body=_ORACLE_ERROR)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
         assert "Oracle SQL error" in results[0].evidence
 
-    def test_detects_postgresql_error(self, make_response):
+    def test_detects_postgresql_error(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/", status_code=200)
         with patch("requests.get", return_value=make_response(body=_PG_ERROR)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
         assert "PostgreSQL error" in results[0].evidence
 
-    def test_detects_aspnet_error(self, make_response):
+    def test_detects_aspnet_error(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/", status_code=200)
         with patch("requests.get", return_value=make_response(body=_ASPNET_ERROR)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
         assert "ASP.NET" in results[0].evidence
 
-    def test_no_finding_for_clean_response(self, make_response):
+    def test_no_finding_for_clean_response(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/", status_code=200)
         with patch(
             "requests.get", return_value=make_response(body="<html><body>Not Found</body></html>")
@@ -101,18 +102,22 @@ class TestCheckErrorDisclosure:
             results = check_error_disclosure([ep])
         assert results == []
 
-    def test_deduplicates_multiple_probe_hits(self, make_response):
+    def test_deduplicates_multiple_probe_hits(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         """Only one finding per endpoint even if both probe URLs trigger errors."""
         ep = Endpoint(url="https://app.example.com/api", status_code=200, parameters=["id"])
         with patch("requests.get", return_value=make_response(body=_PYTHON_TRACEBACK)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
 
-    def test_probes_404_path_even_without_parameters(self, make_response):
+    def test_probes_404_path_even_without_parameters(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/", status_code=200)
         seen_urls: list[str] = []
 
-        def recording_get(url, **kwargs):
+        def recording_get(url, **kwargs) -> MagicMock:
             seen_urls.append(url)
             return make_response(body="")
 

--- a/tests/test_hpp.py
+++ b/tests/test_hpp.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_hpp.py
+++ b/tests/test_hpp.py
@@ -12,23 +12,16 @@ from tools.pentest.hpp import check_hpp
 pytestmark = pytest.mark.unit
 
 
-def _resp(status: int = 200, body: str = "") -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = status
-    resp.text = body
-    return resp
-
-
 class TestCheckHPP:
-    def test_detects_status_delta(self):
+    def test_detects_status_delta(self, make_response):
         # Baseline returns 200, polluted returns 302 - server picked one of
         # the duplicate values and triggered a redirect.
         ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["id"])
 
         def fake_get(url, **kwargs):
             if "id=1&id=2" in url:
-                return _resp(status=302, body="")
-            return _resp(status=200, body="ok")
+                return make_response(status=302, body="")
+            return make_response(status=200, body="ok")
 
         with patch("requests.get", side_effect=fake_get):
             results = check_hpp([ep])
@@ -39,15 +32,15 @@ class TestCheckHPP:
         assert "id" in results[0].evidence
         assert "302" in results[0].evidence
 
-    def test_detects_length_delta(self):
+    def test_detects_length_delta(self, make_response):
         # Same status code, but the polluted response body is materially
         # longer because the server combined both values into the output.
         ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["q"])
 
         def fake_get(url, **kwargs):
             if "q=1&q=2" in url:
-                return _resp(status=200, body="results: 1, 2 (combined)")
-            return _resp(status=200, body="results: 1")
+                return make_response(status=200, body="results: 1, 2 (combined)")
+            return make_response(status=200, body="results: 1")
 
         with patch("requests.get", side_effect=fake_get):
             results = check_hpp([ep])
@@ -55,11 +48,11 @@ class TestCheckHPP:
         assert len(results) == 1
         assert "HPP behaviour confirmed" in results[0].evidence
 
-    def test_no_finding_when_responses_identical(self):
+    def test_no_finding_when_responses_identical(self, make_response):
         # Server collapses duplicates - baseline and polluted look the same.
         ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["id"])
 
-        with patch("requests.get", return_value=_resp(status=200, body="ok")):
+        with patch("requests.get", return_value=make_response(status=200, body="ok")):
             results = check_hpp([ep])
 
         assert results == []
@@ -78,7 +71,7 @@ class TestCheckHPP:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_one_finding_per_endpoint(self):
+    def test_one_finding_per_endpoint(self, make_response):
         # First param triggers - subsequent params should not be probed.
         ep = Endpoint(
             url="https://app.example.com/",
@@ -88,8 +81,8 @@ class TestCheckHPP:
 
         def fake_get(url, **kwargs):
             if "a=1&a=2" in url:
-                return _resp(status=200, body="much longer body here than baseline")
-            return _resp(status=200, body="ok")
+                return make_response(status=200, body="much longer body here than baseline")
+            return make_response(status=200, body="ok")
 
         with patch("requests.get", side_effect=fake_get) as mock_get:
             results = check_hpp([ep])
@@ -98,13 +91,13 @@ class TestCheckHPP:
         # Only param 'a' probed: baseline + polluted = 2 calls
         assert mock_get.call_count == 2
 
-    def test_baseline_and_polluted_both_sent(self):
+    def test_baseline_and_polluted_both_sent(self, make_response):
         ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["q"])
         urls_seen: list[str] = []
 
         def fake_get(url, **kwargs):
             urls_seen.append(url)
-            return _resp(status=200, body="ok")
+            return make_response(status=200, body="ok")
 
         with patch("requests.get", side_effect=fake_get):
             check_hpp([ep])
@@ -113,7 +106,7 @@ class TestCheckHPP:
         assert any(url.endswith("?q=1&q=2") for url in urls_seen)
         assert len(urls_seen) == 2
 
-    def test_continues_to_next_param_when_first_does_not_trigger(self):
+    def test_continues_to_next_param_when_first_does_not_trigger(self, make_response):
         # Param 'a' shows no delta; param 'b' does. Tool must keep probing.
         ep = Endpoint(
             url="https://app.example.com/",
@@ -123,8 +116,8 @@ class TestCheckHPP:
 
         def fake_get(url, **kwargs):
             if "b=1&b=2" in url:
-                return _resp(status=500, body="error: ambiguous parameter")
-            return _resp(status=200, body="ok")
+                return make_response(status=500, body="error: ambiguous parameter")
+            return make_response(status=200, body="ok")
 
         with patch("requests.get", side_effect=fake_get):
             results = check_hpp([ep])
@@ -138,13 +131,13 @@ class TestCheckHPP:
             results = check_hpp([ep])
         assert results == []
 
-    def test_evidence_records_both_signatures(self):
+    def test_evidence_records_both_signatures(self, make_response):
         ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["id"])
 
         def fake_get(url, **kwargs):
             if "id=1&id=2" in url:
-                return _resp(status=403, body="forbidden")
-            return _resp(status=200, body="ok")
+                return make_response(status=403, body="forbidden")
+            return make_response(status=200, body="ok")
 
         with patch("requests.get", side_effect=fake_get):
             results = check_hpp([ep])

--- a/tests/test_hpp.py
+++ b/tests/test_hpp.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from collections.abc import Callable
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -13,12 +14,12 @@ pytestmark = pytest.mark.unit
 
 
 class TestCheckHPP:
-    def test_detects_status_delta(self, make_response):
+    def test_detects_status_delta(self, make_response: Callable[..., MagicMock]) -> None:
         # Baseline returns 200, polluted returns 302 - server picked one of
         # the duplicate values and triggered a redirect.
         ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["id"])
 
-        def fake_get(url, **kwargs):
+        def fake_get(url, **kwargs) -> MagicMock:
             if "id=1&id=2" in url:
                 return make_response(status=302, body="")
             return make_response(status=200, body="ok")
@@ -32,12 +33,12 @@ class TestCheckHPP:
         assert "id" in results[0].evidence
         assert "302" in results[0].evidence
 
-    def test_detects_length_delta(self, make_response):
+    def test_detects_length_delta(self, make_response: Callable[..., MagicMock]) -> None:
         # Same status code, but the polluted response body is materially
         # longer because the server combined both values into the output.
         ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["q"])
 
-        def fake_get(url, **kwargs):
+        def fake_get(url, **kwargs) -> MagicMock:
             if "q=1&q=2" in url:
                 return make_response(status=200, body="results: 1, 2 (combined)")
             return make_response(status=200, body="results: 1")
@@ -48,7 +49,9 @@ class TestCheckHPP:
         assert len(results) == 1
         assert "HPP behaviour confirmed" in results[0].evidence
 
-    def test_no_finding_when_responses_identical(self, make_response):
+    def test_no_finding_when_responses_identical(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Server collapses duplicates - baseline and polluted look the same.
         ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["id"])
 
@@ -71,7 +74,7 @@ class TestCheckHPP:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_one_finding_per_endpoint(self, make_response):
+    def test_one_finding_per_endpoint(self, make_response: Callable[..., MagicMock]) -> None:
         # First param triggers - subsequent params should not be probed.
         ep = Endpoint(
             url="https://app.example.com/",
@@ -79,7 +82,7 @@ class TestCheckHPP:
             parameters=["a", "b", "c"],
         )
 
-        def fake_get(url, **kwargs):
+        def fake_get(url, **kwargs) -> MagicMock:
             if "a=1&a=2" in url:
                 return make_response(status=200, body="much longer body here than baseline")
             return make_response(status=200, body="ok")
@@ -91,11 +94,11 @@ class TestCheckHPP:
         # Only param 'a' probed: baseline + polluted = 2 calls
         assert mock_get.call_count == 2
 
-    def test_baseline_and_polluted_both_sent(self, make_response):
+    def test_baseline_and_polluted_both_sent(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["q"])
         urls_seen: list[str] = []
 
-        def fake_get(url, **kwargs):
+        def fake_get(url, **kwargs) -> MagicMock:
             urls_seen.append(url)
             return make_response(status=200, body="ok")
 
@@ -106,7 +109,9 @@ class TestCheckHPP:
         assert any(url.endswith("?q=1&q=2") for url in urls_seen)
         assert len(urls_seen) == 2
 
-    def test_continues_to_next_param_when_first_does_not_trigger(self, make_response):
+    def test_continues_to_next_param_when_first_does_not_trigger(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Param 'a' shows no delta; param 'b' does. Tool must keep probing.
         ep = Endpoint(
             url="https://app.example.com/",
@@ -114,7 +119,7 @@ class TestCheckHPP:
             parameters=["a", "b"],
         )
 
-        def fake_get(url, **kwargs):
+        def fake_get(url, **kwargs) -> MagicMock:
             if "b=1&b=2" in url:
                 return make_response(status=500, body="error: ambiguous parameter")
             return make_response(status=200, body="ok")
@@ -131,10 +136,12 @@ class TestCheckHPP:
             results = check_hpp([ep])
         assert results == []
 
-    def test_evidence_records_both_signatures(self, make_response):
+    def test_evidence_records_both_signatures(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["id"])
 
-        def fake_get(url, **kwargs):
+        def fake_get(url, **kwargs) -> MagicMock:
             if "id=1&id=2" in url:
                 return make_response(status=403, body="forbidden")
             return make_response(status=200, body="ok")

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -6,8 +6,9 @@ import base64
 import hashlib
 import hmac
 import json
+from collections.abc import Callable
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -90,7 +91,7 @@ class TestHelpers:
 
 
 class TestAlgNone:
-    def test_detects_alg_none_bypass(self, make_response) -> None:
+    def test_detects_alg_none_bypass(self, make_response: Callable[..., MagicMock]) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1", "role": "user"})
         with patch("requests.get", return_value=make_response(status=200, body="{}")):
             results = check_jwt(token, _ENDPOINT)
@@ -98,13 +99,15 @@ class TestAlgNone:
         assert len(alg_none) == 1
         assert alg_none[0].severity_hint == Severity.CRITICAL
 
-    def test_no_finding_when_none_rejected(self, make_response) -> None:
+    def test_no_finding_when_none_rejected(self, make_response: Callable[..., MagicMock]) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1"})
         with patch("requests.get", return_value=make_response(status=401, body="{}")):
             results = check_jwt(token, _ENDPOINT)
         assert not any("alg:none" in r.title for r in results)
 
-    def test_stops_after_first_accepted_variant(self, make_response) -> None:
+    def test_stops_after_first_accepted_variant(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Only one alg:none finding should be reported even though 4 variants exist.
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1"})
 
@@ -123,7 +126,7 @@ class TestAlgNone:
 
 
 class TestWeakSecret:
-    def test_detects_weak_secret(self, make_response) -> None:
+    def test_detects_weak_secret(self, make_response: Callable[..., MagicMock]) -> None:
         header = {"alg": "HS256", "typ": "JWT"}
         payload = {"sub": "1", "role": "user"}
         token = _make_hmac_signed_token(header, payload, b"secret")
@@ -136,7 +139,7 @@ class TestWeakSecret:
         assert weak[0].severity_hint == Severity.CRITICAL
         assert "secret" in weak[0].evidence
 
-    def test_no_finding_on_strong_secret(self, make_response) -> None:
+    def test_no_finding_on_strong_secret(self, make_response: Callable[..., MagicMock]) -> None:
         header = {"alg": "HS256", "typ": "JWT"}
         payload = {"sub": "1"}
         token = _make_hmac_signed_token(header, payload, b"v3ryStr0ngS3cr3t!XYZ987")
@@ -146,7 +149,9 @@ class TestWeakSecret:
 
         assert not any("weak HMAC" in r.title for r in results)
 
-    def test_weak_secret_reported_even_without_2xx_replay(self, make_response) -> None:
+    def test_weak_secret_reported_even_without_2xx_replay(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Cracking the secret offline is proof enough - even if replay returns 403.
         header = {"alg": "HS256", "typ": "JWT"}
         payload = {"sub": "1"}
@@ -163,10 +168,10 @@ class TestWeakSecret:
         assert "password" in _WEAK_SECRETS
         assert "" in _WEAK_SECRETS
 
-    def test_non_hs_alg_skips_brute_force(self, make_response) -> None:
+    def test_non_hs_alg_skips_brute_force(self, make_response: Callable[..., MagicMock]) -> None:
         token = _make_token({"alg": "RS256", "typ": "JWT"}, {"sub": "1"})
 
-        def fake_get(url: str, **kw: Any):
+        def fake_get(url: str, **kw: Any) -> MagicMock:
             r = make_response(status=404, body="{}")
             r.json.return_value = {}
             return r
@@ -178,10 +183,10 @@ class TestWeakSecret:
 
 
 class TestKidInjection:
-    def test_detects_kid_path_traversal(self, make_response) -> None:
+    def test_detects_kid_path_traversal(self, make_response: Callable[..., MagicMock]) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT", "kid": "key-1"}, {"sub": "1"})
 
-        def fake_get(url: str, **kw: Any):
+        def fake_get(url: str, **kw: Any) -> MagicMock:
             # Only the path-traversal probe is accepted.
             auth = str(kw.get("headers", {}).get("Authorization", ""))
             t = auth.removeprefix("Bearer ") if "Bearer " in auth else ""
@@ -198,10 +203,10 @@ class TestKidInjection:
         assert trav[0].severity_hint == Severity.CRITICAL
         assert _KID_PATH_TRAVERSAL in trav[0].evidence
 
-    def test_detects_kid_sql_injection(self, make_response) -> None:
+    def test_detects_kid_sql_injection(self, make_response: Callable[..., MagicMock]) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT", "kid": "key-1"}, {"sub": "1"})
 
-        def fake_get(url: str, **kw: Any):
+        def fake_get(url: str, **kw: Any) -> MagicMock:
             auth = str(kw.get("headers", {}).get("Authorization", ""))
             t = auth.removeprefix("Bearer ") if "Bearer " in auth else ""
             h = _decode_token_part(t, 0) if t else {}
@@ -216,10 +221,10 @@ class TestKidInjection:
         assert len(sqli) == 1
         assert sqli[0].severity_hint == Severity.CRITICAL
 
-    def test_detects_kid_nosql_injection(self, make_response) -> None:
+    def test_detects_kid_nosql_injection(self, make_response: Callable[..., MagicMock]) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT", "kid": "key-1"}, {"sub": "1"})
 
-        def fake_get(url: str, **kw: Any):
+        def fake_get(url: str, **kw: Any) -> MagicMock:
             auth = str(kw.get("headers", {}).get("Authorization", ""))
             t = auth.removeprefix("Bearer ") if "Bearer " in auth else ""
             h = _decode_token_part(t, 0) if t else {}
@@ -239,7 +244,7 @@ class TestKidInjection:
         assert "$gt" in operators
         assert "$ne" in operators
 
-    def test_kid_attacks_skipped_when_no_kid(self, make_response) -> None:
+    def test_kid_attacks_skipped_when_no_kid(self, make_response: Callable[..., MagicMock]) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1"})
         with patch("requests.get", return_value=make_response(status=401, body="{}")):
             results = check_jwt(token, _ENDPOINT)
@@ -248,10 +253,12 @@ class TestKidInjection:
 
 
 class TestClaimsTampering:
-    def test_detects_missing_signature_verification(self, make_response) -> None:
+    def test_detects_missing_signature_verification(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1", "role": "user"})
 
-        def fake_get(url: str, **kw: Any):
+        def fake_get(url: str, **kw: Any) -> MagicMock:
             # Accept any token with modified payload regardless of signature.
             auth = str(kw.get("headers", {}).get("Authorization", ""))
             if "Bearer " in auth:
@@ -272,7 +279,9 @@ class TestClaimsTampering:
         assert tamper[0].severity_hint == Severity.CRITICAL
         assert "Original signature retained" in tamper[0].evidence
 
-    def test_no_tamper_finding_when_signature_checked(self, make_response) -> None:
+    def test_no_tamper_finding_when_signature_checked(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1", "role": "user"})
         with patch("requests.get", return_value=make_response(status=401, body="{}")):
             results = check_jwt(token, _ENDPOINT)
@@ -281,7 +290,7 @@ class TestClaimsTampering:
 
 
 class TestRS256Confusion:
-    def test_detects_rs256_hs256_confusion(self, make_response) -> None:
+    def test_detects_rs256_hs256_confusion(self, make_response: Callable[..., MagicMock]) -> None:
         token = _make_token({"alg": "RS256", "typ": "JWT", "kid": "k1"}, {"sub": "1"})
 
         # Minimal self-signed RSA public key as a JWK (tiny key, test only).
@@ -312,7 +321,7 @@ class TestRS256Confusion:
         }
         pem_secret = pub.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo)
 
-        def fake_get(url: str, **kw: Any):
+        def fake_get(url: str, **kw: Any) -> MagicMock:
             if "jwks" in url:
                 r = make_response(status=200, body=json.dumps(jwks_payload))
                 r.json.return_value = jwks_payload
@@ -336,7 +345,7 @@ class TestRS256Confusion:
         assert len(confusion) == 1
         assert confusion[0].severity_hint == Severity.CRITICAL
 
-    def test_rs256_skipped_when_no_jwks(self, make_response) -> None:
+    def test_rs256_skipped_when_no_jwks(self, make_response: Callable[..., MagicMock]) -> None:
         token = _make_token({"alg": "RS256", "typ": "JWT"}, {"sub": "1"})
         with patch("requests.get", return_value=make_response(status=404, body="{}")):
             results = check_jwt(token, _ENDPOINT)
@@ -344,7 +353,7 @@ class TestRS256Confusion:
 
 
 class TestEdgeCases:
-    def test_invalid_token_returns_empty(self, make_response) -> None:
+    def test_invalid_token_returns_empty(self, make_response: Callable[..., MagicMock]) -> None:
         with patch("requests.get", return_value=make_response(status=200, body="{}")):
             results = check_jwt("not.a.jwt", _ENDPOINT)
         assert results == []
@@ -355,7 +364,7 @@ class TestEdgeCases:
             results = check_jwt(token, _ENDPOINT)
         assert isinstance(results, list)
 
-    def test_two_part_token_returns_empty(self, make_response) -> None:
+    def test_two_part_token_returns_empty(self, make_response: Callable[..., MagicMock]) -> None:
         with patch("requests.get", return_value=make_response(status=200, body="{}")):
             results = check_jwt("onlytwoparts.here", _ENDPOINT)
         assert results == []
@@ -372,7 +381,9 @@ class TestAttackFilter:
     def _token_with_kid(self) -> str:
         return _make_token({"alg": "HS256", "kid": "k1", "typ": "JWT"}, {"sub": "1"})
 
-    def test_only_alg_none_runs_when_filtered(self, make_response) -> None:
+    def test_only_alg_none_runs_when_filtered(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # A token with kid set would normally trigger alg-none + kid-traversal
         # + kid-sqli + kid-nosqli + claims-escalation = 5 attack classes.
         # With attack_names=["alg-none"] we must only see alg-none requests.
@@ -380,7 +391,7 @@ class TestAttackFilter:
 
         replayed_tokens: list[str] = []
 
-        def record(url: str, **kw: Any):
+        def record(url: str, **kw: Any) -> MagicMock:
             auth = str(kw.get("headers", {}).get("Authorization", ""))
             if "Bearer " in auth:
                 replayed_tokens.append(auth.removeprefix("Bearer "))
@@ -395,12 +406,14 @@ class TestAttackFilter:
         for replayed in replayed_tokens:
             assert replayed.endswith(".")
 
-    def test_only_claims_escalation_runs_when_filtered(self, make_response) -> None:
+    def test_only_claims_escalation_runs_when_filtered(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         token = self._token_with_kid()
 
         seen_tokens: list[str] = []
 
-        def record(url: str, **kw: Any):
+        def record(url: str, **kw: Any) -> MagicMock:
             auth = str(kw.get("headers", {}).get("Authorization", ""))
             if "Bearer " in auth:
                 seen_tokens.append(auth.removeprefix("Bearer "))
@@ -415,7 +428,9 @@ class TestAttackFilter:
         orig_sig = token.split(".")[2]
         assert seen_tokens[0].split(".")[2] == orig_sig
 
-    def test_kid_attacks_only_runs_when_filtered(self, make_response) -> None:
+    def test_kid_attacks_only_runs_when_filtered(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # The agent wants to focus on kid-* attacks because the token has a
         # kid header. Passing the three kid-* attack names should run them
         # all and skip alg-none, weak-secret, and claims-escalation.
@@ -423,7 +438,7 @@ class TestAttackFilter:
 
         replayed: list[str] = []
 
-        def record(url: str, **kw: Any):
+        def record(url: str, **kw: Any) -> MagicMock:
             auth = str(kw.get("headers", {}).get("Authorization", ""))
             if "Bearer " in auth:
                 replayed.append(auth.removeprefix("Bearer "))
@@ -455,14 +470,16 @@ class TestAttackFilter:
         assert results == []
         mock_get.assert_not_called()
 
-    def test_attack_filter_none_runs_every_attack(self, make_response) -> None:
+    def test_attack_filter_none_runs_every_attack(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Sanity check: default attack_names=None must run all seven attack
         # blocks (those whose preconditions hold for this token).
         token = self._token_with_kid()
 
         attempted: list[str] = []
 
-        def record(url: str, **kw: Any):
+        def record(url: str, **kw: Any) -> MagicMock:
             auth = str(kw.get("headers", {}).get("Authorization", ""))
             if "Bearer " in auth:
                 attempted.append(auth.removeprefix("Bearer "))
@@ -476,12 +493,14 @@ class TestAttackFilter:
         # alg-confusion needs RS256, claims-escalation always runs once.
         assert len(attempted) == 9
 
-    def test_filtered_finding_evidence_names_the_attack(self, make_response) -> None:
+    def test_filtered_finding_evidence_names_the_attack(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # When alg-none succeeds, evidence must name the attack class so the
         # agent and report know what fired.
         token = self._token_with_kid()
 
-        def accept_unsigned(url: str, **kw: Any):
+        def accept_unsigned(url: str, **kw: Any) -> MagicMock:
             auth = str(kw.get("headers", {}).get("Authorization", ""))
             if "Bearer " in auth:
                 t = auth.removeprefix("Bearer ")

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -7,7 +7,7 @@ import hashlib
 import hmac
 import json
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -50,14 +50,6 @@ def _make_hmac_signed_token(header: dict, payload: dict, secret: bytes) -> str:
     return f"{h}.{p}.{s}"
 
 
-def _mock_response(status: int = 200) -> MagicMock:
-    r = MagicMock()
-    r.status_code = status
-    r.text = "{}"
-    r.json.return_value = {}
-    return r
-
-
 class TestHelpers:
     def test_base64url_roundtrip(self) -> None:
         original = b"\x00\xff\xfe hello world"
@@ -98,25 +90,25 @@ class TestHelpers:
 
 
 class TestAlgNone:
-    def test_detects_alg_none_bypass(self) -> None:
+    def test_detects_alg_none_bypass(self, make_response) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1", "role": "user"})
-        with patch("requests.get", return_value=_mock_response(200)):
+        with patch("requests.get", return_value=make_response(status=200, body="{}")):
             results = check_jwt(token, _ENDPOINT)
         alg_none = [r for r in results if "alg:none" in r.title]
         assert len(alg_none) == 1
         assert alg_none[0].severity_hint == Severity.CRITICAL
 
-    def test_no_finding_when_none_rejected(self) -> None:
+    def test_no_finding_when_none_rejected(self, make_response) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1"})
-        with patch("requests.get", return_value=_mock_response(401)):
+        with patch("requests.get", return_value=make_response(status=401, body="{}")):
             results = check_jwt(token, _ENDPOINT)
         assert not any("alg:none" in r.title for r in results)
 
-    def test_stops_after_first_accepted_variant(self) -> None:
+    def test_stops_after_first_accepted_variant(self, make_response) -> None:
         # Only one alg:none finding should be reported even though 4 variants exist.
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1"})
 
-        with patch("requests.get", return_value=_mock_response(200)):
+        with patch("requests.get", return_value=make_response(status=200, body="{}")):
             results = check_jwt(token, _ENDPOINT)
 
         alg_none = [r for r in results if "alg:none" in r.title]
@@ -131,12 +123,12 @@ class TestAlgNone:
 
 
 class TestWeakSecret:
-    def test_detects_weak_secret(self) -> None:
+    def test_detects_weak_secret(self, make_response) -> None:
         header = {"alg": "HS256", "typ": "JWT"}
         payload = {"sub": "1", "role": "user"}
         token = _make_hmac_signed_token(header, payload, b"secret")
 
-        with patch("requests.get", return_value=_mock_response(401)):
+        with patch("requests.get", return_value=make_response(status=401, body="{}")):
             results = check_jwt(token, _ENDPOINT)
 
         weak = [r for r in results if "weak HMAC" in r.title]
@@ -144,23 +136,23 @@ class TestWeakSecret:
         assert weak[0].severity_hint == Severity.CRITICAL
         assert "secret" in weak[0].evidence
 
-    def test_no_finding_on_strong_secret(self) -> None:
+    def test_no_finding_on_strong_secret(self, make_response) -> None:
         header = {"alg": "HS256", "typ": "JWT"}
         payload = {"sub": "1"}
         token = _make_hmac_signed_token(header, payload, b"v3ryStr0ngS3cr3t!XYZ987")
 
-        with patch("requests.get", return_value=_mock_response(401)):
+        with patch("requests.get", return_value=make_response(status=401, body="{}")):
             results = check_jwt(token, _ENDPOINT)
 
         assert not any("weak HMAC" in r.title for r in results)
 
-    def test_weak_secret_reported_even_without_2xx_replay(self) -> None:
+    def test_weak_secret_reported_even_without_2xx_replay(self, make_response) -> None:
         # Cracking the secret offline is proof enough - even if replay returns 403.
         header = {"alg": "HS256", "typ": "JWT"}
         payload = {"sub": "1"}
         token = _make_hmac_signed_token(header, payload, b"secret")
 
-        with patch("requests.get", return_value=_mock_response(403)):
+        with patch("requests.get", return_value=make_response(status=403, body="{}")):
             results = check_jwt(token, _ENDPOINT)
 
         weak = [r for r in results if "weak HMAC" in r.title]
@@ -171,13 +163,12 @@ class TestWeakSecret:
         assert "password" in _WEAK_SECRETS
         assert "" in _WEAK_SECRETS
 
-    def test_non_hs_alg_skips_brute_force(self) -> None:
+    def test_non_hs_alg_skips_brute_force(self, make_response) -> None:
         token = _make_token({"alg": "RS256", "typ": "JWT"}, {"sub": "1"})
 
-        def fake_get(url: str, **kw: Any) -> MagicMock:
-            r = _mock_response(404)
+        def fake_get(url: str, **kw: Any):
+            r = make_response(status=404, body="{}")
             r.json.return_value = {}
-            r.text = "{}"
             return r
 
         with patch("requests.get", side_effect=fake_get):
@@ -187,17 +178,17 @@ class TestWeakSecret:
 
 
 class TestKidInjection:
-    def test_detects_kid_path_traversal(self) -> None:
+    def test_detects_kid_path_traversal(self, make_response) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT", "kid": "key-1"}, {"sub": "1"})
 
-        def fake_get(url: str, **kw: Any) -> MagicMock:
+        def fake_get(url: str, **kw: Any):
             # Only the path-traversal probe is accepted.
             auth = str(kw.get("headers", {}).get("Authorization", ""))
             t = auth.removeprefix("Bearer ") if "Bearer " in auth else ""
             h = _decode_token_part(t, 0) if t else {}
             if h.get("kid") == _KID_PATH_TRAVERSAL:
-                return _mock_response(200)
-            return _mock_response(401)
+                return make_response(status=200, body="{}")
+            return make_response(status=401, body="{}")
 
         with patch("requests.get", side_effect=fake_get):
             results = check_jwt(token, _ENDPOINT)
@@ -207,16 +198,16 @@ class TestKidInjection:
         assert trav[0].severity_hint == Severity.CRITICAL
         assert _KID_PATH_TRAVERSAL in trav[0].evidence
 
-    def test_detects_kid_sql_injection(self) -> None:
+    def test_detects_kid_sql_injection(self, make_response) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT", "kid": "key-1"}, {"sub": "1"})
 
-        def fake_get(url: str, **kw: Any) -> MagicMock:
+        def fake_get(url: str, **kw: Any):
             auth = str(kw.get("headers", {}).get("Authorization", ""))
             t = auth.removeprefix("Bearer ") if "Bearer " in auth else ""
             h = _decode_token_part(t, 0) if t else {}
             if h.get("kid") == _KID_SQLI:
-                return _mock_response(200)
-            return _mock_response(401)
+                return make_response(status=200, body="{}")
+            return make_response(status=401, body="{}")
 
         with patch("requests.get", side_effect=fake_get):
             results = check_jwt(token, _ENDPOINT)
@@ -225,16 +216,16 @@ class TestKidInjection:
         assert len(sqli) == 1
         assert sqli[0].severity_hint == Severity.CRITICAL
 
-    def test_detects_kid_nosql_injection(self) -> None:
+    def test_detects_kid_nosql_injection(self, make_response) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT", "kid": "key-1"}, {"sub": "1"})
 
-        def fake_get(url: str, **kw: Any) -> MagicMock:
+        def fake_get(url: str, **kw: Any):
             auth = str(kw.get("headers", {}).get("Authorization", ""))
             t = auth.removeprefix("Bearer ") if "Bearer " in auth else ""
             h = _decode_token_part(t, 0) if t else {}
             if isinstance(h.get("kid"), dict):
-                return _mock_response(200)
-            return _mock_response(401)
+                return make_response(status=200, body="{}")
+            return make_response(status=401, body="{}")
 
         with patch("requests.get", side_effect=fake_get):
             results = check_jwt(token, _ENDPOINT)
@@ -248,19 +239,19 @@ class TestKidInjection:
         assert "$gt" in operators
         assert "$ne" in operators
 
-    def test_kid_attacks_skipped_when_no_kid(self) -> None:
+    def test_kid_attacks_skipped_when_no_kid(self, make_response) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1"})
-        with patch("requests.get", return_value=_mock_response(401)):
+        with patch("requests.get", return_value=make_response(status=401, body="{}")):
             results = check_jwt(token, _ENDPOINT)
         kid_findings = [r for r in results if "kid" in r.title]
         assert kid_findings == []
 
 
 class TestClaimsTampering:
-    def test_detects_missing_signature_verification(self) -> None:
+    def test_detects_missing_signature_verification(self, make_response) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1", "role": "user"})
 
-        def fake_get(url: str, **kw: Any) -> MagicMock:
+        def fake_get(url: str, **kw: Any):
             # Accept any token with modified payload regardless of signature.
             auth = str(kw.get("headers", {}).get("Authorization", ""))
             if "Bearer " in auth:
@@ -268,10 +259,10 @@ class TestClaimsTampering:
                 try:
                     pl = _decode_token_part(t, 1)
                     if pl.get("role") == "admin":
-                        return _mock_response(200)
+                        return make_response(status=200, body="{}")
                 except Exception:
                     pass
-            return _mock_response(401)
+            return make_response(status=401, body="{}")
 
         with patch("requests.get", side_effect=fake_get):
             results = check_jwt(token, _ENDPOINT)
@@ -281,16 +272,16 @@ class TestClaimsTampering:
         assert tamper[0].severity_hint == Severity.CRITICAL
         assert "Original signature retained" in tamper[0].evidence
 
-    def test_no_tamper_finding_when_signature_checked(self) -> None:
+    def test_no_tamper_finding_when_signature_checked(self, make_response) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1", "role": "user"})
-        with patch("requests.get", return_value=_mock_response(401)):
+        with patch("requests.get", return_value=make_response(status=401, body="{}")):
             results = check_jwt(token, _ENDPOINT)
         tamper = [r for r in results if "signature not verified" in r.title]
         assert tamper == []
 
 
 class TestRS256Confusion:
-    def test_detects_rs256_hs256_confusion(self) -> None:
+    def test_detects_rs256_hs256_confusion(self, make_response) -> None:
         token = _make_token({"alg": "RS256", "typ": "JWT", "kid": "k1"}, {"sub": "1"})
 
         # Minimal self-signed RSA public key as a JWK (tiny key, test only).
@@ -321,11 +312,10 @@ class TestRS256Confusion:
         }
         pem_secret = pub.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo)
 
-        def fake_get(url: str, **kw: Any) -> MagicMock:
+        def fake_get(url: str, **kw: Any):
             if "jwks" in url:
-                r = _mock_response(200)
+                r = make_response(status=200, body=json.dumps(jwks_payload))
                 r.json.return_value = jwks_payload
-                r.text = json.dumps(jwks_payload)
                 return r
             # Accept the HS256-signed token (simulates the confused server).
             auth = str(kw.get("headers", {}).get("Authorization", ""))
@@ -334,10 +324,10 @@ class TestRS256Confusion:
                 try:
                     header_alg_is_hs256 = _decode_token_part(t, 0).get("alg") == "HS256"
                     if header_alg_is_hs256 and _verify_hmac_signature(t, pem_secret, "HS256"):
-                        return _mock_response(200)
+                        return make_response(status=200, body="{}")
                 except Exception:
                     pass
-            return _mock_response(401)
+            return make_response(status=401, body="{}")
 
         with patch("requests.get", side_effect=fake_get):
             results = check_jwt(token, _ENDPOINT)
@@ -346,16 +336,16 @@ class TestRS256Confusion:
         assert len(confusion) == 1
         assert confusion[0].severity_hint == Severity.CRITICAL
 
-    def test_rs256_skipped_when_no_jwks(self) -> None:
+    def test_rs256_skipped_when_no_jwks(self, make_response) -> None:
         token = _make_token({"alg": "RS256", "typ": "JWT"}, {"sub": "1"})
-        with patch("requests.get", return_value=_mock_response(404)):
+        with patch("requests.get", return_value=make_response(status=404, body="{}")):
             results = check_jwt(token, _ENDPOINT)
         assert not any("RS256->HS256" in r.title for r in results)
 
 
 class TestEdgeCases:
-    def test_invalid_token_returns_empty(self) -> None:
-        with patch("requests.get", return_value=_mock_response(200)):
+    def test_invalid_token_returns_empty(self, make_response) -> None:
+        with patch("requests.get", return_value=make_response(status=200, body="{}")):
             results = check_jwt("not.a.jwt", _ENDPOINT)
         assert results == []
 
@@ -365,8 +355,8 @@ class TestEdgeCases:
             results = check_jwt(token, _ENDPOINT)
         assert isinstance(results, list)
 
-    def test_two_part_token_returns_empty(self) -> None:
-        with patch("requests.get", return_value=_mock_response(200)):
+    def test_two_part_token_returns_empty(self, make_response) -> None:
+        with patch("requests.get", return_value=make_response(status=200, body="{}")):
             results = check_jwt("onlytwoparts.here", _ENDPOINT)
         assert results == []
 
@@ -382,7 +372,7 @@ class TestAttackFilter:
     def _token_with_kid(self) -> str:
         return _make_token({"alg": "HS256", "kid": "k1", "typ": "JWT"}, {"sub": "1"})
 
-    def test_only_alg_none_runs_when_filtered(self) -> None:
+    def test_only_alg_none_runs_when_filtered(self, make_response) -> None:
         # A token with kid set would normally trigger alg-none + kid-traversal
         # + kid-sqli + kid-nosqli + claims-escalation = 5 attack classes.
         # With attack_names=["alg-none"] we must only see alg-none requests.
@@ -390,11 +380,11 @@ class TestAttackFilter:
 
         replayed_tokens: list[str] = []
 
-        def record(url: str, **kw: Any) -> MagicMock:
+        def record(url: str, **kw: Any):
             auth = str(kw.get("headers", {}).get("Authorization", ""))
             if "Bearer " in auth:
                 replayed_tokens.append(auth.removeprefix("Bearer "))
-            return _mock_response(401)
+            return make_response(status=401, body="{}")
 
         with patch("requests.get", side_effect=record):
             check_jwt(token, _ENDPOINT, attack_names=[JwtAttack.alg_none])
@@ -405,16 +395,16 @@ class TestAttackFilter:
         for replayed in replayed_tokens:
             assert replayed.endswith(".")
 
-    def test_only_claims_escalation_runs_when_filtered(self) -> None:
+    def test_only_claims_escalation_runs_when_filtered(self, make_response) -> None:
         token = self._token_with_kid()
 
         seen_tokens: list[str] = []
 
-        def record(url: str, **kw: Any) -> MagicMock:
+        def record(url: str, **kw: Any):
             auth = str(kw.get("headers", {}).get("Authorization", ""))
             if "Bearer " in auth:
                 seen_tokens.append(auth.removeprefix("Bearer "))
-            return _mock_response(401)
+            return make_response(status=401, body="{}")
 
         with patch("requests.get", side_effect=record):
             check_jwt(token, _ENDPOINT, attack_names=[JwtAttack.claims_escalation])
@@ -425,7 +415,7 @@ class TestAttackFilter:
         orig_sig = token.split(".")[2]
         assert seen_tokens[0].split(".")[2] == orig_sig
 
-    def test_kid_attacks_only_runs_when_filtered(self) -> None:
+    def test_kid_attacks_only_runs_when_filtered(self, make_response) -> None:
         # The agent wants to focus on kid-* attacks because the token has a
         # kid header. Passing the three kid-* attack names should run them
         # all and skip alg-none, weak-secret, and claims-escalation.
@@ -433,11 +423,11 @@ class TestAttackFilter:
 
         replayed: list[str] = []
 
-        def record(url: str, **kw: Any) -> MagicMock:
+        def record(url: str, **kw: Any):
             auth = str(kw.get("headers", {}).get("Authorization", ""))
             if "Bearer " in auth:
                 replayed.append(auth.removeprefix("Bearer "))
-            return _mock_response(401)
+            return make_response(status=401, body="{}")
 
         with patch("requests.get", side_effect=record):
             check_jwt(
@@ -465,18 +455,18 @@ class TestAttackFilter:
         assert results == []
         mock_get.assert_not_called()
 
-    def test_attack_filter_none_runs_every_attack(self) -> None:
+    def test_attack_filter_none_runs_every_attack(self, make_response) -> None:
         # Sanity check: default attack_names=None must run all seven attack
         # blocks (those whose preconditions hold for this token).
         token = self._token_with_kid()
 
         attempted: list[str] = []
 
-        def record(url: str, **kw: Any) -> MagicMock:
+        def record(url: str, **kw: Any):
             auth = str(kw.get("headers", {}).get("Authorization", ""))
             if "Bearer " in auth:
                 attempted.append(auth.removeprefix("Bearer "))
-            return _mock_response(401)
+            return make_response(status=401, body="{}")
 
         with patch("requests.get", side_effect=record):
             check_jwt(token, _ENDPOINT, attack_names=None)
@@ -486,18 +476,18 @@ class TestAttackFilter:
         # alg-confusion needs RS256, claims-escalation always runs once.
         assert len(attempted) == 9
 
-    def test_filtered_finding_evidence_names_the_attack(self) -> None:
+    def test_filtered_finding_evidence_names_the_attack(self, make_response) -> None:
         # When alg-none succeeds, evidence must name the attack class so the
         # agent and report know what fired.
         token = self._token_with_kid()
 
-        def accept_unsigned(url: str, **kw: Any) -> MagicMock:
+        def accept_unsigned(url: str, **kw: Any):
             auth = str(kw.get("headers", {}).get("Authorization", ""))
             if "Bearer " in auth:
                 t = auth.removeprefix("Bearer ")
                 if t.endswith("."):
-                    return _mock_response(200)
-            return _mock_response(401)
+                    return make_response(status=200, body="{}")
+            return make_response(status=401, body="{}")
 
         with patch("requests.get", side_effect=accept_unsigned):
             results = check_jwt(token, _ENDPOINT, attack_names=[JwtAttack.alg_none])

--- a/tests/test_ldap_injection.py
+++ b/tests/test_ldap_injection.py
@@ -18,13 +18,6 @@ from tools.pentest.ldap_injection import (
 pytestmark = pytest.mark.unit
 
 
-def _resp(status: int = 200, body: str = "") -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = status
-    resp.text = body
-    return resp
-
-
 def _baseline_or_probe(
     url: str, baseline_resp: MagicMock, probe_resp: MagicMock, **_: object
 ) -> MagicMock:
@@ -35,13 +28,15 @@ def _baseline_or_probe(
 
 
 class TestCheckLDAPInjection:
-    def test_detects_auth_bypass_high(self) -> None:
+    def test_detects_auth_bypass_high(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
 
         with patch(
             "requests.get",
             side_effect=lambda url, **kw: _baseline_or_probe(
-                url, _resp(401, "Invalid credentials"), _resp(200, "Welcome!")
+                url,
+                make_response(status=401, body="Invalid credentials"),
+                make_response(status=200, body="Welcome!"),
             ),
         ):
             results = check_ldap_injection([ep])
@@ -52,15 +47,15 @@ class TestCheckLDAPInjection:
         assert "auth-bypass" in results[0].evidence or "bypass" in results[0].evidence.lower()
         assert "username" in results[0].evidence
 
-    def test_detects_ldap_error_marker_medium(self) -> None:
+    def test_detects_ldap_error_marker_medium(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/search", status_code=200, parameters=["q"])
 
         with patch(
             "requests.get",
             side_effect=lambda url, **kw: _baseline_or_probe(
                 url,
-                _resp(200, "No results"),
-                _resp(200, "javax.naming.NamingException: invalid attribute"),
+                make_response(status=200, body="No results"),
+                make_response(status=200, body="javax.naming.NamingException: invalid attribute"),
             ),
         ):
             results = check_ldap_injection([ep])
@@ -69,13 +64,15 @@ class TestCheckLDAPInjection:
         assert results[0].severity_hint == Severity.MEDIUM
         assert "javax.naming" in results[0].evidence
 
-    def test_detects_server_error_on_payload_medium(self) -> None:
+    def test_detects_server_error_on_payload_medium(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/auth", status_code=200, parameters=["user"])
 
         with patch(
             "requests.get",
             side_effect=lambda url, **kw: _baseline_or_probe(
-                url, _resp(200, "ok"), _resp(500, "Internal Server Error")
+                url,
+                make_response(status=200, body="ok"),
+                make_response(status=500, body="Internal Server Error"),
             ),
         ):
             results = check_ldap_injection([ep])
@@ -84,10 +81,10 @@ class TestCheckLDAPInjection:
         assert results[0].severity_hint == Severity.MEDIUM
         assert "500" in results[0].evidence
 
-    def test_no_finding_on_clean_response(self) -> None:
+    def test_no_finding_on_clean_response(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
 
-        with patch("requests.get", return_value=_resp(401, "Invalid credentials")):
+        with patch("requests.get", return_value=make_response(status=401, body="Invalid credentials")):
             results = check_ldap_injection([ep])
 
         assert results == []
@@ -110,7 +107,7 @@ class TestCheckLDAPInjection:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_one_finding_per_endpoint_with_multiple_params(self) -> None:
+    def test_one_finding_per_endpoint_with_multiple_params(self, make_response) -> None:
         ep = Endpoint(
             url="https://app.example.com/login",
             status_code=200,
@@ -120,14 +117,16 @@ class TestCheckLDAPInjection:
         with patch(
             "requests.get",
             side_effect=lambda url, **kw: _baseline_or_probe(
-                url, _resp(401, "bad"), _resp(200, "Welcome!")
+                url,
+                make_response(status=401, body="bad"),
+                make_response(status=200, body="Welcome!"),
             ),
         ):
             results = check_ldap_injection([ep])
 
         assert len(results) == 1
 
-    def test_stops_probing_after_first_match(self) -> None:
+    def test_stops_probing_after_first_match(self, make_response) -> None:
         ep = Endpoint(
             url="https://app.example.com/login",
             status_code=200,
@@ -137,7 +136,9 @@ class TestCheckLDAPInjection:
         with patch(
             "requests.get",
             side_effect=lambda url, **kw: _baseline_or_probe(
-                url, _resp(401, "bad"), _resp(200, "Welcome!")
+                url,
+                make_response(status=401, body="bad"),
+                make_response(status=200, body="Welcome!"),
             ),
         ) as mock_get:
             check_ldap_injection([ep])
@@ -145,25 +146,25 @@ class TestCheckLDAPInjection:
         # One baseline + one payload before match - should stop immediately.
         assert mock_get.call_count == 2
 
-    def test_baseline_exception_skips_param(self) -> None:
+    def test_baseline_exception_skips_param(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
 
         def raise_on_baseline(url: str, **kw: object) -> MagicMock:
             if _BASELINE_VALUE in url:
                 raise OSError("connection refused")
-            return _resp(200, "Welcome!")
+            return make_response(status=200, body="Welcome!")
 
         with patch("requests.get", side_effect=raise_on_baseline):
             results = check_ldap_injection([ep])
 
         assert results == []
 
-    def test_probe_exception_is_swallowed(self) -> None:
+    def test_probe_exception_is_swallowed(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
 
         def raise_on_probe(url: str, **kw: object) -> MagicMock:
             if _BASELINE_VALUE in url:
-                return _resp(401, "bad")
+                return make_response(status=401, body="bad")
             raise OSError("timeout")
 
         with patch("requests.get", side_effect=raise_on_probe):
@@ -171,7 +172,7 @@ class TestCheckLDAPInjection:
 
         assert results == []
 
-    def test_deduplicates_across_multiple_endpoints_same_url(self) -> None:
+    def test_deduplicates_across_multiple_endpoints_same_url(self, make_response) -> None:
         ep1 = Endpoint(
             url="https://app.example.com/login", status_code=200, parameters=["username"]
         )
@@ -180,14 +181,16 @@ class TestCheckLDAPInjection:
         with patch(
             "requests.get",
             side_effect=lambda url, **kw: _baseline_or_probe(
-                url, _resp(401, "bad"), _resp(200, "Welcome!")
+                url,
+                make_response(status=401, body="bad"),
+                make_response(status=200, body="Welcome!"),
             ),
         ):
             results = check_ldap_injection([ep1, ep2])
 
         assert len(results) == 1
 
-    def test_high_takes_priority_over_medium(self) -> None:
+    def test_high_takes_priority_over_medium(self, make_response) -> None:
         # Response triggers both a status-code bypass AND an error marker -
         # the finding should be HIGH, not MEDIUM.
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
@@ -196,8 +199,8 @@ class TestCheckLDAPInjection:
             "requests.get",
             side_effect=lambda url, **kw: _baseline_or_probe(
                 url,
-                _resp(401, "bad"),
-                _resp(200, "Welcome! objectClass=person"),
+                make_response(status=401, body="bad"),
+                make_response(status=200, body="Welcome! objectClass=person"),
             ),
         ):
             results = check_ldap_injection([ep])
@@ -218,7 +221,7 @@ class TestCheckLDAPInjection:
         assert "ldap_search" in _LDAP_ERROR_MARKERS
         assert "objectClass" in _LDAP_ERROR_MARKERS
 
-    def test_payload_filter_restricts_to_named_variants(self) -> None:
+    def test_payload_filter_restricts_to_named_variants(self, make_response) -> None:
         # Asking only for auth-bypass should send one baseline + one probe
         # per parameter - the other five payloads must not fire.
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
@@ -227,7 +230,7 @@ class TestCheckLDAPInjection:
 
         def record(url: str, **_: object) -> MagicMock:
             seen_urls.append(url)
-            return _resp(401, "Invalid credentials")
+            return make_response(status=401, body="Invalid credentials")
 
         with patch("requests.get", side_effect=record):
             check_ldap_injection([ep], payload_names=[LdapPayload.auth_bypass])
@@ -235,13 +238,15 @@ class TestCheckLDAPInjection:
         # 1 baseline + 1 payload only.
         assert len(seen_urls) == 2
 
-    def test_payload_filter_finding_evidence_names_the_variant(self) -> None:
+    def test_payload_filter_finding_evidence_names_the_variant(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
 
         with patch(
             "requests.get",
             side_effect=lambda url, **kw: _baseline_or_probe(
-                url, _resp(401, "bad"), _resp(200, "Welcome!")
+                url,
+                make_response(status=401, body="bad"),
+                make_response(status=200, body="Welcome!"),
             ),
         ):
             results = check_ldap_injection([ep], payload_names=[LdapPayload.boolean_blind_true])
@@ -249,14 +254,14 @@ class TestCheckLDAPInjection:
         assert len(results) == 1
         assert "boolean-blind-true" in results[0].evidence
 
-    def test_payload_filter_empty_list_is_a_noop(self) -> None:
+    def test_payload_filter_empty_list_is_a_noop(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
 
         seen_urls: list[str] = []
 
         def record(url: str, **_: object) -> MagicMock:
             seen_urls.append(url)
-            return _resp(401, "bad")
+            return make_response(status=401, body="bad")
 
         with patch("requests.get", side_effect=record):
             results = check_ldap_injection([ep], payload_names=[])

--- a/tests/test_ldap_injection.py
+++ b/tests/test_ldap_injection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -26,7 +27,7 @@ def _baseline_or_probe(url: str, baseline_resp: MagicMock, probe_resp: MagicMock
 
 
 class TestCheckLDAPInjection:
-    def test_detects_auth_bypass_high(self, make_response) -> None:
+    def test_detects_auth_bypass_high(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
 
         with patch(
@@ -45,7 +46,9 @@ class TestCheckLDAPInjection:
         assert "auth-bypass" in results[0].evidence or "bypass" in results[0].evidence.lower()
         assert "username" in results[0].evidence
 
-    def test_detects_ldap_error_marker_medium(self, make_response) -> None:
+    def test_detects_ldap_error_marker_medium(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/search", status_code=200, parameters=["q"])
 
         with patch(
@@ -62,7 +65,9 @@ class TestCheckLDAPInjection:
         assert results[0].severity_hint == Severity.MEDIUM
         assert "javax.naming" in results[0].evidence
 
-    def test_detects_server_error_on_payload_medium(self, make_response) -> None:
+    def test_detects_server_error_on_payload_medium(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/auth", status_code=200, parameters=["user"])
 
         with patch(
@@ -79,7 +84,7 @@ class TestCheckLDAPInjection:
         assert results[0].severity_hint == Severity.MEDIUM
         assert "500" in results[0].evidence
 
-    def test_no_finding_on_clean_response(self, make_response) -> None:
+    def test_no_finding_on_clean_response(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
 
         with patch(
@@ -107,7 +112,9 @@ class TestCheckLDAPInjection:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_one_finding_per_endpoint_with_multiple_params(self, make_response) -> None:
+    def test_one_finding_per_endpoint_with_multiple_params(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(
             url="https://app.example.com/login",
             status_code=200,
@@ -126,7 +133,7 @@ class TestCheckLDAPInjection:
 
         assert len(results) == 1
 
-    def test_stops_probing_after_first_match(self, make_response) -> None:
+    def test_stops_probing_after_first_match(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(
             url="https://app.example.com/login",
             status_code=200,
@@ -146,10 +153,10 @@ class TestCheckLDAPInjection:
         # One baseline + one payload before match - should stop immediately.
         assert mock_get.call_count == 2
 
-    def test_baseline_exception_skips_param(self, make_response) -> None:
+    def test_baseline_exception_skips_param(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
 
-        def raise_on_baseline(url: str, **kw: object):
+        def raise_on_baseline(url: str, **kw: object) -> MagicMock:
             if _BASELINE_VALUE in url:
                 raise OSError("connection refused")
             return make_response(status=200, body="Welcome!")
@@ -159,10 +166,10 @@ class TestCheckLDAPInjection:
 
         assert results == []
 
-    def test_probe_exception_is_swallowed(self, make_response) -> None:
+    def test_probe_exception_is_swallowed(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
 
-        def raise_on_probe(url: str, **kw: object):
+        def raise_on_probe(url: str, **kw: object) -> MagicMock:
             if _BASELINE_VALUE in url:
                 return make_response(status=401, body="bad")
             raise OSError("timeout")
@@ -172,7 +179,9 @@ class TestCheckLDAPInjection:
 
         assert results == []
 
-    def test_deduplicates_across_multiple_endpoints_same_url(self, make_response) -> None:
+    def test_deduplicates_across_multiple_endpoints_same_url(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep1 = Endpoint(
             url="https://app.example.com/login", status_code=200, parameters=["username"]
         )
@@ -190,7 +199,7 @@ class TestCheckLDAPInjection:
 
         assert len(results) == 1
 
-    def test_high_takes_priority_over_medium(self, make_response) -> None:
+    def test_high_takes_priority_over_medium(self, make_response: Callable[..., MagicMock]) -> None:
         # Response triggers both a status-code bypass AND an error marker -
         # the finding should be HIGH, not MEDIUM.
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
@@ -221,14 +230,16 @@ class TestCheckLDAPInjection:
         assert "ldap_search" in _LDAP_ERROR_MARKERS
         assert "objectClass" in _LDAP_ERROR_MARKERS
 
-    def test_payload_filter_restricts_to_named_variants(self, make_response) -> None:
+    def test_payload_filter_restricts_to_named_variants(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Asking only for auth-bypass should send one baseline + one probe
         # per parameter - the other five payloads must not fire.
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
 
         seen_urls: list[str] = []
 
-        def record(url: str, **_: object):
+        def record(url: str, **_: object) -> MagicMock:
             seen_urls.append(url)
             return make_response(status=401, body="Invalid credentials")
 
@@ -238,7 +249,9 @@ class TestCheckLDAPInjection:
         # 1 baseline + 1 payload only.
         assert len(seen_urls) == 2
 
-    def test_payload_filter_finding_evidence_names_the_variant(self, make_response) -> None:
+    def test_payload_filter_finding_evidence_names_the_variant(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
 
         with patch(
@@ -254,12 +267,14 @@ class TestCheckLDAPInjection:
         assert len(results) == 1
         assert "boolean-blind-true" in results[0].evidence
 
-    def test_payload_filter_empty_list_is_a_noop(self, make_response) -> None:
+    def test_payload_filter_empty_list_is_a_noop(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
 
         seen_urls: list[str] = []
 
-        def record(url: str, **_: object):
+        def record(url: str, **_: object) -> MagicMock:
             seen_urls.append(url)
             return make_response(status=401, body="bad")
 

--- a/tests/test_ldap_injection.py
+++ b/tests/test_ldap_injection.py
@@ -18,9 +18,7 @@ from tools.pentest.ldap_injection import (
 pytestmark = pytest.mark.unit
 
 
-def _baseline_or_probe(
-    url: str, baseline_resp: MagicMock, probe_resp: MagicMock, **_: object
-) -> MagicMock:
+def _baseline_or_probe(url: str, baseline_resp: MagicMock, probe_resp: MagicMock, **_: object):
     """Return baseline_resp for the baseline URL, probe_resp for everything else."""
     if _BASELINE_VALUE in url:
         return baseline_resp
@@ -84,7 +82,9 @@ class TestCheckLDAPInjection:
     def test_no_finding_on_clean_response(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
 
-        with patch("requests.get", return_value=make_response(status=401, body="Invalid credentials")):
+        with patch(
+            "requests.get", return_value=make_response(status=401, body="Invalid credentials")
+        ):
             results = check_ldap_injection([ep])
 
         assert results == []
@@ -149,7 +149,7 @@ class TestCheckLDAPInjection:
     def test_baseline_exception_skips_param(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
 
-        def raise_on_baseline(url: str, **kw: object) -> MagicMock:
+        def raise_on_baseline(url: str, **kw: object):
             if _BASELINE_VALUE in url:
                 raise OSError("connection refused")
             return make_response(status=200, body="Welcome!")
@@ -162,7 +162,7 @@ class TestCheckLDAPInjection:
     def test_probe_exception_is_swallowed(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
 
-        def raise_on_probe(url: str, **kw: object) -> MagicMock:
+        def raise_on_probe(url: str, **kw: object):
             if _BASELINE_VALUE in url:
                 return make_response(status=401, body="bad")
             raise OSError("timeout")
@@ -228,7 +228,7 @@ class TestCheckLDAPInjection:
 
         seen_urls: list[str] = []
 
-        def record(url: str, **_: object) -> MagicMock:
+        def record(url: str, **_: object):
             seen_urls.append(url)
             return make_response(status=401, body="Invalid credentials")
 
@@ -259,7 +259,7 @@ class TestCheckLDAPInjection:
 
         seen_urls: list[str] = []
 
-        def record(url: str, **_: object) -> MagicMock:
+        def record(url: str, **_: object):
             seen_urls.append(url)
             return make_response(status=401, body="bad")
 

--- a/tests/test_open_redirect.py
+++ b/tests/test_open_redirect.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from collections.abc import Callable
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -20,23 +21,23 @@ pytestmark = pytest.mark.unit
 
 
 class TestRedirectTarget:
-    def test_picks_up_location_header(self, make_response):
+    def test_picks_up_location_header(self, make_response: Callable[..., MagicMock]) -> None:
         assert (
             _redirect_target(make_response(status=302, headers={"Location": "https://x/"}))
             == "https://x/"
         )
 
-    def test_picks_up_refresh_header(self, make_response):
+    def test_picks_up_refresh_header(self, make_response: Callable[..., MagicMock]) -> None:
         target = _redirect_target(
             make_response(status=200, headers={"Refresh": "0; url=https://x/"})
         )
         assert target == "https://x/"
 
-    def test_picks_up_meta_refresh(self, make_response):
+    def test_picks_up_meta_refresh(self, make_response: Callable[..., MagicMock]) -> None:
         body = '<html><head><meta http-equiv="refresh" content="0;url=https://x/"></head></html>'
         assert _redirect_target(make_response(status=200, body=body)) == "https://x/"
 
-    def test_returns_none_when_no_redirect(self, make_response):
+    def test_returns_none_when_no_redirect(self, make_response: Callable[..., MagicMock]) -> None:
         assert _redirect_target(make_response(status=200, body="<html>plain page</html>")) is None
 
 
@@ -60,10 +61,10 @@ class TestRedirectsToCanary:
 
 
 class TestCheckOpenRedirect:
-    def test_detects_30x_to_canary(self, make_response):
+    def test_detects_30x_to_canary(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
 
-        def fake_get(url, **kwargs):
+        def fake_get(url, **kwargs) -> MagicMock:
             payload = url.split("next=", 1)[1]
             return make_response(status=302, headers={"Location": payload})
 
@@ -76,10 +77,10 @@ class TestCheckOpenRedirect:
         assert "next" in results[0].evidence
         assert _PAYLOAD_HOST in results[0].evidence
 
-    def test_detects_meta_refresh_redirect(self, make_response):
+    def test_detects_meta_refresh_redirect(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/go", status_code=200, parameters=["dest"])
 
-        def fake_get(url, **kwargs):
+        def fake_get(url, **kwargs) -> MagicMock:
             payload = url.split("dest=", 1)[1]
             body = (
                 f'<html><head><meta http-equiv="refresh" content="0;url={payload}"></head></html>'
@@ -92,11 +93,13 @@ class TestCheckOpenRedirect:
         assert len(results) == 1
         assert "Redirect target" in results[0].evidence
 
-    def test_no_finding_when_redirect_stays_on_origin(self, make_response):
+    def test_no_finding_when_redirect_stays_on_origin(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Application sanitises by ignoring our payload and redirecting home
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
 
-        def fake_get(url, **kwargs):
+        def fake_get(url, **kwargs) -> MagicMock:
             return make_response(status=302, headers={"Location": "/dashboard"})
 
         with patch("requests.get", side_effect=fake_get):
@@ -104,10 +107,12 @@ class TestCheckOpenRedirect:
 
         assert results == []
 
-    def test_no_finding_when_no_redirect_at_all(self, make_response):
+    def test_no_finding_when_no_redirect_at_all(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
 
-        def fake_get(url, **kwargs):
+        def fake_get(url, **kwargs) -> MagicMock:
             return make_response(status=200, body="<html>login form</html>")
 
         with patch("requests.get", side_effect=fake_get):
@@ -129,14 +134,16 @@ class TestCheckOpenRedirect:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_one_finding_per_endpoint_even_with_multiple_vuln_params(self, make_response):
+    def test_one_finding_per_endpoint_even_with_multiple_vuln_params(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(
             url="https://app.example.com/login",
             status_code=200,
             parameters=["next", "return_to"],
         )
 
-        def fake_get(url, **kwargs):
+        def fake_get(url, **kwargs) -> MagicMock:
             # Both params would redirect if probed
             for key in ("next=", "return_to="):
                 if key in url:
@@ -149,11 +156,13 @@ class TestCheckOpenRedirect:
 
         assert len(results) == 1
 
-    def test_protocol_relative_payload_in_location(self, make_response):
+    def test_protocol_relative_payload_in_location(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Server normalises a backslash payload to protocol-relative
         ep = Endpoint(url="https://app.example.com/r", status_code=200, parameters=["u"])
 
-        def fake_get(url, **kwargs):
+        def fake_get(url, **kwargs) -> MagicMock:
             return make_response(status=302, headers={"Location": f"//{_PAYLOAD_HOST}/"})
 
         with patch("requests.get", side_effect=fake_get):
@@ -172,14 +181,16 @@ class TestCheckOpenRedirect:
         # if a victim browser followed the redirect, no live service receives it.
         assert _PAYLOAD_HOST.endswith(".invalid")
 
-    def test_payload_filter_restricts_to_named_variants(self, make_response):
+    def test_payload_filter_restricts_to_named_variants(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Selecting only "https" should fire one request per parameter,
         # not four.
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
 
         seen_urls: list[str] = []
 
-        def record(url, **_):
+        def record(url, **_) -> MagicMock:
             seen_urls.append(url)
             return make_response(status=200)
 
@@ -188,7 +199,9 @@ class TestCheckOpenRedirect:
 
         assert len(seen_urls) == 1
 
-    def test_payload_filter_finding_evidence_names_the_variant(self, make_response):
+    def test_payload_filter_finding_evidence_names_the_variant(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
 
         with patch(
@@ -202,12 +215,14 @@ class TestCheckOpenRedirect:
         assert len(results) == 1
         assert "https" in results[0].evidence
 
-    def test_payload_filter_none_runs_all_variants(self, make_response):
+    def test_payload_filter_none_runs_all_variants(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
 
         seen_urls: list[str] = []
 
-        def record(url, **_):
+        def record(url, **_) -> MagicMock:
             seen_urls.append(url)
             return make_response(status=200)
 

--- a/tests/test_open_redirect.py
+++ b/tests/test_open_redirect.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -19,28 +19,25 @@ from tools.pentest.open_redirect import (
 pytestmark = pytest.mark.unit
 
 
-def _resp(status: int = 302, headers: dict[str, str] | None = None, body: str = "") -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = status
-    resp.headers = headers or {}
-    resp.text = body
-    return resp
-
-
 class TestRedirectTarget:
-    def test_picks_up_location_header(self):
-        assert _redirect_target(_resp(headers={"Location": "https://x/"})) == "https://x/"
+    def test_picks_up_location_header(self, make_response):
+        assert (
+            _redirect_target(make_response(status=302, headers={"Location": "https://x/"}))
+            == "https://x/"
+        )
 
-    def test_picks_up_refresh_header(self):
-        target = _redirect_target(_resp(status=200, headers={"Refresh": "0; url=https://x/"}))
+    def test_picks_up_refresh_header(self, make_response):
+        target = _redirect_target(
+            make_response(status=200, headers={"Refresh": "0; url=https://x/"})
+        )
         assert target == "https://x/"
 
-    def test_picks_up_meta_refresh(self):
+    def test_picks_up_meta_refresh(self, make_response):
         body = '<html><head><meta http-equiv="refresh" content="0;url=https://x/"></head></html>'
-        assert _redirect_target(_resp(status=200, body=body)) == "https://x/"
+        assert _redirect_target(make_response(status=200, body=body)) == "https://x/"
 
-    def test_returns_none_when_no_redirect(self):
-        assert _redirect_target(_resp(status=200, body="<html>plain page</html>")) is None
+    def test_returns_none_when_no_redirect(self, make_response):
+        assert _redirect_target(make_response(status=200, body="<html>plain page</html>")) is None
 
 
 class TestRedirectsToCanary:
@@ -63,12 +60,12 @@ class TestRedirectsToCanary:
 
 
 class TestCheckOpenRedirect:
-    def test_detects_30x_to_canary(self):
+    def test_detects_30x_to_canary(self, make_response):
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
 
         def fake_get(url, **kwargs):
             payload = url.split("next=", 1)[1]
-            return _resp(status=302, headers={"Location": payload})
+            return make_response(status=302, headers={"Location": payload})
 
         with patch("requests.get", side_effect=fake_get):
             results = check_open_redirect([ep])
@@ -79,7 +76,7 @@ class TestCheckOpenRedirect:
         assert "next" in results[0].evidence
         assert _PAYLOAD_HOST in results[0].evidence
 
-    def test_detects_meta_refresh_redirect(self):
+    def test_detects_meta_refresh_redirect(self, make_response):
         ep = Endpoint(url="https://app.example.com/go", status_code=200, parameters=["dest"])
 
         def fake_get(url, **kwargs):
@@ -87,7 +84,7 @@ class TestCheckOpenRedirect:
             body = (
                 f'<html><head><meta http-equiv="refresh" content="0;url={payload}"></head></html>'
             )
-            return _resp(status=200, body=body)
+            return make_response(status=200, body=body)
 
         with patch("requests.get", side_effect=fake_get):
             results = check_open_redirect([ep])
@@ -95,23 +92,23 @@ class TestCheckOpenRedirect:
         assert len(results) == 1
         assert "Redirect target" in results[0].evidence
 
-    def test_no_finding_when_redirect_stays_on_origin(self):
+    def test_no_finding_when_redirect_stays_on_origin(self, make_response):
         # Application sanitises by ignoring our payload and redirecting home
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
 
         def fake_get(url, **kwargs):
-            return _resp(status=302, headers={"Location": "/dashboard"})
+            return make_response(status=302, headers={"Location": "/dashboard"})
 
         with patch("requests.get", side_effect=fake_get):
             results = check_open_redirect([ep])
 
         assert results == []
 
-    def test_no_finding_when_no_redirect_at_all(self):
+    def test_no_finding_when_no_redirect_at_all(self, make_response):
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
 
         def fake_get(url, **kwargs):
-            return _resp(status=200, body="<html>login form</html>")
+            return make_response(status=200, body="<html>login form</html>")
 
         with patch("requests.get", side_effect=fake_get):
             results = check_open_redirect([ep])
@@ -132,7 +129,7 @@ class TestCheckOpenRedirect:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_one_finding_per_endpoint_even_with_multiple_vuln_params(self):
+    def test_one_finding_per_endpoint_even_with_multiple_vuln_params(self, make_response):
         ep = Endpoint(
             url="https://app.example.com/login",
             status_code=200,
@@ -144,20 +141,20 @@ class TestCheckOpenRedirect:
             for key in ("next=", "return_to="):
                 if key in url:
                     payload = url.split(key, 1)[1]
-                    return _resp(status=302, headers={"Location": payload})
-            return _resp(status=200)
+                    return make_response(status=302, headers={"Location": payload})
+            return make_response(status=200)
 
         with patch("requests.get", side_effect=fake_get):
             results = check_open_redirect([ep])
 
         assert len(results) == 1
 
-    def test_protocol_relative_payload_in_location(self):
+    def test_protocol_relative_payload_in_location(self, make_response):
         # Server normalises a backslash payload to protocol-relative
         ep = Endpoint(url="https://app.example.com/r", status_code=200, parameters=["u"])
 
         def fake_get(url, **kwargs):
-            return _resp(status=302, headers={"Location": f"//{_PAYLOAD_HOST}/"})
+            return make_response(status=302, headers={"Location": f"//{_PAYLOAD_HOST}/"})
 
         with patch("requests.get", side_effect=fake_get):
             results = check_open_redirect([ep])
@@ -175,7 +172,7 @@ class TestCheckOpenRedirect:
         # if a victim browser followed the redirect, no live service receives it.
         assert _PAYLOAD_HOST.endswith(".invalid")
 
-    def test_payload_filter_restricts_to_named_variants(self):
+    def test_payload_filter_restricts_to_named_variants(self, make_response):
         # Selecting only "https" should fire one request per parameter,
         # not four.
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
@@ -184,33 +181,35 @@ class TestCheckOpenRedirect:
 
         def record(url, **_):
             seen_urls.append(url)
-            return _resp(status=200)
+            return make_response(status=200)
 
         with patch("requests.get", side_effect=record):
             check_open_redirect([ep], payload_names=[OpenRedirectPayload.https])
 
         assert len(seen_urls) == 1
 
-    def test_payload_filter_finding_evidence_names_the_variant(self):
+    def test_payload_filter_finding_evidence_names_the_variant(self, make_response):
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
 
         with patch(
             "requests.get",
-            return_value=_resp(status=302, headers={"Location": f"https://{_PAYLOAD_HOST}/"}),
+            return_value=make_response(
+                status=302, headers={"Location": f"https://{_PAYLOAD_HOST}/"}
+            ),
         ):
             results = check_open_redirect([ep], payload_names=[OpenRedirectPayload.https])
 
         assert len(results) == 1
         assert "https" in results[0].evidence
 
-    def test_payload_filter_none_runs_all_variants(self):
+    def test_payload_filter_none_runs_all_variants(self, make_response):
         ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
 
         seen_urls: list[str] = []
 
         def record(url, **_):
             seen_urls.append(url)
-            return _resp(status=200)
+            return make_response(status=200)
 
         with patch("requests.get", side_effect=record):
             check_open_redirect([ep], payload_names=None)

--- a/tests/test_path_traversal.py
+++ b/tests/test_path_traversal.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from collections.abc import Callable
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -20,7 +21,7 @@ _WIN_INI_BODY = "; for 16-bit app support\n[fonts]\n[extensions]\n"
 
 
 class TestCheckPathTraversal:
-    def test_detects_linux_passwd_marker(self, make_response):
+    def test_detects_linux_passwd_marker(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/download", status_code=200, parameters=["file"])
 
         with patch("requests.get", return_value=make_response(body=_PASSWD_BODY)):
@@ -32,10 +33,10 @@ class TestCheckPathTraversal:
         assert "file" in results[0].evidence
         assert "root:x:0:0:" in results[0].evidence
 
-    def test_detects_windows_win_ini_marker(self, make_response):
+    def test_detects_windows_win_ini_marker(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/view", status_code=200, parameters=["page"])
 
-        def fake_get(url, **kwargs):
+        def fake_get(url, **kwargs) -> MagicMock:
             # Only respond with win.ini content when the Windows payload is sent
             if "windows" in url.lower() and "win.ini" in url.lower():
                 return make_response(body=_WIN_INI_BODY)
@@ -47,12 +48,14 @@ class TestCheckPathTraversal:
         assert len(results) == 1
         assert "for 16-bit app support" in results[0].evidence
 
-    def test_detects_url_encoded_payload_only(self, make_response):
+    def test_detects_url_encoded_payload_only(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Server sanitises plain "../" but not "%2f" - the encoded variant
         # must still be tried so this is detected.
         ep = Endpoint(url="https://app.example.com/dl", status_code=200, parameters=["f"])
 
-        def fake_get(url, **kwargs):
+        def fake_get(url, **kwargs) -> MagicMock:
             # Plain "../" is stripped by the (fake) server's filter
             if "../" in url:
                 return make_response(body="forbidden")
@@ -66,7 +69,7 @@ class TestCheckPathTraversal:
         assert len(results) == 1
         assert "%2f" in results[0].evidence.lower()
 
-    def test_no_finding_when_marker_absent(self, make_response):
+    def test_no_finding_when_marker_absent(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/download", status_code=200, parameters=["file"])
 
         with patch("requests.get", return_value=make_response(body="<html>Not Found</html>")):
@@ -74,7 +77,9 @@ class TestCheckPathTraversal:
 
         assert results == []
 
-    def test_no_false_positive_when_only_word_root_present(self, make_response):
+    def test_no_false_positive_when_only_word_root_present(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Body mentions "root" but not the unique "root:x:0:0:" prefix - the
         # marker check must be strict enough to skip this.
         ep = Endpoint(url="https://app.example.com/download", status_code=200, parameters=["file"])
@@ -98,7 +103,9 @@ class TestCheckPathTraversal:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_one_finding_per_endpoint_even_with_multiple_vuln_params(self, make_response):
+    def test_one_finding_per_endpoint_even_with_multiple_vuln_params(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(
             url="https://app.example.com/dl",
             status_code=200,
@@ -110,7 +117,7 @@ class TestCheckPathTraversal:
 
         assert len(results) == 1
 
-    def test_stops_calling_after_first_match(self, make_response):
+    def test_stops_calling_after_first_match(self, make_response: Callable[..., MagicMock]) -> None:
         # Once we have a finding for an endpoint we should not keep firing
         # additional payloads against later parameters.
         ep = Endpoint(
@@ -142,14 +149,16 @@ class TestCheckPathTraversal:
         assert "%00" in joined
         assert "\\" in joined
 
-    def test_payload_filter_restricts_to_named_variants(self, make_response):
+    def test_payload_filter_restricts_to_named_variants(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Asking for just the Linux variants should skip both Windows probes
         # entirely - useful when recon already confirms the target OS.
         ep = Endpoint(url="https://app.example.com/dl", status_code=200, parameters=["file"])
 
         seen_urls: list[str] = []
 
-        def record(url, **_):
+        def record(url, **_) -> MagicMock:
             seen_urls.append(url)
             return make_response(body="not found")
 
@@ -168,7 +177,9 @@ class TestCheckPathTraversal:
         assert "win.ini" not in joined.lower()
         assert "windows" not in joined.lower()
 
-    def test_payload_filter_finding_evidence_names_the_variant(self, make_response):
+    def test_payload_filter_finding_evidence_names_the_variant(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/dl", status_code=200, parameters=["file"])
 
         with patch("requests.get", return_value=make_response(body=_PASSWD_BODY)):
@@ -179,12 +190,14 @@ class TestCheckPathTraversal:
         assert len(results) == 1
         assert "unix-null-byte" in results[0].evidence
 
-    def test_payload_filter_none_runs_all_variants(self, make_response):
+    def test_payload_filter_none_runs_all_variants(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/dl", status_code=200, parameters=["file"])
 
         seen_urls: list[str] = []
 
-        def record(url, **_):
+        def record(url, **_) -> MagicMock:
             seen_urls.append(url)
             return make_response(body="not found")
 

--- a/tests/test_path_traversal.py
+++ b/tests/test_path_traversal.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -19,18 +19,11 @@ _PASSWD_BODY = "root:x:0:0:root:/root:/bin/bash\nbin:x:1:1:bin:/bin:/sbin/nologi
 _WIN_INI_BODY = "; for 16-bit app support\n[fonts]\n[extensions]\n"
 
 
-def _resp(status: int = 200, body: str = "") -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = status
-    resp.text = body
-    return resp
-
-
 class TestCheckPathTraversal:
-    def test_detects_linux_passwd_marker(self):
+    def test_detects_linux_passwd_marker(self, make_response):
         ep = Endpoint(url="https://app.example.com/download", status_code=200, parameters=["file"])
 
-        with patch("requests.get", return_value=_resp(body=_PASSWD_BODY)):
+        with patch("requests.get", return_value=make_response(body=_PASSWD_BODY)):
             results = check_path_traversal([ep])
 
         assert len(results) == 1
@@ -39,14 +32,14 @@ class TestCheckPathTraversal:
         assert "file" in results[0].evidence
         assert "root:x:0:0:" in results[0].evidence
 
-    def test_detects_windows_win_ini_marker(self):
+    def test_detects_windows_win_ini_marker(self, make_response):
         ep = Endpoint(url="https://app.example.com/view", status_code=200, parameters=["page"])
 
         def fake_get(url, **kwargs):
             # Only respond with win.ini content when the Windows payload is sent
             if "windows" in url.lower() and "win.ini" in url.lower():
-                return _resp(body=_WIN_INI_BODY)
-            return _resp(body="not found")
+                return make_response(body=_WIN_INI_BODY)
+            return make_response(body="not found")
 
         with patch("requests.get", side_effect=fake_get):
             results = check_path_traversal([ep])
@@ -54,7 +47,7 @@ class TestCheckPathTraversal:
         assert len(results) == 1
         assert "for 16-bit app support" in results[0].evidence
 
-    def test_detects_url_encoded_payload_only(self):
+    def test_detects_url_encoded_payload_only(self, make_response):
         # Server sanitises plain "../" but not "%2f" - the encoded variant
         # must still be tried so this is detected.
         ep = Endpoint(url="https://app.example.com/dl", status_code=200, parameters=["f"])
@@ -62,10 +55,10 @@ class TestCheckPathTraversal:
         def fake_get(url, **kwargs):
             # Plain "../" is stripped by the (fake) server's filter
             if "../" in url:
-                return _resp(body="forbidden")
+                return make_response(body="forbidden")
             if "%2f" in url.lower():
-                return _resp(body=_PASSWD_BODY)
-            return _resp(body="")
+                return make_response(body=_PASSWD_BODY)
+            return make_response(body="")
 
         with patch("requests.get", side_effect=fake_get):
             results = check_path_traversal([ep])
@@ -73,20 +66,20 @@ class TestCheckPathTraversal:
         assert len(results) == 1
         assert "%2f" in results[0].evidence.lower()
 
-    def test_no_finding_when_marker_absent(self):
+    def test_no_finding_when_marker_absent(self, make_response):
         ep = Endpoint(url="https://app.example.com/download", status_code=200, parameters=["file"])
 
-        with patch("requests.get", return_value=_resp(body="<html>Not Found</html>")):
+        with patch("requests.get", return_value=make_response(body="<html>Not Found</html>")):
             results = check_path_traversal([ep])
 
         assert results == []
 
-    def test_no_false_positive_when_only_word_root_present(self):
+    def test_no_false_positive_when_only_word_root_present(self, make_response):
         # Body mentions "root" but not the unique "root:x:0:0:" prefix - the
         # marker check must be strict enough to skip this.
         ep = Endpoint(url="https://app.example.com/download", status_code=200, parameters=["file"])
 
-        with patch("requests.get", return_value=_resp(body="Welcome, root admin user!")):
+        with patch("requests.get", return_value=make_response(body="Welcome, root admin user!")):
             results = check_path_traversal([ep])
 
         assert results == []
@@ -105,19 +98,19 @@ class TestCheckPathTraversal:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_one_finding_per_endpoint_even_with_multiple_vuln_params(self):
+    def test_one_finding_per_endpoint_even_with_multiple_vuln_params(self, make_response):
         ep = Endpoint(
             url="https://app.example.com/dl",
             status_code=200,
             parameters=["file", "path"],
         )
 
-        with patch("requests.get", return_value=_resp(body=_PASSWD_BODY)):
+        with patch("requests.get", return_value=make_response(body=_PASSWD_BODY)):
             results = check_path_traversal([ep])
 
         assert len(results) == 1
 
-    def test_stops_calling_after_first_match(self):
+    def test_stops_calling_after_first_match(self, make_response):
         # Once we have a finding for an endpoint we should not keep firing
         # additional payloads against later parameters.
         ep = Endpoint(
@@ -126,7 +119,7 @@ class TestCheckPathTraversal:
             parameters=["file", "path", "page"],
         )
 
-        with patch("requests.get", return_value=_resp(body=_PASSWD_BODY)) as mock_get:
+        with patch("requests.get", return_value=make_response(body=_PASSWD_BODY)) as mock_get:
             check_path_traversal([ep])
 
         # First param matches on the very first probe - only one request expected
@@ -149,7 +142,7 @@ class TestCheckPathTraversal:
         assert "%00" in joined
         assert "\\" in joined
 
-    def test_payload_filter_restricts_to_named_variants(self):
+    def test_payload_filter_restricts_to_named_variants(self, make_response):
         # Asking for just the Linux variants should skip both Windows probes
         # entirely - useful when recon already confirms the target OS.
         ep = Endpoint(url="https://app.example.com/dl", status_code=200, parameters=["file"])
@@ -158,7 +151,7 @@ class TestCheckPathTraversal:
 
         def record(url, **_):
             seen_urls.append(url)
-            return _resp(body="not found")
+            return make_response(body="not found")
 
         with patch("requests.get", side_effect=record):
             check_path_traversal(
@@ -175,10 +168,10 @@ class TestCheckPathTraversal:
         assert "win.ini" not in joined.lower()
         assert "windows" not in joined.lower()
 
-    def test_payload_filter_finding_evidence_names_the_variant(self):
+    def test_payload_filter_finding_evidence_names_the_variant(self, make_response):
         ep = Endpoint(url="https://app.example.com/dl", status_code=200, parameters=["file"])
 
-        with patch("requests.get", return_value=_resp(body=_PASSWD_BODY)):
+        with patch("requests.get", return_value=make_response(body=_PASSWD_BODY)):
             results = check_path_traversal(
                 [ep], payload_names=[PathTraversalPayload.unix_null_byte]
             )
@@ -186,14 +179,14 @@ class TestCheckPathTraversal:
         assert len(results) == 1
         assert "unix-null-byte" in results[0].evidence
 
-    def test_payload_filter_none_runs_all_variants(self):
+    def test_payload_filter_none_runs_all_variants(self, make_response):
         ep = Endpoint(url="https://app.example.com/dl", status_code=200, parameters=["file"])
 
         seen_urls: list[str] = []
 
         def record(url, **_):
             seen_urls.append(url)
-            return _resp(body="not found")
+            return make_response(body="not found")
 
         with patch("requests.get", side_effect=record):
             check_path_traversal([ep], payload_names=None)

--- a/tests/test_prompt_injection.py
+++ b/tests/test_prompt_injection.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -19,53 +19,42 @@ from tools.recon.llm import detect_llm_endpoints
 pytestmark = pytest.mark.unit
 
 
-# --- helpers -----------------------------------------------------------------
-
-
-def _mock_resp(status: int, body: str = "", headers: dict | None = None) -> MagicMock:
-    m = MagicMock()
-    m.status_code = status
-    m.text = body
-    m.headers = headers or {}
-    return m
-
-
 # --- detect_llm_endpoints ----------------------------------------------------
 
 
 class TestDetectLlmEndpoints:
-    def test_detects_by_url_path_token(self):
+    def test_detects_by_url_path_token(self, make_response):
         ep = Endpoint(url="https://example.com/chat", status_code=200)
-        with patch("requests.get", return_value=_mock_resp(200)):
+        with patch("requests.get", return_value=make_response(status=200)):
             results = detect_llm_endpoints([ep])
         assert len(results) == 1
         assert "LLM" in results[0].technologies
 
-    def test_detects_by_openai_header(self):
+    def test_detects_by_openai_header(self, make_response):
         ep = Endpoint(url="https://example.com/api/v1", status_code=200)
         headers = {"x-openai-organization": "org-abc123"}
-        with patch("requests.get", return_value=_mock_resp(200, headers=headers)):
+        with patch("requests.get", return_value=make_response(status=200, headers=headers)):
             results = detect_llm_endpoints([ep])
         assert len(results) == 1
 
-    def test_detects_by_sse_content_type(self):
+    def test_detects_by_sse_content_type(self, make_response):
         ep = Endpoint(url="https://example.com/stream", status_code=200)
         headers = {"content-type": "text/event-stream"}
-        with patch("requests.get", return_value=_mock_resp(200, headers=headers)):
+        with patch("requests.get", return_value=make_response(status=200, headers=headers)):
             results = detect_llm_endpoints([ep])
         assert len(results) == 1
 
-    def test_detects_by_openai_response_json(self):
+    def test_detects_by_openai_response_json(self, make_response):
         ep = Endpoint(url="https://example.com/api", status_code=200)
         body = '{"choices": [{"message": {"content": "hello"}}], "model": "gpt-4"}'
-        with patch("requests.get", return_value=_mock_resp(200, body=body)):
+        with patch("requests.get", return_value=make_response(status=200, body=body)):
             results = detect_llm_endpoints([ep])
         assert len(results) == 1
 
-    def test_detects_by_body_phrase(self):
+    def test_detects_by_body_phrase(self, make_response):
         ep = Endpoint(url="https://example.com/support", status_code=200)
         body = "I'm an AI assistant and I can help you with that."
-        with patch("requests.get", return_value=_mock_resp(200, body=body)):
+        with patch("requests.get", return_value=make_response(status=200, body=body)):
             results = detect_llm_endpoints([ep])
         assert len(results) == 1
 
@@ -76,16 +65,16 @@ class TestDetectLlmEndpoints:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_clean_endpoint_produces_no_result(self):
+    def test_clean_endpoint_produces_no_result(self, make_response):
         ep = Endpoint(url="https://example.com/products", status_code=200)
         body = "<html><body>Product listing</body></html>"
-        with patch("requests.get", return_value=_mock_resp(200, body=body)):
+        with patch("requests.get", return_value=make_response(status=200, body=body)):
             results = detect_llm_endpoints([ep])
         assert results == []
 
-    def test_preserves_existing_technologies(self):
+    def test_preserves_existing_technologies(self, make_response):
         ep = Endpoint(url="https://example.com/chat", status_code=200, technologies=["React"])
-        with patch("requests.get", return_value=_mock_resp(200)):
+        with patch("requests.get", return_value=make_response(status=200)):
             results = detect_llm_endpoints([ep])
         assert "React" in results[0].technologies
         assert "LLM" in results[0].technologies
@@ -102,26 +91,28 @@ class TestDetectLlmEndpoints:
 
 
 class TestCheckPromptInjection:
-    def test_detects_canary_reflection(self):
+    def test_detects_canary_reflection(self, make_response):
         ep = Endpoint(url="https://example.com/chat", status_code=200)
-        with patch("requests.post", return_value=_mock_resp(200, "CYBERSQUADCANARY")):
+        with patch(
+            "requests.post", return_value=make_response(status=200, body="CYBERSQUADCANARY")
+        ):
             results = check_prompt_injection([ep])
         assert len(results) == 1
         assert results[0].vuln_class == "PromptInjection"
         assert results[0].severity_hint == Severity.CRITICAL
 
-    def test_detects_system_prompt_leakage(self):
+    def test_detects_system_prompt_leakage(self, make_response):
         ep = Endpoint(url="https://example.com/chat", status_code=200)
         body = "You are a helpful customer service assistant. Your role is to help users."
-        with patch("requests.post", return_value=_mock_resp(200, body)):
+        with patch("requests.post", return_value=make_response(status=200, body=body)):
             results = check_prompt_injection([ep])
         assert len(results) == 1
         assert results[0].severity_hint == Severity.HIGH
 
-    def test_safe_response_produces_no_finding(self):
+    def test_safe_response_produces_no_finding(self, make_response):
         ep = Endpoint(url="https://example.com/chat", status_code=200)
         body = "I can help you with that! What would you like to know?"
-        with patch("requests.post", return_value=_mock_resp(200, body)):
+        with patch("requests.post", return_value=make_response(status=200, body=body)):
             results = check_prompt_injection([ep])
         assert results == []
 
@@ -138,9 +129,11 @@ class TestCheckPromptInjection:
             results = check_prompt_injection([ep])
         assert results == []
 
-    def test_deduplicates_per_endpoint(self):
+    def test_deduplicates_per_endpoint(self, make_response):
         ep = Endpoint(url="https://example.com/chat", status_code=200)
-        with patch("requests.post", return_value=_mock_resp(200, "CYBERSQUADCANARY")):
+        with patch(
+            "requests.post", return_value=make_response(status=200, body="CYBERSQUADCANARY")
+        ):
             results = check_prompt_injection([ep])
         assert len(results) == 1
 
@@ -154,7 +147,7 @@ class TestCheckPromptInjection:
         assert score == 7.2
         assert "CVSS:3.1" in vector
 
-    def test_payload_filter_restricts_to_named_variants(self):
+    def test_payload_filter_restricts_to_named_variants(self, make_response):
         # Selecting only "override" should fire one payload across all four
         # body formats, not three payloads x four formats.
         ep = Endpoint(url="https://example.com/chat", status_code=200)
@@ -164,7 +157,7 @@ class TestCheckPromptInjection:
         def record(url, **kw):
             body = kw.get("json", {})
             seen_bodies.append(str(body))
-            return _mock_resp(200, "safe response")
+            return make_response(status=200, body="safe response")
 
         with patch("requests.post", side_effect=record):
             check_prompt_injection([ep], payload_names=[PromptPayload.override])
@@ -175,17 +168,19 @@ class TestCheckPromptInjection:
         for body in seen_bodies:
             assert "Ignore all previous instructions" in body
 
-    def test_payload_filter_finding_evidence_names_the_variant(self):
+    def test_payload_filter_finding_evidence_names_the_variant(self, make_response):
         ep = Endpoint(url="https://example.com/chat", status_code=200)
 
-        with patch("requests.post", return_value=_mock_resp(200, "CYBERSQUADCANARY")):
+        with patch(
+            "requests.post", return_value=make_response(status=200, body="CYBERSQUADCANARY")
+        ):
             results = check_prompt_injection([ep], payload_names=[PromptPayload.chat_delimiters])
 
         assert len(results) == 1
         # The token-boundary payload contains <|im_end|>.
         assert "<|im_end|>" in results[0].evidence
 
-    def test_payload_filter_none_runs_all_variants(self):
+    def test_payload_filter_none_runs_all_variants(self, make_response):
         ep = Endpoint(url="https://example.com/chat", status_code=200)
 
         seen_payloads: set[str] = set()
@@ -195,7 +190,7 @@ class TestCheckPromptInjection:
             for name, payload in _INJECTION_PAYLOADS.items():
                 if payload.replace("\n", "\\n") in body_str.replace("\n", "\\n"):
                     seen_payloads.add(name)
-            return _mock_resp(200, "safe")
+            return make_response(status=200, body="safe")
 
         with patch("requests.post", side_effect=record):
             check_prompt_injection([ep], payload_names=None)

--- a/tests/test_prompt_injection.py
+++ b/tests/test_prompt_injection.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from collections.abc import Callable
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -23,35 +24,35 @@ pytestmark = pytest.mark.unit
 
 
 class TestDetectLlmEndpoints:
-    def test_detects_by_url_path_token(self, make_response):
+    def test_detects_by_url_path_token(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://example.com/chat", status_code=200)
         with patch("requests.get", return_value=make_response(status=200)):
             results = detect_llm_endpoints([ep])
         assert len(results) == 1
         assert "LLM" in results[0].technologies
 
-    def test_detects_by_openai_header(self, make_response):
+    def test_detects_by_openai_header(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://example.com/api/v1", status_code=200)
         headers = {"x-openai-organization": "org-abc123"}
         with patch("requests.get", return_value=make_response(status=200, headers=headers)):
             results = detect_llm_endpoints([ep])
         assert len(results) == 1
 
-    def test_detects_by_sse_content_type(self, make_response):
+    def test_detects_by_sse_content_type(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://example.com/stream", status_code=200)
         headers = {"content-type": "text/event-stream"}
         with patch("requests.get", return_value=make_response(status=200, headers=headers)):
             results = detect_llm_endpoints([ep])
         assert len(results) == 1
 
-    def test_detects_by_openai_response_json(self, make_response):
+    def test_detects_by_openai_response_json(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://example.com/api", status_code=200)
         body = '{"choices": [{"message": {"content": "hello"}}], "model": "gpt-4"}'
         with patch("requests.get", return_value=make_response(status=200, body=body)):
             results = detect_llm_endpoints([ep])
         assert len(results) == 1
 
-    def test_detects_by_body_phrase(self, make_response):
+    def test_detects_by_body_phrase(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://example.com/support", status_code=200)
         body = "I'm an AI assistant and I can help you with that."
         with patch("requests.get", return_value=make_response(status=200, body=body)):
@@ -65,14 +66,16 @@ class TestDetectLlmEndpoints:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_clean_endpoint_produces_no_result(self, make_response):
+    def test_clean_endpoint_produces_no_result(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://example.com/products", status_code=200)
         body = "<html><body>Product listing</body></html>"
         with patch("requests.get", return_value=make_response(status=200, body=body)):
             results = detect_llm_endpoints([ep])
         assert results == []
 
-    def test_preserves_existing_technologies(self, make_response):
+    def test_preserves_existing_technologies(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://example.com/chat", status_code=200, technologies=["React"])
         with patch("requests.get", return_value=make_response(status=200)):
             results = detect_llm_endpoints([ep])
@@ -91,7 +94,7 @@ class TestDetectLlmEndpoints:
 
 
 class TestCheckPromptInjection:
-    def test_detects_canary_reflection(self, make_response):
+    def test_detects_canary_reflection(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://example.com/chat", status_code=200)
         with patch(
             "requests.post", return_value=make_response(status=200, body="CYBERSQUADCANARY")
@@ -101,7 +104,7 @@ class TestCheckPromptInjection:
         assert results[0].vuln_class == "PromptInjection"
         assert results[0].severity_hint == Severity.CRITICAL
 
-    def test_detects_system_prompt_leakage(self, make_response):
+    def test_detects_system_prompt_leakage(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://example.com/chat", status_code=200)
         body = "You are a helpful customer service assistant. Your role is to help users."
         with patch("requests.post", return_value=make_response(status=200, body=body)):
@@ -109,7 +112,9 @@ class TestCheckPromptInjection:
         assert len(results) == 1
         assert results[0].severity_hint == Severity.HIGH
 
-    def test_safe_response_produces_no_finding(self, make_response):
+    def test_safe_response_produces_no_finding(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://example.com/chat", status_code=200)
         body = "I can help you with that! What would you like to know?"
         with patch("requests.post", return_value=make_response(status=200, body=body)):
@@ -129,7 +134,7 @@ class TestCheckPromptInjection:
             results = check_prompt_injection([ep])
         assert results == []
 
-    def test_deduplicates_per_endpoint(self, make_response):
+    def test_deduplicates_per_endpoint(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://example.com/chat", status_code=200)
         with patch(
             "requests.post", return_value=make_response(status=200, body="CYBERSQUADCANARY")
@@ -147,14 +152,16 @@ class TestCheckPromptInjection:
         assert score == 7.2
         assert "CVSS:3.1" in vector
 
-    def test_payload_filter_restricts_to_named_variants(self, make_response):
+    def test_payload_filter_restricts_to_named_variants(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Selecting only "override" should fire one payload across all four
         # body formats, not three payloads x four formats.
         ep = Endpoint(url="https://example.com/chat", status_code=200)
 
         seen_bodies: list[str] = []
 
-        def record(url, **kw):
+        def record(url, **kw) -> MagicMock:
             body = kw.get("json", {})
             seen_bodies.append(str(body))
             return make_response(status=200, body="safe response")
@@ -168,7 +175,9 @@ class TestCheckPromptInjection:
         for body in seen_bodies:
             assert "Ignore all previous instructions" in body
 
-    def test_payload_filter_finding_evidence_names_the_variant(self, make_response):
+    def test_payload_filter_finding_evidence_names_the_variant(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://example.com/chat", status_code=200)
 
         with patch(
@@ -180,12 +189,14 @@ class TestCheckPromptInjection:
         # The token-boundary payload contains <|im_end|>.
         assert "<|im_end|>" in results[0].evidence
 
-    def test_payload_filter_none_runs_all_variants(self, make_response):
+    def test_payload_filter_none_runs_all_variants(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://example.com/chat", status_code=200)
 
         seen_payloads: set[str] = set()
 
-        def record(url, **kw):
+        def record(url, **kw) -> MagicMock:
             body_str = str(kw.get("json", {}))
             for name, payload in _INJECTION_PAYLOADS.items():
                 if payload.replace("\n", "\\n") in body_str.replace("\n", "\\n"):

--- a/tests/test_prototype_pollution.py
+++ b/tests/test_prototype_pollution.py
@@ -18,21 +18,14 @@ from tools.pentest.prototype_pollution import (
 pytestmark = pytest.mark.unit
 
 
-def _resp(status: int = 200, body: str = "") -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = status
-    resp.text = body
-    return resp
-
-
 class TestCheckPrototypePollution:
-    def test_detects_canary_in_url_param_get_response(self) -> None:
+    def test_detects_canary_in_url_param_get_response(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/api", status_code=200)
 
         # Baseline GET returns clean body; second GET (URL param probe) reflects canary.
         responses = [
-            _resp(body="normal response"),  # baseline
-            _resp(body=f"response containing {_CANARY}"),  # first URL param vector
+            make_response(body="normal response"),  # baseline
+            make_response(body=f"response containing {_CANARY}"),  # first URL param vector
         ]
         with patch("requests.get", side_effect=responses):
             results = check_prototype_pollution([ep])
@@ -43,12 +36,12 @@ class TestCheckPrototypePollution:
         assert _CANARY in results[0].evidence
         assert "URL parameter" in results[0].evidence
 
-    def test_detects_canary_in_json_post_response(self) -> None:
+    def test_detects_canary_in_json_post_response(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/api", status_code=200)
 
         # All GETs return empty; first POST reflects canary.
-        clean_get = _resp(body="")
-        canary_post = _resp(body=f"echo: {_CANARY}")
+        clean_get = make_response(body="")
+        canary_post = make_response(body=f"echo: {_CANARY}")
 
         def fake_get(url: str, **kw: object) -> MagicMock:
             return clean_get
@@ -67,28 +60,28 @@ class TestCheckPrototypePollution:
         assert _CANARY in results[0].evidence
         assert "JSON body" in results[0].evidence
 
-    def test_no_finding_when_canary_absent_and_no_500(self) -> None:
+    def test_no_finding_when_canary_absent_and_no_500(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/api", status_code=200)
 
         with (
-            patch("requests.get", return_value=_resp(body="nothing here")),
-            patch("requests.post", return_value=_resp(body="still nothing")),
+            patch("requests.get", return_value=make_response(body="nothing here")),
+            patch("requests.post", return_value=make_response(body="still nothing")),
         ):
             results = check_prototype_pollution([ep])
 
         assert results == []
 
-    def test_detects_server_error_after_injection_medium(self) -> None:
+    def test_detects_server_error_after_injection_medium(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/api", status_code=200)
 
-        baseline = _resp(status=200, body="ok")
-        error_resp = _resp(status=500, body="Internal Server Error")
+        baseline = make_response(status=200, body="ok")
+        error_resp = make_response(status=500, body="Internal Server Error")
 
         # Baseline GET is 200; first URL param probe triggers 500.
         responses = [baseline, error_resp]
         with (
             patch("requests.get", side_effect=responses),
-            patch("requests.post", return_value=_resp(body="")),
+            patch("requests.post", return_value=make_response(body="")),
         ):
             results = check_prototype_pollution([ep])
 
@@ -97,19 +90,19 @@ class TestCheckPrototypePollution:
         assert "server error" in results[0].title.lower() or "injection" in results[0].title.lower()
         assert "500" in results[0].evidence
 
-    def test_critical_takes_priority_over_medium(self) -> None:
+    def test_critical_takes_priority_over_medium(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/api", status_code=200)
 
-        baseline = _resp(status=200, body="ok")
+        baseline = make_response(status=200, body="ok")
 
         # First URL param probe gives 500 (would be MEDIUM), but second gives canary (CRITICAL).
-        url_probe_1 = _resp(status=500, body="err")
-        url_probe_2 = _resp(body=f"reflected {_CANARY}")
+        url_probe_1 = make_response(status=500, body="err")
+        url_probe_2 = make_response(body=f"reflected {_CANARY}")
 
         responses = [baseline, url_probe_1, url_probe_2]
         with (
             patch("requests.get", side_effect=responses),
-            patch("requests.post", return_value=_resp(body="")),
+            patch("requests.post", return_value=make_response(body="")),
         ):
             results = check_prototype_pollution([ep])
 
@@ -126,30 +119,30 @@ class TestCheckPrototypePollution:
         mock_post.assert_not_called()
         assert results == []
 
-    def test_deduplicates_same_url(self) -> None:
+    def test_deduplicates_same_url(self, make_response) -> None:
         ep1 = Endpoint(url="https://app.example.com/api", status_code=200)
         ep2 = Endpoint(url="https://app.example.com/api", status_code=200)
 
         responses_get = [
-            _resp(body=""),  # baseline for ep1
-            _resp(body=f"{_CANARY}"),  # first URL probe for ep1 -> CRITICAL
+            make_response(body=""),  # baseline for ep1
+            make_response(body=f"{_CANARY}"),  # first URL probe for ep1 -> CRITICAL
         ]
         with (
             patch("requests.get", side_effect=responses_get),
-            patch("requests.post", return_value=_resp(body="")),
+            patch("requests.post", return_value=make_response(body="")),
         ):
             results = check_prototype_pollution([ep1, ep2])
 
         # ep2 is a duplicate URL; only one finding expected.
         assert len(results) == 1
 
-    def test_multiple_distinct_endpoints_each_get_a_finding(self) -> None:
+    def test_multiple_distinct_endpoints_each_get_a_finding(self, make_response) -> None:
         ep1 = Endpoint(url="https://app.example.com/api/users", status_code=200)
         ep2 = Endpoint(url="https://app.example.com/api/posts", status_code=200)
 
         with (
-            patch("requests.get", return_value=_resp(body=f"{_CANARY}")),
-            patch("requests.post", return_value=_resp(body="")),
+            patch("requests.get", return_value=make_response(body=f"{_CANARY}")),
+            patch("requests.post", return_value=make_response(body="")),
         ):
             results = check_prototype_pollution([ep1, ep2])
 
@@ -183,7 +176,7 @@ class TestCheckPrototypePollution:
         assert "constructor" in serialised
         assert _CANARY in serialised
 
-    def test_payload_filter_restricts_to_json_vector_only(self) -> None:
+    def test_payload_filter_restricts_to_json_vector_only(self, make_response) -> None:
         # Selecting only json-* names should skip the URL GET loop entirely.
         ep = Endpoint(url="https://api.example.com/users", status_code=200)
 
@@ -192,11 +185,11 @@ class TestCheckPrototypePollution:
 
         def record_get(url: str, **_: object) -> MagicMock:
             get_calls.append(url)
-            return _resp(body="baseline")
+            return make_response(body="baseline")
 
         def record_post(url: str, **kw: object) -> MagicMock:
             post_calls.append(kw)
-            return _resp(body="no canary")
+            return make_response(body="no canary")
 
         with (
             patch("requests.get", side_effect=record_get),
@@ -216,7 +209,7 @@ class TestCheckPrototypePollution:
         # Both JSON POSTs fire.
         assert len(post_calls) == 2
 
-    def test_payload_filter_url_only_skips_json(self) -> None:
+    def test_payload_filter_url_only_skips_json(self, make_response) -> None:
         ep = Endpoint(url="https://api.example.com/users", status_code=200)
 
         get_calls: list[str] = []
@@ -224,11 +217,11 @@ class TestCheckPrototypePollution:
 
         def record_get(url: str, **_: object) -> MagicMock:
             get_calls.append(url)
-            return _resp(body="no canary")
+            return make_response(body="no canary")
 
         def record_post(url: str, **kw: object) -> MagicMock:
             post_calls.append(kw)
-            return _resp(body="no canary")
+            return make_response(body="no canary")
 
         with (
             patch("requests.get", side_effect=record_get),
@@ -243,12 +236,12 @@ class TestCheckPrototypePollution:
         assert len(get_calls) == 2
         assert post_calls == []
 
-    def test_payload_filter_finding_evidence_names_the_variant(self) -> None:
+    def test_payload_filter_finding_evidence_names_the_variant(self, make_response) -> None:
         ep = Endpoint(url="https://api.example.com/users", status_code=200)
 
         with (
-            patch("requests.get", return_value=_resp(body=f"reflected {_CANARY}")),
-            patch("requests.post", return_value=_resp(body="")),
+            patch("requests.get", return_value=make_response(body=f"reflected {_CANARY}")),
+            patch("requests.post", return_value=make_response(body="")),
         ):
             results = check_prototype_pollution(
                 [ep],
@@ -258,11 +251,11 @@ class TestCheckPrototypePollution:
         assert len(results) == 1
         assert "proto-dot" in results[0].evidence
 
-    def test_payload_filter_empty_list_is_a_noop(self) -> None:
+    def test_payload_filter_empty_list_is_a_noop(self, make_response) -> None:
         ep = Endpoint(url="https://api.example.com/users", status_code=200)
 
         with (
-            patch("requests.get", return_value=_resp(body="baseline")) as mock_get,
+            patch("requests.get", return_value=make_response(body="baseline")) as mock_get,
             patch("requests.post") as mock_post,
         ):
             results = check_prototype_pollution([ep], payload_names=[])
@@ -272,39 +265,39 @@ class TestCheckPrototypePollution:
         assert mock_get.call_count == 1
         mock_post.assert_not_called()
 
-    def test_endpoint_with_none_status_code_is_probed(self) -> None:
+    def test_endpoint_with_none_status_code_is_probed(self, make_response) -> None:
         # status_code=None means the endpoint was discovered but not yet probed.
         ep = Endpoint(url="https://app.example.com/api", status_code=None)
 
         with (
-            patch("requests.get", return_value=_resp(body=f"{_CANARY}")),
-            patch("requests.post", return_value=_resp(body="")),
+            patch("requests.get", return_value=make_response(body=f"{_CANARY}")),
+            patch("requests.post", return_value=make_response(body="")),
         ):
             results = check_prototype_pollution([ep])
 
         assert len(results) == 1
         assert results[0].severity_hint == Severity.CRITICAL
 
-    def test_endpoint_with_400_status_is_probed(self) -> None:
+    def test_endpoint_with_400_status_is_probed(self, make_response) -> None:
         # Non-5xx error responses should still be probed.
         ep = Endpoint(url="https://app.example.com/api", status_code=400)
 
         with (
-            patch("requests.get", return_value=_resp(body=f"{_CANARY}")),
-            patch("requests.post", return_value=_resp(body="")),
+            patch("requests.get", return_value=make_response(body=f"{_CANARY}")),
+            patch("requests.post", return_value=make_response(body="")),
         ):
             results = check_prototype_pollution([ep])
 
         assert len(results) == 1
 
-    def test_medium_not_emitted_when_baseline_already_500(self) -> None:
+    def test_medium_not_emitted_when_baseline_already_500(self, make_response) -> None:
         # If the baseline itself is 500, a 500 on injection is not evidence.
         ep = Endpoint(url="https://app.example.com/api", status_code=200)
 
         # Baseline returns 500 too, so server was already broken.
         with (
-            patch("requests.get", return_value=_resp(status=500, body="")),
-            patch("requests.post", return_value=_resp(status=500, body="")),
+            patch("requests.get", return_value=make_response(status=500, body="")),
+            patch("requests.post", return_value=make_response(status=500, body="")),
         ):
             results = check_prototype_pollution([ep])
 

--- a/tests/test_prototype_pollution.py
+++ b/tests/test_prototype_pollution.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -43,10 +43,10 @@ class TestCheckPrototypePollution:
         clean_get = make_response(body="")
         canary_post = make_response(body=f"echo: {_CANARY}")
 
-        def fake_get(url: str, **kw: object) -> MagicMock:
+        def fake_get(url: str, **kw: object):
             return clean_get
 
-        def fake_post(url: str, **kw: object) -> MagicMock:
+        def fake_post(url: str, **kw: object):
             return canary_post
 
         with (
@@ -183,11 +183,11 @@ class TestCheckPrototypePollution:
         get_calls: list[str] = []
         post_calls: list[dict] = []
 
-        def record_get(url: str, **_: object) -> MagicMock:
+        def record_get(url: str, **_: object):
             get_calls.append(url)
             return make_response(body="baseline")
 
-        def record_post(url: str, **kw: object) -> MagicMock:
+        def record_post(url: str, **kw: object):
             post_calls.append(kw)
             return make_response(body="no canary")
 
@@ -215,11 +215,11 @@ class TestCheckPrototypePollution:
         get_calls: list[str] = []
         post_calls: list[dict] = []
 
-        def record_get(url: str, **_: object) -> MagicMock:
+        def record_get(url: str, **_: object):
             get_calls.append(url)
             return make_response(body="no canary")
 
-        def record_post(url: str, **kw: object) -> MagicMock:
+        def record_post(url: str, **kw: object):
             post_calls.append(kw)
             return make_response(body="no canary")
 

--- a/tests/test_prototype_pollution.py
+++ b/tests/test_prototype_pollution.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from collections.abc import Callable
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -19,7 +20,9 @@ pytestmark = pytest.mark.unit
 
 
 class TestCheckPrototypePollution:
-    def test_detects_canary_in_url_param_get_response(self, make_response) -> None:
+    def test_detects_canary_in_url_param_get_response(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/api", status_code=200)
 
         # Baseline GET returns clean body; second GET (URL param probe) reflects canary.
@@ -36,7 +39,9 @@ class TestCheckPrototypePollution:
         assert _CANARY in results[0].evidence
         assert "URL parameter" in results[0].evidence
 
-    def test_detects_canary_in_json_post_response(self, make_response) -> None:
+    def test_detects_canary_in_json_post_response(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/api", status_code=200)
 
         # All GETs return empty; first POST reflects canary.
@@ -60,7 +65,9 @@ class TestCheckPrototypePollution:
         assert _CANARY in results[0].evidence
         assert "JSON body" in results[0].evidence
 
-    def test_no_finding_when_canary_absent_and_no_500(self, make_response) -> None:
+    def test_no_finding_when_canary_absent_and_no_500(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/api", status_code=200)
 
         with (
@@ -71,7 +78,9 @@ class TestCheckPrototypePollution:
 
         assert results == []
 
-    def test_detects_server_error_after_injection_medium(self, make_response) -> None:
+    def test_detects_server_error_after_injection_medium(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/api", status_code=200)
 
         baseline = make_response(status=200, body="ok")
@@ -90,7 +99,9 @@ class TestCheckPrototypePollution:
         assert "server error" in results[0].title.lower() or "injection" in results[0].title.lower()
         assert "500" in results[0].evidence
 
-    def test_critical_takes_priority_over_medium(self, make_response) -> None:
+    def test_critical_takes_priority_over_medium(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/api", status_code=200)
 
         baseline = make_response(status=200, body="ok")
@@ -119,7 +130,7 @@ class TestCheckPrototypePollution:
         mock_post.assert_not_called()
         assert results == []
 
-    def test_deduplicates_same_url(self, make_response) -> None:
+    def test_deduplicates_same_url(self, make_response: Callable[..., MagicMock]) -> None:
         ep1 = Endpoint(url="https://app.example.com/api", status_code=200)
         ep2 = Endpoint(url="https://app.example.com/api", status_code=200)
 
@@ -136,7 +147,9 @@ class TestCheckPrototypePollution:
         # ep2 is a duplicate URL; only one finding expected.
         assert len(results) == 1
 
-    def test_multiple_distinct_endpoints_each_get_a_finding(self, make_response) -> None:
+    def test_multiple_distinct_endpoints_each_get_a_finding(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep1 = Endpoint(url="https://app.example.com/api/users", status_code=200)
         ep2 = Endpoint(url="https://app.example.com/api/posts", status_code=200)
 
@@ -176,18 +189,20 @@ class TestCheckPrototypePollution:
         assert "constructor" in serialised
         assert _CANARY in serialised
 
-    def test_payload_filter_restricts_to_json_vector_only(self, make_response) -> None:
+    def test_payload_filter_restricts_to_json_vector_only(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Selecting only json-* names should skip the URL GET loop entirely.
         ep = Endpoint(url="https://api.example.com/users", status_code=200)
 
         get_calls: list[str] = []
         post_calls: list[dict] = []
 
-        def record_get(url: str, **_: object):
+        def record_get(url: str, **_: object) -> MagicMock:
             get_calls.append(url)
             return make_response(body="baseline")
 
-        def record_post(url: str, **kw: object):
+        def record_post(url: str, **kw: object) -> MagicMock:
             post_calls.append(kw)
             return make_response(body="no canary")
 
@@ -209,17 +224,19 @@ class TestCheckPrototypePollution:
         # Both JSON POSTs fire.
         assert len(post_calls) == 2
 
-    def test_payload_filter_url_only_skips_json(self, make_response) -> None:
+    def test_payload_filter_url_only_skips_json(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://api.example.com/users", status_code=200)
 
         get_calls: list[str] = []
         post_calls: list[dict] = []
 
-        def record_get(url: str, **_: object):
+        def record_get(url: str, **_: object) -> MagicMock:
             get_calls.append(url)
             return make_response(body="no canary")
 
-        def record_post(url: str, **kw: object):
+        def record_post(url: str, **kw: object) -> MagicMock:
             post_calls.append(kw)
             return make_response(body="no canary")
 
@@ -236,7 +253,9 @@ class TestCheckPrototypePollution:
         assert len(get_calls) == 2
         assert post_calls == []
 
-    def test_payload_filter_finding_evidence_names_the_variant(self, make_response) -> None:
+    def test_payload_filter_finding_evidence_names_the_variant(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://api.example.com/users", status_code=200)
 
         with (
@@ -251,7 +270,9 @@ class TestCheckPrototypePollution:
         assert len(results) == 1
         assert "proto-dot" in results[0].evidence
 
-    def test_payload_filter_empty_list_is_a_noop(self, make_response) -> None:
+    def test_payload_filter_empty_list_is_a_noop(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://api.example.com/users", status_code=200)
 
         with (
@@ -265,7 +286,9 @@ class TestCheckPrototypePollution:
         assert mock_get.call_count == 1
         mock_post.assert_not_called()
 
-    def test_endpoint_with_none_status_code_is_probed(self, make_response) -> None:
+    def test_endpoint_with_none_status_code_is_probed(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # status_code=None means the endpoint was discovered but not yet probed.
         ep = Endpoint(url="https://app.example.com/api", status_code=None)
 
@@ -278,7 +301,9 @@ class TestCheckPrototypePollution:
         assert len(results) == 1
         assert results[0].severity_hint == Severity.CRITICAL
 
-    def test_endpoint_with_400_status_is_probed(self, make_response) -> None:
+    def test_endpoint_with_400_status_is_probed(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Non-5xx error responses should still be probed.
         ep = Endpoint(url="https://app.example.com/api", status_code=400)
 
@@ -290,7 +315,9 @@ class TestCheckPrototypePollution:
 
         assert len(results) == 1
 
-    def test_medium_not_emitted_when_baseline_already_500(self, make_response) -> None:
+    def test_medium_not_emitted_when_baseline_already_500(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # If the baseline itself is 500, a 500 on injection is not evidence.
         ep = Endpoint(url="https://app.example.com/api", status_code=200)
 

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from collections.abc import Callable
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -13,7 +14,7 @@ pytestmark = pytest.mark.unit
 
 
 class TestCheckSSRF:
-    def test_detects_aws_imds_response(self, make_response) -> None:
+    def test_detects_aws_imds_response(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/fetch", status_code=200, parameters=["url"])
 
         body = "ami-id\nami-launch-index\nhostname\n"
@@ -25,7 +26,9 @@ class TestCheckSSRF:
         assert results[0].severity_hint == Severity.CRITICAL
         assert "url" in results[0].evidence
 
-    def test_no_finding_when_no_marker_in_response(self, make_response) -> None:
+    def test_no_finding_when_no_marker_in_response(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/fetch", status_code=200, parameters=["url"])
 
         with patch("requests.get", return_value=make_response(body="<html>nothing here</html>")):
@@ -59,14 +62,16 @@ class TestCheckSSRF:
         # IPv6 loopback for dual-stack servers.
         assert "[::1]" in joined
 
-    def test_payload_filter_restricts_to_named_variants(self, make_response) -> None:
+    def test_payload_filter_restricts_to_named_variants(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # An agent on a known AWS target should be able to fire only the
         # AWS IMDS payload and skip the two loopback probes.
         ep = Endpoint(url="https://app.example.com/fetch", status_code=200, parameters=["url"])
 
         seen_urls: list[str] = []
 
-        def record(url: str, **_: object):
+        def record(url: str, **_: object) -> MagicMock:
             seen_urls.append(url)
             return make_response(body="no metadata here")
 
@@ -80,7 +85,9 @@ class TestCheckSSRF:
         assert "127.0.0.1" not in joined
         assert "%5B%3A%3A1%5D" not in joined  # urlencoded [::1]
 
-    def test_payload_filter_finding_evidence_names_the_variant(self, make_response) -> None:
+    def test_payload_filter_finding_evidence_names_the_variant(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/fetch", status_code=200, parameters=["url"])
 
         with patch("requests.get", return_value=make_response(body="ami-id")):
@@ -89,12 +96,14 @@ class TestCheckSSRF:
         assert len(results) == 1
         assert "aws-imds" in results[0].evidence
 
-    def test_payload_filter_none_runs_all_variants(self, make_response) -> None:
+    def test_payload_filter_none_runs_all_variants(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/fetch", status_code=200, parameters=["url"])
 
         seen_urls: list[str] = []
 
-        def record(url: str, **_: object):
+        def record(url: str, **_: object) -> MagicMock:
             seen_urls.append(url)
             return make_response(body="clean")
 

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -12,19 +12,12 @@ from tools.pentest.ssrf import _SSRF_PAYLOADS, SsrfPayload, check_ssrf
 pytestmark = pytest.mark.unit
 
 
-def _resp(status: int = 200, body: str = "") -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = status
-    resp.text = body
-    return resp
-
-
 class TestCheckSSRF:
-    def test_detects_aws_imds_response(self) -> None:
+    def test_detects_aws_imds_response(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/fetch", status_code=200, parameters=["url"])
 
         body = "ami-id\nami-launch-index\nhostname\n"
-        with patch("requests.get", return_value=_resp(body=body)):
+        with patch("requests.get", return_value=make_response(body=body)):
             results = check_ssrf([ep])
 
         assert len(results) == 1
@@ -32,10 +25,10 @@ class TestCheckSSRF:
         assert results[0].severity_hint == Severity.CRITICAL
         assert "url" in results[0].evidence
 
-    def test_no_finding_when_no_marker_in_response(self) -> None:
+    def test_no_finding_when_no_marker_in_response(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/fetch", status_code=200, parameters=["url"])
 
-        with patch("requests.get", return_value=_resp(body="<html>nothing here</html>")):
+        with patch("requests.get", return_value=make_response(body="<html>nothing here</html>")):
             results = check_ssrf([ep])
 
         assert results == []
@@ -66,7 +59,7 @@ class TestCheckSSRF:
         # IPv6 loopback for dual-stack servers.
         assert "[::1]" in joined
 
-    def test_payload_filter_restricts_to_named_variants(self) -> None:
+    def test_payload_filter_restricts_to_named_variants(self, make_response) -> None:
         # An agent on a known AWS target should be able to fire only the
         # AWS IMDS payload and skip the two loopback probes.
         ep = Endpoint(url="https://app.example.com/fetch", status_code=200, parameters=["url"])
@@ -75,7 +68,7 @@ class TestCheckSSRF:
 
         def record(url: str, **_: object) -> MagicMock:
             seen_urls.append(url)
-            return _resp(body="no metadata here")
+            return make_response(body="no metadata here")
 
         with patch("requests.get", side_effect=record):
             check_ssrf([ep], payload_names=[SsrfPayload.aws_imds])
@@ -87,23 +80,23 @@ class TestCheckSSRF:
         assert "127.0.0.1" not in joined
         assert "%5B%3A%3A1%5D" not in joined  # urlencoded [::1]
 
-    def test_payload_filter_finding_evidence_names_the_variant(self) -> None:
+    def test_payload_filter_finding_evidence_names_the_variant(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/fetch", status_code=200, parameters=["url"])
 
-        with patch("requests.get", return_value=_resp(body="ami-id")):
+        with patch("requests.get", return_value=make_response(body="ami-id")):
             results = check_ssrf([ep], payload_names=[SsrfPayload.aws_imds])
 
         assert len(results) == 1
         assert "aws-imds" in results[0].evidence
 
-    def test_payload_filter_none_runs_all_variants(self) -> None:
+    def test_payload_filter_none_runs_all_variants(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/fetch", status_code=200, parameters=["url"])
 
         seen_urls: list[str] = []
 
         def record(url: str, **_: object) -> MagicMock:
             seen_urls.append(url)
-            return _resp(body="clean")
+            return make_response(body="clean")
 
         with patch("requests.get", side_effect=record):
             check_ssrf([ep], payload_names=None)

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -66,7 +66,7 @@ class TestCheckSSRF:
 
         seen_urls: list[str] = []
 
-        def record(url: str, **_: object) -> MagicMock:
+        def record(url: str, **_: object):
             seen_urls.append(url)
             return make_response(body="no metadata here")
 
@@ -94,7 +94,7 @@ class TestCheckSSRF:
 
         seen_urls: list[str] = []
 
-        def record(url: str, **_: object) -> MagicMock:
+        def record(url: str, **_: object):
             seen_urls.append(url)
             return make_response(body="clean")
 

--- a/tests/test_ssti.py
+++ b/tests/test_ssti.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -16,7 +16,7 @@ class TestCheckSSTI:
     def test_detects_jinja_style_evaluation(self, make_response):
         ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
 
-        def echo(url: str) -> MagicMock:
+        def echo(url: str):
             payload = url.split("=", 1)[1] if "=" in url else ""
             return make_response(body=f"<html>Echo: {payload}</html>")
 
@@ -40,7 +40,7 @@ class TestCheckSSTI:
     def test_detects_dollar_brace_engine(self, make_response):
         ep = Endpoint(url="https://app.example.com/render", status_code=200, parameters=["tpl"])
 
-        def echo(url: str) -> MagicMock:
+        def echo(url: str):
             payload = url.split("=", 1)[1] if "=" in url else ""
             return make_response(body=f"<html>Echo: {payload}</html>")
 
@@ -62,7 +62,7 @@ class TestCheckSSTI:
         # Twig {{x+y}} form which Liquid would render literally).
         ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
 
-        def echo(url: str) -> MagicMock:
+        def echo(url: str):
             payload = url.split("=", 1)[1] if "=" in url else ""
             return make_response(body=f"<html>Echo: {payload}</html>")
 
@@ -84,7 +84,7 @@ class TestCheckSSTI:
         # addition. Only fire when the Django payload signature shows up.
         ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
 
-        def echo(url: str) -> MagicMock:
+        def echo(url: str):
             payload = url.split("=", 1)[1] if "=" in url else ""
             return make_response(body=f"<html>Echo: {payload}</html>")
 
@@ -215,7 +215,7 @@ class TestCheckSSTI:
         # carry the verbose engine label so reports name what was probed.
         ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
 
-        def echo(url: str) -> MagicMock:
+        def echo(url: str):
             payload = url.split("=", 1)[1] if "=" in url else ""
             return make_response(body=f"<html>Echo: {payload}</html>")
 

--- a/tests/test_ssti.py
+++ b/tests/test_ssti.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from collections.abc import Callable
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -13,14 +14,14 @@ pytestmark = pytest.mark.unit
 
 
 class TestCheckSSTI:
-    def test_detects_jinja_style_evaluation(self, make_response):
+    def test_detects_jinja_style_evaluation(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
 
-        def echo(url: str):
+        def echo(url: str) -> MagicMock:
             payload = url.split("=", 1)[1] if "=" in url else ""
             return make_response(body=f"<html>Echo: {payload}</html>")
 
-        def fake_get(url, **kwargs):
+        def fake_get(url, **kwargs) -> MagicMock:
             # Server evaluates {{x+y}} - Jinja2/Twig path. The Jinja2 probe
             # is first in the iteration order so it wins before any other
             # {{...}} payload (Liquid, Django) is even sent.
@@ -37,14 +38,14 @@ class TestCheckSSTI:
         assert _EXPECTED in results[0].evidence
         assert "Jinja2" in results[0].evidence
 
-    def test_detects_dollar_brace_engine(self, make_response):
+    def test_detects_dollar_brace_engine(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/render", status_code=200, parameters=["tpl"])
 
-        def echo(url: str):
+        def echo(url: str) -> MagicMock:
             payload = url.split("=", 1)[1] if "=" in url else ""
             return make_response(body=f"<html>Echo: {payload}</html>")
 
-        def fake_get(url, **kwargs):
+        def fake_get(url, **kwargs) -> MagicMock:
             # Only Mako-style ${...} triggers; everything else is echoed.
             if "${" in url:
                 return make_response(body=f"Result: {_EXPECTED}")
@@ -56,17 +57,17 @@ class TestCheckSSTI:
         assert len(results) == 1
         assert "Mako" in results[0].evidence or "FreeMarker" in results[0].evidence
 
-    def test_detects_liquid_plus_filter(self, make_response):
+    def test_detects_liquid_plus_filter(self, make_response: Callable[..., MagicMock]) -> None:
         # Liquid has no infix arithmetic - it can only do `{{ x | plus: y }}`.
         # The probe must fire on that signature specifically (not the Jinja2/
         # Twig {{x+y}} form which Liquid would render literally).
         ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
 
-        def echo(url: str):
+        def echo(url: str) -> MagicMock:
             payload = url.split("=", 1)[1] if "=" in url else ""
             return make_response(body=f"<html>Echo: {payload}</html>")
 
-        def fake_get(url, **kwargs):
+        def fake_get(url, **kwargs) -> MagicMock:
             if "| plus:" in url:
                 return make_response(body=f"<html>Total: {_EXPECTED}</html>")
             return echo(url)
@@ -78,17 +79,17 @@ class TestCheckSSTI:
         assert "Liquid" in results[0].evidence
         assert _EXPECTED in results[0].evidence
 
-    def test_detects_django_add_filter(self, make_response):
+    def test_detects_django_add_filter(self, make_response: Callable[..., MagicMock]) -> None:
         # Django does not evaluate raw arithmetic in {{ }} but it does
         # evaluate its built-in filter chain - the |add: filter does integer
         # addition. Only fire when the Django payload signature shows up.
         ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
 
-        def echo(url: str):
+        def echo(url: str) -> MagicMock:
             payload = url.split("=", 1)[1] if "=" in url else ""
             return make_response(body=f"<html>Echo: {payload}</html>")
 
-        def fake_get(url, **kwargs):
+        def fake_get(url, **kwargs) -> MagicMock:
             if "|add:" in url:
                 return make_response(body=f"<html>Total: {_EXPECTED}</html>")
             return echo(url)
@@ -100,13 +101,15 @@ class TestCheckSSTI:
         assert "Django" in results[0].evidence
         assert _EXPECTED in results[0].evidence
 
-    def test_no_finding_when_input_is_echoed_literally(self, make_response):
+    def test_no_finding_when_input_is_echoed_literally(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Page reflects the raw payload (input echo) but does not evaluate it.
         # The literal-absence guard must suppress detection even when the
         # expected sum happens to appear somewhere unrelated on the page.
         ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
 
-        def fake_get(url, **kwargs):
+        def fake_get(url, **kwargs) -> MagicMock:
             payload = url.split("name=", 1)[1]
             return make_response(body=f"<html>You said: {payload}. Total {_EXPECTED}.</html>")
 
@@ -115,10 +118,10 @@ class TestCheckSSTI:
 
         assert results == []
 
-    def test_no_finding_when_expected_absent(self, make_response):
+    def test_no_finding_when_expected_absent(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
 
-        def fake_get(url, **kwargs):
+        def fake_get(url, **kwargs) -> MagicMock:
             return make_response(body="<html>Hello world</html>")
 
         with patch("requests.get", side_effect=fake_get):
@@ -140,14 +143,14 @@ class TestCheckSSTI:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_one_finding_per_endpoint(self, make_response):
+    def test_one_finding_per_endpoint(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(
             url="https://app.example.com/preview",
             status_code=200,
             parameters=["name", "title"],
         )
 
-        def fake_get(url, **kwargs):
+        def fake_get(url, **kwargs) -> MagicMock:
             return make_response(body=f"Hello {_EXPECTED}!")
 
         with patch("requests.get", side_effect=fake_get) as mock_get:
@@ -191,14 +194,16 @@ class TestCheckSSTI:
         assert any("| plus:" in p for p in payloads)
         assert any("|add:" in p for p in payloads)
 
-    def test_payload_filter_restricts_to_named_engines(self, make_response):
+    def test_payload_filter_restricts_to_named_engines(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # When the agent knows the stack is Jinja2 it should only fire that
         # one probe - five other engine probes must be skipped.
         ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
 
         seen_urls: list[str] = []
 
-        def record(url, **_):
+        def record(url, **_) -> MagicMock:
             seen_urls.append(url)
             return make_response(body="<html>no eval</html>")
 
@@ -210,16 +215,18 @@ class TestCheckSSTI:
         joined = " ".join(seen_urls)
         assert "%7B%7B" in joined or "{{" in joined
 
-    def test_payload_filter_finding_uses_engine_label_in_evidence(self, make_response):
+    def test_payload_filter_finding_uses_engine_label_in_evidence(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # The agent picked "django" by name; the finding evidence must still
         # carry the verbose engine label so reports name what was probed.
         ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
 
-        def echo(url: str):
+        def echo(url: str) -> MagicMock:
             payload = url.split("=", 1)[1] if "=" in url else ""
             return make_response(body=f"<html>Echo: {payload}</html>")
 
-        def fake_get(url, **_):
+        def fake_get(url, **_) -> MagicMock:
             if "|add:" in url:
                 return make_response(body=f"<html>Total: {_EXPECTED}</html>")
             return echo(url)

--- a/tests/test_ssti.py
+++ b/tests/test_ssti.py
@@ -12,32 +12,21 @@ from tools.pentest.ssti import _EXPECTED, _PROBES, SstiPayload, check_ssti
 pytestmark = pytest.mark.unit
 
 
-def _resp(status: int = 200, body: str = "") -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = status
-    resp.text = body
-    return resp
-
-
-def _echo(url: str) -> MagicMock:
-    """Echo the URL parameter back literally - simulates naive reflection
-    where no template engine is involved. Triggers the literal-absence
-    guard so no probe should fire against this response."""
-    payload = url.split("=", 1)[1] if "=" in url else ""
-    return _resp(body=f"<html>Echo: {payload}</html>")
-
-
 class TestCheckSSTI:
-    def test_detects_jinja_style_evaluation(self):
+    def test_detects_jinja_style_evaluation(self, make_response):
         ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
+
+        def echo(url: str) -> MagicMock:
+            payload = url.split("=", 1)[1] if "=" in url else ""
+            return make_response(body=f"<html>Echo: {payload}</html>")
 
         def fake_get(url, **kwargs):
             # Server evaluates {{x+y}} - Jinja2/Twig path. The Jinja2 probe
             # is first in the iteration order so it wins before any other
             # {{...}} payload (Liquid, Django) is even sent.
             if "{{" in url and "+" in url:
-                return _resp(body=f"<html>Hello {_EXPECTED}</html>")
-            return _echo(url)
+                return make_response(body=f"<html>Hello {_EXPECTED}</html>")
+            return echo(url)
 
         with patch("requests.get", side_effect=fake_get):
             results = check_ssti([ep])
@@ -48,14 +37,18 @@ class TestCheckSSTI:
         assert _EXPECTED in results[0].evidence
         assert "Jinja2" in results[0].evidence
 
-    def test_detects_dollar_brace_engine(self):
+    def test_detects_dollar_brace_engine(self, make_response):
         ep = Endpoint(url="https://app.example.com/render", status_code=200, parameters=["tpl"])
+
+        def echo(url: str) -> MagicMock:
+            payload = url.split("=", 1)[1] if "=" in url else ""
+            return make_response(body=f"<html>Echo: {payload}</html>")
 
         def fake_get(url, **kwargs):
             # Only Mako-style ${...} triggers; everything else is echoed.
             if "${" in url:
-                return _resp(body=f"Result: {_EXPECTED}")
-            return _echo(url)
+                return make_response(body=f"Result: {_EXPECTED}")
+            return echo(url)
 
         with patch("requests.get", side_effect=fake_get):
             results = check_ssti([ep])
@@ -63,16 +56,20 @@ class TestCheckSSTI:
         assert len(results) == 1
         assert "Mako" in results[0].evidence or "FreeMarker" in results[0].evidence
 
-    def test_detects_liquid_plus_filter(self):
+    def test_detects_liquid_plus_filter(self, make_response):
         # Liquid has no infix arithmetic - it can only do `{{ x | plus: y }}`.
         # The probe must fire on that signature specifically (not the Jinja2/
         # Twig {{x+y}} form which Liquid would render literally).
         ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
 
+        def echo(url: str) -> MagicMock:
+            payload = url.split("=", 1)[1] if "=" in url else ""
+            return make_response(body=f"<html>Echo: {payload}</html>")
+
         def fake_get(url, **kwargs):
             if "| plus:" in url:
-                return _resp(body=f"<html>Total: {_EXPECTED}</html>")
-            return _echo(url)
+                return make_response(body=f"<html>Total: {_EXPECTED}</html>")
+            return echo(url)
 
         with patch("requests.get", side_effect=fake_get):
             results = check_ssti([ep])
@@ -81,16 +78,20 @@ class TestCheckSSTI:
         assert "Liquid" in results[0].evidence
         assert _EXPECTED in results[0].evidence
 
-    def test_detects_django_add_filter(self):
+    def test_detects_django_add_filter(self, make_response):
         # Django does not evaluate raw arithmetic in {{ }} but it does
         # evaluate its built-in filter chain - the |add: filter does integer
         # addition. Only fire when the Django payload signature shows up.
         ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
 
+        def echo(url: str) -> MagicMock:
+            payload = url.split("=", 1)[1] if "=" in url else ""
+            return make_response(body=f"<html>Echo: {payload}</html>")
+
         def fake_get(url, **kwargs):
             if "|add:" in url:
-                return _resp(body=f"<html>Total: {_EXPECTED}</html>")
-            return _echo(url)
+                return make_response(body=f"<html>Total: {_EXPECTED}</html>")
+            return echo(url)
 
         with patch("requests.get", side_effect=fake_get):
             results = check_ssti([ep])
@@ -99,7 +100,7 @@ class TestCheckSSTI:
         assert "Django" in results[0].evidence
         assert _EXPECTED in results[0].evidence
 
-    def test_no_finding_when_input_is_echoed_literally(self):
+    def test_no_finding_when_input_is_echoed_literally(self, make_response):
         # Page reflects the raw payload (input echo) but does not evaluate it.
         # The literal-absence guard must suppress detection even when the
         # expected sum happens to appear somewhere unrelated on the page.
@@ -107,18 +108,18 @@ class TestCheckSSTI:
 
         def fake_get(url, **kwargs):
             payload = url.split("name=", 1)[1]
-            return _resp(body=f"<html>You said: {payload}. Total {_EXPECTED}.</html>")
+            return make_response(body=f"<html>You said: {payload}. Total {_EXPECTED}.</html>")
 
         with patch("requests.get", side_effect=fake_get):
             results = check_ssti([ep])
 
         assert results == []
 
-    def test_no_finding_when_expected_absent(self):
+    def test_no_finding_when_expected_absent(self, make_response):
         ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
 
         def fake_get(url, **kwargs):
-            return _resp(body="<html>Hello world</html>")
+            return make_response(body="<html>Hello world</html>")
 
         with patch("requests.get", side_effect=fake_get):
             results = check_ssti([ep])
@@ -139,7 +140,7 @@ class TestCheckSSTI:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_one_finding_per_endpoint(self):
+    def test_one_finding_per_endpoint(self, make_response):
         ep = Endpoint(
             url="https://app.example.com/preview",
             status_code=200,
@@ -147,7 +148,7 @@ class TestCheckSSTI:
         )
 
         def fake_get(url, **kwargs):
-            return _resp(body=f"Hello {_EXPECTED}!")
+            return make_response(body=f"Hello {_EXPECTED}!")
 
         with patch("requests.get", side_effect=fake_get) as mock_get:
             results = check_ssti([ep])
@@ -190,7 +191,7 @@ class TestCheckSSTI:
         assert any("| plus:" in p for p in payloads)
         assert any("|add:" in p for p in payloads)
 
-    def test_payload_filter_restricts_to_named_engines(self):
+    def test_payload_filter_restricts_to_named_engines(self, make_response):
         # When the agent knows the stack is Jinja2 it should only fire that
         # one probe - five other engine probes must be skipped.
         ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
@@ -199,7 +200,7 @@ class TestCheckSSTI:
 
         def record(url, **_):
             seen_urls.append(url)
-            return _resp(body="<html>no eval</html>")
+            return make_response(body="<html>no eval</html>")
 
         with patch("requests.get", side_effect=record):
             check_ssti([ep], payload_names=[SstiPayload.jinja2])
@@ -209,15 +210,19 @@ class TestCheckSSTI:
         joined = " ".join(seen_urls)
         assert "%7B%7B" in joined or "{{" in joined
 
-    def test_payload_filter_finding_uses_engine_label_in_evidence(self):
+    def test_payload_filter_finding_uses_engine_label_in_evidence(self, make_response):
         # The agent picked "django" by name; the finding evidence must still
         # carry the verbose engine label so reports name what was probed.
         ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
 
+        def echo(url: str) -> MagicMock:
+            payload = url.split("=", 1)[1] if "=" in url else ""
+            return make_response(body=f"<html>Echo: {payload}</html>")
+
         def fake_get(url, **_):
             if "|add:" in url:
-                return _resp(body=f"<html>Total: {_EXPECTED}</html>")
-            return _echo(url)
+                return make_response(body=f"<html>Total: {_EXPECTED}</html>")
+            return echo(url)
 
         with patch("requests.get", side_effect=fake_get):
             results = check_ssti([ep], payload_names=[SstiPayload.django])

--- a/tests/test_xxe.py
+++ b/tests/test_xxe.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from collections.abc import Callable
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -21,7 +22,9 @@ pytestmark = pytest.mark.unit
 
 
 class TestCheckXXE:
-    def test_detects_linux_file_read_critical(self, make_response) -> None:
+    def test_detects_linux_file_read_critical(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/soap", status_code=200)
 
         with patch("requests.post", return_value=make_response(body=f"data: {_LINUX_MARKER} more")):
@@ -32,10 +35,12 @@ class TestCheckXXE:
         assert results[0].severity_hint == Severity.CRITICAL
         assert _LINUX_MARKER in results[0].evidence
 
-    def test_detects_windows_file_read_critical(self, make_response) -> None:
+    def test_detects_windows_file_read_critical(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/xml", status_code=200)
 
-        def fake_post(url: str, **kw: object):
+        def fake_post(url: str, **kw: object) -> MagicMock:
             body = kw.get("data", "")
             if "Windows" in str(body):
                 return make_response(body=f"result {_WIN_MARKER} end")
@@ -48,10 +53,10 @@ class TestCheckXXE:
         assert results[0].severity_hint == Severity.CRITICAL
         assert _WIN_MARKER in results[0].evidence
 
-    def test_detects_xml_parser_error_medium(self, make_response) -> None:
+    def test_detects_xml_parser_error_medium(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/api", status_code=200)
 
-        def fake_post(url: str, **kw: object):
+        def fake_post(url: str, **kw: object) -> MagicMock:
             body = str(kw.get("data", ""))
             # Only the error probe (undefined entity) triggers a parser error.
             if "cybersquad_xxe_probe" in body:
@@ -65,7 +70,9 @@ class TestCheckXXE:
         assert results[0].severity_hint == Severity.MEDIUM
         assert "SAXParseException" in results[0].evidence
 
-    def test_file_read_takes_priority_over_error(self, make_response) -> None:
+    def test_file_read_takes_priority_over_error(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Both file marker and XML error present - CRITICAL should win because
         # file-read probes are tried first and stop before error probes run.
         ep = Endpoint(url="https://app.example.com/soap", status_code=200)
@@ -77,7 +84,7 @@ class TestCheckXXE:
         assert len(results) == 1
         assert results[0].severity_hint == Severity.CRITICAL
 
-    def test_no_finding_on_clean_response(self, make_response) -> None:
+    def test_no_finding_on_clean_response(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/api", status_code=200)
 
         with patch("requests.post", return_value=make_response(body="<response>ok</response>")):
@@ -94,7 +101,9 @@ class TestCheckXXE:
         mock_post.assert_not_called()
         assert results == []
 
-    def test_endpoint_without_status_code_is_probed(self, make_response) -> None:
+    def test_endpoint_without_status_code_is_probed(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # status_code=None means recon didn't record it - still worth trying.
         ep = Endpoint(url="https://app.example.com/soap")
 
@@ -103,7 +112,7 @@ class TestCheckXXE:
 
         assert len(results) == 1
 
-    def test_one_finding_per_endpoint(self, make_response) -> None:
+    def test_one_finding_per_endpoint(self, make_response: Callable[..., MagicMock]) -> None:
         # Even though multiple probes would match, we stop at the first.
         ep = Endpoint(url="https://app.example.com/soap", status_code=200)
 
@@ -112,7 +121,7 @@ class TestCheckXXE:
 
         assert len(results) == 1
 
-    def test_deduplicates_same_url(self, make_response) -> None:
+    def test_deduplicates_same_url(self, make_response: Callable[..., MagicMock]) -> None:
         ep1 = Endpoint(url="https://app.example.com/soap", status_code=200)
         ep2 = Endpoint(url="https://app.example.com/soap", status_code=200)
 
@@ -121,7 +130,9 @@ class TestCheckXXE:
 
         assert len(results) == 1
 
-    def test_multiple_distinct_endpoints_each_get_a_finding(self, make_response) -> None:
+    def test_multiple_distinct_endpoints_each_get_a_finding(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep1 = Endpoint(url="https://app.example.com/soap", status_code=200)
         ep2 = Endpoint(url="https://app.example.com/xml-api", status_code=200)
 
@@ -165,14 +176,16 @@ class TestCheckXXE:
         assert "undefined entity" in joined
         assert "expat" in joined
 
-    def test_payload_filter_restricts_to_named_probes(self, make_response) -> None:
+    def test_payload_filter_restricts_to_named_probes(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # Restricting to only linux-* probes must skip every windows-* probe
         # and every error-* probe.
         ep = Endpoint(url="https://app.example.com/api", status_code=200)
 
         seen_bodies: list[str] = []
 
-        def record(url: str, **kw: object):
+        def record(url: str, **kw: object) -> MagicMock:
             seen_bodies.append(str(kw.get("data", "")))
             return make_response(body="clean")
 
@@ -192,7 +205,9 @@ class TestCheckXXE:
         # No error-only probes (those use a separate body shape).
         assert "cybersquad_xxe_probe" not in joined
 
-    def test_payload_filter_only_error_probes_runs_just_error_tier(self, make_response) -> None:
+    def test_payload_filter_only_error_probes_runs_just_error_tier(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         # The Tier 1 file-read loop only fires if any active file-read probe
         # exists. Restricting to error-* names should skip Tier 1 entirely
         # and go straight to the parser-error probes - exactly what an agent
@@ -201,7 +216,7 @@ class TestCheckXXE:
 
         seen_bodies: list[str] = []
 
-        def record(url: str, **kw: object):
+        def record(url: str, **kw: object) -> MagicMock:
             seen_bodies.append(str(kw.get("data", "")))
             return make_response(body="SAXParseException: undefined entity")
 
@@ -214,7 +229,9 @@ class TestCheckXXE:
         assert len(results) == 1
         assert results[0].severity_hint == Severity.MEDIUM
 
-    def test_payload_filter_finding_evidence_names_the_probe(self, make_response) -> None:
+    def test_payload_filter_finding_evidence_names_the_probe(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/api", status_code=200)
 
         with patch("requests.post", return_value=make_response(body=_LINUX_MARKER)):

--- a/tests/test_xxe.py
+++ b/tests/test_xxe.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -20,18 +20,11 @@ from tools.pentest.xxe import (
 pytestmark = pytest.mark.unit
 
 
-def _resp(status: int = 200, body: str = "") -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = status
-    resp.text = body
-    return resp
-
-
 class TestCheckXXE:
-    def test_detects_linux_file_read_critical(self) -> None:
+    def test_detects_linux_file_read_critical(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/soap", status_code=200)
 
-        with patch("requests.post", return_value=_resp(body=f"data: {_LINUX_MARKER} more")):
+        with patch("requests.post", return_value=make_response(body=f"data: {_LINUX_MARKER} more")):
             results = check_xxe([ep])
 
         assert len(results) == 1
@@ -39,14 +32,14 @@ class TestCheckXXE:
         assert results[0].severity_hint == Severity.CRITICAL
         assert _LINUX_MARKER in results[0].evidence
 
-    def test_detects_windows_file_read_critical(self) -> None:
+    def test_detects_windows_file_read_critical(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/xml", status_code=200)
 
-        def fake_post(url: str, **kw: object) -> MagicMock:
+        def fake_post(url: str, **kw: object):
             body = kw.get("data", "")
             if "Windows" in str(body):
-                return _resp(body=f"result {_WIN_MARKER} end")
-            return _resp(body="")
+                return make_response(body=f"result {_WIN_MARKER} end")
+            return make_response(body="")
 
         with patch("requests.post", side_effect=fake_post):
             results = check_xxe([ep])
@@ -55,15 +48,15 @@ class TestCheckXXE:
         assert results[0].severity_hint == Severity.CRITICAL
         assert _WIN_MARKER in results[0].evidence
 
-    def test_detects_xml_parser_error_medium(self) -> None:
+    def test_detects_xml_parser_error_medium(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/api", status_code=200)
 
-        def fake_post(url: str, **kw: object) -> MagicMock:
+        def fake_post(url: str, **kw: object):
             body = str(kw.get("data", ""))
             # Only the error probe (undefined entity) triggers a parser error.
             if "cybersquad_xxe_probe" in body:
-                return _resp(body="SAXParseException: undefined entity at line 1")
-            return _resp(body="")
+                return make_response(body="SAXParseException: undefined entity at line 1")
+            return make_response(body="")
 
         with patch("requests.post", side_effect=fake_post):
             results = check_xxe([ep])
@@ -72,22 +65,22 @@ class TestCheckXXE:
         assert results[0].severity_hint == Severity.MEDIUM
         assert "SAXParseException" in results[0].evidence
 
-    def test_file_read_takes_priority_over_error(self) -> None:
+    def test_file_read_takes_priority_over_error(self, make_response) -> None:
         # Both file marker and XML error present - CRITICAL should win because
         # file-read probes are tried first and stop before error probes run.
         ep = Endpoint(url="https://app.example.com/soap", status_code=200)
         body = f"{_LINUX_MARKER}\nSAXParseException: something"
 
-        with patch("requests.post", return_value=_resp(body=body)):
+        with patch("requests.post", return_value=make_response(body=body)):
             results = check_xxe([ep])
 
         assert len(results) == 1
         assert results[0].severity_hint == Severity.CRITICAL
 
-    def test_no_finding_on_clean_response(self) -> None:
+    def test_no_finding_on_clean_response(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/api", status_code=200)
 
-        with patch("requests.post", return_value=_resp(body="<response>ok</response>")):
+        with patch("requests.post", return_value=make_response(body="<response>ok</response>")):
             results = check_xxe([ep])
 
         assert results == []
@@ -101,38 +94,38 @@ class TestCheckXXE:
         mock_post.assert_not_called()
         assert results == []
 
-    def test_endpoint_without_status_code_is_probed(self) -> None:
+    def test_endpoint_without_status_code_is_probed(self, make_response) -> None:
         # status_code=None means recon didn't record it - still worth trying.
         ep = Endpoint(url="https://app.example.com/soap")
 
-        with patch("requests.post", return_value=_resp(body=_LINUX_MARKER)):
+        with patch("requests.post", return_value=make_response(body=_LINUX_MARKER)):
             results = check_xxe([ep])
 
         assert len(results) == 1
 
-    def test_one_finding_per_endpoint(self) -> None:
+    def test_one_finding_per_endpoint(self, make_response) -> None:
         # Even though multiple probes would match, we stop at the first.
         ep = Endpoint(url="https://app.example.com/soap", status_code=200)
 
-        with patch("requests.post", return_value=_resp(body=_LINUX_MARKER)):
+        with patch("requests.post", return_value=make_response(body=_LINUX_MARKER)):
             results = check_xxe([ep])
 
         assert len(results) == 1
 
-    def test_deduplicates_same_url(self) -> None:
+    def test_deduplicates_same_url(self, make_response) -> None:
         ep1 = Endpoint(url="https://app.example.com/soap", status_code=200)
         ep2 = Endpoint(url="https://app.example.com/soap", status_code=200)
 
-        with patch("requests.post", return_value=_resp(body=_LINUX_MARKER)):
+        with patch("requests.post", return_value=make_response(body=_LINUX_MARKER)):
             results = check_xxe([ep1, ep2])
 
         assert len(results) == 1
 
-    def test_multiple_distinct_endpoints_each_get_a_finding(self) -> None:
+    def test_multiple_distinct_endpoints_each_get_a_finding(self, make_response) -> None:
         ep1 = Endpoint(url="https://app.example.com/soap", status_code=200)
         ep2 = Endpoint(url="https://app.example.com/xml-api", status_code=200)
 
-        with patch("requests.post", return_value=_resp(body=_LINUX_MARKER)):
+        with patch("requests.post", return_value=make_response(body=_LINUX_MARKER)):
             results = check_xxe([ep1, ep2])
 
         assert len(results) == 2
@@ -172,16 +165,16 @@ class TestCheckXXE:
         assert "undefined entity" in joined
         assert "expat" in joined
 
-    def test_payload_filter_restricts_to_named_probes(self) -> None:
+    def test_payload_filter_restricts_to_named_probes(self, make_response) -> None:
         # Restricting to only linux-* probes must skip every windows-* probe
         # and every error-* probe.
         ep = Endpoint(url="https://app.example.com/api", status_code=200)
 
         seen_bodies: list[str] = []
 
-        def record(url: str, **kw: object) -> MagicMock:
+        def record(url: str, **kw: object):
             seen_bodies.append(str(kw.get("data", "")))
-            return _resp(body="clean")
+            return make_response(body="clean")
 
         with patch("requests.post", side_effect=record):
             check_xxe(
@@ -199,7 +192,7 @@ class TestCheckXXE:
         # No error-only probes (those use a separate body shape).
         assert "cybersquad_xxe_probe" not in joined
 
-    def test_payload_filter_only_error_probes_runs_just_error_tier(self) -> None:
+    def test_payload_filter_only_error_probes_runs_just_error_tier(self, make_response) -> None:
         # The Tier 1 file-read loop only fires if any active file-read probe
         # exists. Restricting to error-* names should skip Tier 1 entirely
         # and go straight to the parser-error probes - exactly what an agent
@@ -208,9 +201,9 @@ class TestCheckXXE:
 
         seen_bodies: list[str] = []
 
-        def record(url: str, **kw: object) -> MagicMock:
+        def record(url: str, **kw: object):
             seen_bodies.append(str(kw.get("data", "")))
-            return _resp(body="SAXParseException: undefined entity")
+            return make_response(body="SAXParseException: undefined entity")
 
         with patch("requests.post", side_effect=record):
             results = check_xxe([ep], payload_names=[XxePayload.error_generic])
@@ -221,10 +214,10 @@ class TestCheckXXE:
         assert len(results) == 1
         assert results[0].severity_hint == Severity.MEDIUM
 
-    def test_payload_filter_finding_evidence_names_the_probe(self) -> None:
+    def test_payload_filter_finding_evidence_names_the_probe(self, make_response) -> None:
         ep = Endpoint(url="https://app.example.com/api", status_code=200)
 
-        with patch("requests.post", return_value=_resp(body=_LINUX_MARKER)):
+        with patch("requests.post", return_value=make_response(body=_LINUX_MARKER)):
             results = check_xxe([ep], payload_names=[XxePayload.linux_soap])
 
         assert len(results) == 1


### PR DESCRIPTION
Closes #82

## Summary

Adds a single `make_response` factory fixture to `tests/conftest.py` and migrates every test file that had its own local response mock helper to use it. Before this PR there were 14 slightly-different helpers drifting apart (the CSRF PR added `cookies` support that most others were missing). Now there is one.

**Fixture added to conftest.py:**
```python
@pytest.fixture
def make_response():
    def _make(status=200, body="", headers=None, cookies=None, json=None) -> MagicMock: ...
    return _make
```

**Helpers removed (fully replaced):**
| File | Helper removed |
|---|---|
| `test_cmd_injection.py` | `_resp` |
| `test_errors.py` | `_resp` (body was first positional arg - all call sites updated) |
| `test_hpp.py` | `_resp` |
| `test_ssti.py` | `_resp`, `_echo` (inlined as closures) |
| `test_ldap_injection.py` | `_resp` (all positional call sites converted to kwargs) |
| `test_prototype_pollution.py` | `_resp` |
| `test_ssrf.py` | `_resp` |
| `test_xxe.py` | `_resp` |
| `test_open_redirect.py` | `_resp` (had status=302 default; all call sites already passed status explicitly) |
| `test_path_traversal.py` | `_resp` |
| `test_prompt_injection.py` | `_mock_resp` (status was first positional; all call sites updated) |
| `test_jwt.py` | `_mock_response` (set body="{}" by default; preserved at all call sites) |
| `test_csrf.py` | `_get_resp` (content_type param folded into headers dict) |

**Left alone (tool-specific, not generic response mocks):**
- `test_csrf.py` `_post_resp` - CSRF-specific
- `test_cookies.py` `_resp` - unique set_cookies signature

## Test plan

- [x] 668 unit tests pass
- [x] `ruff check` + `ruff format` clean
- [x] `mypy --ignore-missing-imports` clean (0 errors)
