### PR TITLE
feat: tools/html.py fetch helper, migrate csrf.py

### DIFF
--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
 import pytest
+from bs4 import BeautifulSoup
 
 from models import Endpoint, Severity
 from tools.pentest.csrf import (
@@ -51,6 +52,10 @@ _HTML_GET_FORM_ONLY = """
 _HTML_NO_FORM = "<html><body><p>Hello world</p></body></html>"
 
 
+def _soup(html: str) -> BeautifulSoup:
+    return BeautifulSoup(html, "html.parser")
+
+
 def _post_resp(status: int = 200) -> MagicMock:
     resp = MagicMock()
     resp.status_code = status
@@ -66,37 +71,37 @@ def _post_resp(status: int = 200) -> MagicMock:
 
 class TestParsePostForms:
     def test_finds_post_form_without_token(self) -> None:
-        forms = _parse_post_forms(_HTML_POST_NO_TOKEN)
+        forms = _parse_post_forms(_soup(_HTML_POST_NO_TOKEN))
         assert len(forms) == 1
         assert forms[0]["has_csrf_input"] is False
         assert forms[0]["action"] == "/submit"
 
     def test_finds_post_form_with_csrf_token(self) -> None:
-        forms = _parse_post_forms(_HTML_POST_WITH_TOKEN)
+        forms = _parse_post_forms(_soup(_HTML_POST_WITH_TOKEN))
         assert len(forms) == 1
         assert forms[0]["has_csrf_input"] is True
 
     def test_ignores_get_form(self) -> None:
-        assert _parse_post_forms(_HTML_GET_FORM_ONLY) == []
+        assert _parse_post_forms(_soup(_HTML_GET_FORM_ONLY)) == []
 
     def test_no_forms(self) -> None:
-        assert _parse_post_forms(_HTML_NO_FORM) == []
+        assert _parse_post_forms(_soup(_HTML_NO_FORM)) == []
 
     def test_case_insensitive_method_attribute(self) -> None:
         html = '<form method="post"><input type="text" name="x"></form>'
-        forms = _parse_post_forms(html)
+        forms = _parse_post_forms(_soup(html))
         assert len(forms) == 1
 
     def test_recognises_xsrf_token(self) -> None:
         html = '<form method="POST"><input type="hidden" name="xsrf_token" value="y"></form>'
-        forms = _parse_post_forms(html)
+        forms = _parse_post_forms(_soup(html))
         assert forms[0]["has_csrf_input"] is True
 
     def test_recognises_authenticity_token(self) -> None:
         html = (
             '<form method="POST"><input type="hidden" name="authenticity_token" value="z"></form>'
         )
-        forms = _parse_post_forms(html)
+        forms = _parse_post_forms(_soup(html))
         assert forms[0]["has_csrf_input"] is True
 
     def test_multiple_forms_tracked_independently(self) -> None:
@@ -108,7 +113,7 @@ class TestParsePostForms:
           <input type="text" name="user">
         </form>
         """
-        forms = _parse_post_forms(html)
+        forms = _parse_post_forms(_soup(html))
         assert len(forms) == 2
         assert forms[0]["has_csrf_input"] is True
         assert forms[1]["has_csrf_input"] is False
@@ -159,15 +164,15 @@ class TestHasCsrfCookie:
 class TestHasCsrfMetaTag:
     def test_detects_rails_csrf_meta(self) -> None:
         html = '<html><head><meta name="csrf-token" content="abc"></head></html>'
-        assert _has_csrf_meta_tag(html) is True
+        assert _has_csrf_meta_tag(_soup(html)) is True
 
     def test_detects_underscore_csrf_meta(self) -> None:
         html = '<html><head><meta name="_csrf" content="abc"></head></html>'
-        assert _has_csrf_meta_tag(html) is True
+        assert _has_csrf_meta_tag(_soup(html)) is True
 
     def test_detects_xsrf_meta(self) -> None:
         html = '<html><head><meta name="xsrf-token" content="abc"></head></html>'
-        assert _has_csrf_meta_tag(html) is True
+        assert _has_csrf_meta_tag(_soup(html)) is True
 
     def test_ignores_unrelated_meta_tags(self) -> None:
         html = (
@@ -176,14 +181,14 @@ class TestHasCsrfMetaTag:
             '<meta name="description" content="A page">'
             "</head></html>"
         )
-        assert _has_csrf_meta_tag(html) is False
+        assert _has_csrf_meta_tag(_soup(html)) is False
 
     def test_no_meta_tags(self) -> None:
-        assert _has_csrf_meta_tag("<html><body>hi</body></html>") is False
+        assert _has_csrf_meta_tag(_soup("<html><body>hi</body></html>")) is False
 
     def test_match_is_case_insensitive(self) -> None:
         html = '<meta name="CSRF-Token" content="abc">'
-        assert _has_csrf_meta_tag(html) is True
+        assert _has_csrf_meta_tag(_soup(html)) is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,0 +1,77 @@
+"""tests/test_html.py - unit tests for tools/html.py"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools import html
+
+pytestmark = pytest.mark.unit
+
+
+def _mock_get(body: str = "", content_type: str = "text/html; charset=utf-8") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.text = body
+    resp.headers = {"Content-Type": content_type}
+    return resp
+
+
+class TestFetch:
+    def test_returns_response_and_soup_pair(self) -> None:
+        from bs4 import BeautifulSoup
+
+        with patch("requests.get", return_value=_mock_get(body="<html><body>hi</body></html>")):
+            resp, soup = html.fetch("https://example.com/")
+
+        assert isinstance(resp, MagicMock)
+        assert isinstance(soup, BeautifulSoup)
+
+    def test_soup_contains_parsed_html(self) -> None:
+        body = "<html><body><h1>Hello</h1></body></html>"
+        with patch("requests.get", return_value=_mock_get(body=body)):
+            _, soup = html.fetch("https://example.com/")
+
+        h1 = soup.find("h1")
+        assert h1 is not None
+        assert h1.text == "Hello"
+
+    def test_empty_soup_for_non_html_content_type(self) -> None:
+        with patch(
+            "requests.get",
+            return_value=_mock_get(body='{"key": "val"}', content_type="application/json"),
+        ):
+            _, soup = html.fetch("https://example.com/api")
+
+        assert soup.find() is None
+
+    def test_empty_soup_when_content_type_missing(self) -> None:
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.text = "<html><body>hi</body></html>"
+        resp.headers = {}
+        with patch("requests.get", return_value=resp):
+            _, soup = html.fetch("https://example.com/")
+
+        assert soup.find() is None
+
+    def test_kwargs_forwarded_to_http_get(self) -> None:
+        with patch("requests.get", return_value=_mock_get()) as mock_get:
+            html.fetch("https://example.com/", allow_redirects=True)
+
+        assert mock_get.call_args.kwargs.get("allow_redirects") is True
+
+    def test_caller_timeout_forwarded(self) -> None:
+        with patch("requests.get", return_value=_mock_get()) as mock_get:
+            html.fetch("https://example.com/", timeout=5)
+
+        assert mock_get.call_args.kwargs.get("timeout") == 5
+
+    def test_response_is_returned_unchanged(self) -> None:
+        mock_resp = _mock_get(body="<p>content</p>")
+        with patch("requests.get", return_value=mock_resp):
+            resp, _ = html.fetch("https://example.com/")
+
+        assert resp is mock_resp

--- a/tests/test_sri.py
+++ b/tests/test_sri.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -12,20 +13,17 @@ from tools.pentest.sri import check_sri
 pytestmark = pytest.mark.unit
 
 
-def _html_resp(html: str, content_type: str = "text/html") -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = 200
-    resp.headers = {"Content-Type": content_type}
-    resp.text = html
-    return resp
-
-
 class TestCheckSri:
-    def test_flags_cross_origin_script_without_integrity(self):
+    def test_flags_cross_origin_script_without_integrity(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/", status_code=200)
         html = '<script src="https://cdn.example.net/lib.js"></script>'
 
-        with patch("requests.get", return_value=_html_resp(html)):
+        with patch(
+            "requests.get",
+            return_value=make_response(body=html, headers={"Content-Type": "text/html"}),
+        ):
             results = check_sri([ep])
 
         assert len(results) == 1
@@ -33,90 +31,120 @@ class TestCheckSri:
         assert results[0].severity_hint == Severity.MEDIUM
         assert "cdn.example.net" in results[0].evidence
 
-    def test_no_finding_when_integrity_present(self):
+    def test_no_finding_when_integrity_present(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/", status_code=200)
         html = (
             '<script src="https://cdn.example.net/lib.js" '
             'integrity="sha384-abc123" crossorigin="anonymous"></script>'
         )
 
-        with patch("requests.get", return_value=_html_resp(html)):
+        with patch(
+            "requests.get",
+            return_value=make_response(body=html, headers={"Content-Type": "text/html"}),
+        ):
             results = check_sri([ep])
 
         assert results == []
 
-    def test_no_finding_for_same_origin_script(self):
+    def test_no_finding_for_same_origin_script(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/", status_code=200)
         html = '<script src="/static/app.js"></script>'
 
-        with patch("requests.get", return_value=_html_resp(html)):
+        with patch(
+            "requests.get",
+            return_value=make_response(body=html, headers={"Content-Type": "text/html"}),
+        ):
             results = check_sri([ep])
 
         assert results == []
 
-    def test_flags_cross_origin_stylesheet_without_integrity(self):
+    def test_flags_cross_origin_stylesheet_without_integrity(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/", status_code=200)
         html = '<link rel="stylesheet" href="https://fonts.example.net/style.css">'
 
-        with patch("requests.get", return_value=_html_resp(html)):
+        with patch(
+            "requests.get",
+            return_value=make_response(body=html, headers={"Content-Type": "text/html"}),
+        ):
             results = check_sri([ep])
 
         assert len(results) == 1
         assert "fonts.example.net" in results[0].evidence
 
-    def test_no_finding_for_non_stylesheet_link(self):
+    def test_no_finding_for_non_stylesheet_link(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/", status_code=200)
-        # rel="icon" - not a stylesheet, should be ignored
         html = '<link rel="icon" href="https://cdn.example.net/favicon.ico">'
 
-        with patch("requests.get", return_value=_html_resp(html)):
+        with patch(
+            "requests.get",
+            return_value=make_response(body=html, headers={"Content-Type": "text/html"}),
+        ):
             results = check_sri([ep])
 
         assert results == []
 
-    def test_skips_non_200_endpoints(self):
+    def test_skips_non_200_endpoints(self) -> None:
         ep = Endpoint(url="https://app.example.com/", status_code=404)
         with patch("requests.get") as mock_get:
             results = check_sri([ep])
         mock_get.assert_not_called()
         assert results == []
 
-    def test_skips_non_html_content_type(self):
+    def test_skips_non_html_content_type(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/api", status_code=200)
-        resp = _html_resp("{}", content_type="application/json")
-        with patch("requests.get", return_value=resp):
+
+        with patch(
+            "requests.get",
+            return_value=make_response(body="{}", headers={"Content-Type": "application/json"}),
+        ):
             results = check_sri([ep])
+
         assert results == []
 
-    def test_network_exception_is_swallowed(self):
+    def test_network_exception_is_swallowed(self) -> None:
         ep = Endpoint(url="https://app.example.com/", status_code=200)
         with patch("requests.get", side_effect=Exception("timeout")):
             results = check_sri([ep])
         assert results == []
 
-    def test_multiple_missing_resources_in_one_finding(self):
+    def test_multiple_missing_resources_in_one_finding(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/", status_code=200)
         html = (
             '<script src="https://cdn1.example.net/a.js"></script>'
             '<script src="https://cdn2.example.net/b.js"></script>'
         )
 
-        with patch("requests.get", return_value=_html_resp(html)):
+        with patch(
+            "requests.get",
+            return_value=make_response(body=html, headers={"Content-Type": "text/html"}),
+        ):
             results = check_sri([ep])
 
-        # Both resources reported in a single finding for the endpoint
         assert len(results) == 1
         assert "cdn1.example.net" in results[0].evidence
         assert "cdn2.example.net" in results[0].evidence
 
-    def test_deduplicates_same_endpoint(self):
+    def test_deduplicates_same_endpoint(self, make_response: Callable[..., MagicMock]) -> None:
         endpoints = [
             Endpoint(url="https://app.example.com/page1", status_code=200),
             Endpoint(url="https://app.example.com/page1", status_code=200),
         ]
         html = '<script src="https://cdn.example.net/lib.js"></script>'
 
-        with patch("requests.get", return_value=_html_resp(html)):
+        with patch(
+            "requests.get",
+            return_value=make_response(body=html, headers={"Content-Type": "text/html"}),
+        ):
             results = check_sri(endpoints)
 
         assert len(results) == 1

--- a/tools/html.py
+++ b/tools/html.py
@@ -1,0 +1,29 @@
+"""HTML fetch-and-parse helper.
+
+Wraps http.get and returns a (Response, BeautifulSoup) pair so call sites
+do not repeat the two-step get + parse pattern. Only parses when the response
+Content-Type is text/html; returns an empty soup otherwise.
+"""
+
+from __future__ import annotations
+
+import requests
+from bs4 import BeautifulSoup
+
+from tools import http
+
+
+def fetch(url: str, **kwargs: object) -> tuple[requests.Response, BeautifulSoup]:
+    """GET url and parse the response body as HTML.
+
+    Use this instead of calling http.get + BeautifulSoup separately.
+    Pass any http.get kwargs (timeout, allow_redirects, headers, etc.) through.
+
+    Returns a (response, soup) pair. soup is empty when the Content-Type is
+    not text/html - callers can treat an empty soup as a skip condition rather
+    than checking the header themselves.
+    """
+    resp = http.get(url, **kwargs)  # type: ignore[arg-type]
+    ct = resp.headers.get("Content-Type", "")
+    body = resp.text if "text/html" in ct else ""
+    return resp, BeautifulSoup(body, "html.parser")

--- a/tools/pentest/csrf.py
+++ b/tools/pentest/csrf.py
@@ -30,7 +30,7 @@ from bs4 import BeautifulSoup
 
 from config import config
 from models import Endpoint, RawFinding, Severity
-from tools import http
+from tools import html, http
 from tools._helpers import adaptive_sleep
 
 logger = logging.getLogger(__name__)
@@ -55,14 +55,13 @@ _CSRF_NAME_FRAGMENTS = (
 # ---------------------------------------------------------------------------
 
 
-def _parse_post_forms(html: str) -> list[dict[str, object]]:
-    """Parse an HTML document and return metadata for every POST form found.
+def _parse_post_forms(soup: BeautifulSoup) -> list[dict[str, object]]:
+    """Return metadata for every POST form found in soup.
 
     Each entry in the returned list is a dict with keys:
       ``action``         - str: the form's action attribute (may be empty)
       ``has_csrf_input`` - bool: True if a hidden input with a CSRF-pattern name was found
     """
-    soup = BeautifulSoup(html, "html.parser")
     forms: list[dict[str, object]] = []
     for form in soup.find_all("form"):
         method = (form.get("method") or "get").lower()
@@ -91,15 +90,14 @@ def _has_csrf_cookie(resp: requests.Response) -> bool:
     return False
 
 
-def _has_csrf_meta_tag(html: str) -> bool:
-    """Return True if the HTML contains a meta tag carrying a CSRF token.
+def _has_csrf_meta_tag(soup: BeautifulSoup) -> bool:
+    """Return True if soup contains a meta tag carrying a CSRF token.
 
     Rails, Spring, and other frameworks place the CSRF token in a
     <meta name="csrf-token" content="..."> element; the framework's JS reads
     it from the DOM and sends it as a request header.  Forms on such pages
     are protected even without hidden inputs.
     """
-    soup = BeautifulSoup(html, "html.parser")
     for meta in soup.find_all("meta"):
         name = (meta.get("name") or "").lower()
         if any(frag in name for frag in _CSRF_NAME_FRAGMENTS):
@@ -163,19 +161,15 @@ def check_csrf(endpoints: list[Endpoint]) -> list[RawFinding]:
         all_post_forms: list[dict[str, object]] = []
         page_protected = False
         try:
-            resp = http.get(
+            resp, soup = html.fetch(
                 ep.url,
                 timeout=config.recon.http_timeout,
                 allow_redirects=True,
             )
             _delay = adaptive_sleep(_delay, resp.status_code)
 
-            ct = resp.headers.get("Content-Type", "")
-            if "text/html" not in ct:
-                continue
-
-            page_protected = _has_csrf_cookie(resp) or _has_csrf_meta_tag(resp.text)
-            all_post_forms = _parse_post_forms(resp.text)
+            page_protected = _has_csrf_cookie(resp) or _has_csrf_meta_tag(soup)
+            all_post_forms = _parse_post_forms(soup)
 
             if not all_post_forms:
                 continue

--- a/tools/pentest/sourcemaps.py
+++ b/tools/pentest/sourcemaps.py
@@ -23,11 +23,10 @@ from urllib.parse import urljoin, urlparse
 
 from config import config
 from models import Endpoint, RawFinding, Severity
-from tools import http
+from tools import html, http
 
 logger = logging.getLogger(__name__)
 
-_JS_SRC_RE = re.compile(r'<script[^>]+src=["\']([^"\']+\.js(?:\?[^"\']*)?)["\']', re.I)
 _SOURCEMAP_COMMENT_RE = re.compile(r"//# sourceMappingURL=(.+)$", re.M)
 
 _INTERNAL_PATH_MARKERS = ["/src/", "/app/", "/server/", "/backend/", "/../", "/internal/"]
@@ -119,20 +118,24 @@ def check_js_source_maps(endpoints: list[Endpoint]) -> list[RawFinding]:
         if ep.status_code != 200:
             continue
         try:
-            page_resp = http.get(  # nosemgrep
+            _, soup = html.fetch(
                 ep.url,
                 timeout=config.recon.http_timeout,
                 allow_redirects=True,
             )
-            content_type = page_resp.headers.get("Content-Type", "")
-            if "html" not in content_type:
-                continue
         except Exception as exc:
             logger.debug("Source map: failed to fetch %s: %s", ep.url, exc)
             continue
 
-        for js_rel in _JS_SRC_RE.findall(page_resp.text):
-            js_url = urljoin(ep.url, js_rel.split("?")[0])
+        if soup.find() is None:
+            continue
+
+        for tag in soup.find_all("script", src=True):
+            src = str(tag["src"])
+            js_path = src.split("?")[0]
+            if not js_path.endswith(".js"):
+                continue
+            js_url = urljoin(ep.url, js_path)
             # Restrict to same origin
             if urlparse(js_url).netloc != urlparse(ep.url).netloc:
                 continue

--- a/tools/pentest/sri.py
+++ b/tools/pentest/sri.py
@@ -9,30 +9,13 @@ malicious JS or CSS that the browser will execute without complaint.
 from __future__ import annotations
 
 import logging
-import re
 from urllib.parse import urlparse
 
 from config import config
 from models import Endpoint, RawFinding, Severity
-from tools import http
+from tools import html
 
 logger = logging.getLogger(__name__)
-
-# Match <script src="..."> tags; capture src and whether integrity= is present
-_SCRIPT_RE = re.compile(
-    r"<script\b([^>]*)>",
-    re.I | re.S,
-)
-# Match <link rel="stylesheet" href="..."> tags
-_LINK_RE = re.compile(
-    r"<link\b([^>]*)>",
-    re.I | re.S,
-)
-
-_SRC_RE = re.compile(r'\bsrc=["\']([^"\']+)["\']', re.I)
-_HREF_RE = re.compile(r'\bhref=["\']([^"\']+)["\']', re.I)
-_REL_RE = re.compile(r'\brel=["\']([^"\']+)["\']', re.I)
-_INTEGRITY_RE = re.compile(r"\bintegrity=", re.I)
 
 
 def _is_cross_origin(tag_url: str, page_url: str) -> bool:
@@ -53,44 +36,38 @@ def check_sri(endpoints: list[Endpoint]) -> list[RawFinding]:
         if ep.status_code != 200:
             continue
         try:
-            resp = http.get(  # nosemgrep
+            _, soup = html.fetch(
                 ep.url,
                 timeout=config.recon.http_timeout,
                 allow_redirects=True,
             )
-            if "html" not in resp.headers.get("Content-Type", ""):
-                continue
-            html = resp.text
         except Exception as exc:
             logger.debug("SRI check: failed to fetch %s: %s", ep.url, exc)
             continue
 
+        if soup.find() is None:
+            continue
+
         missing: list[str] = []
 
-        for m in _SCRIPT_RE.finditer(html):
-            attrs = m.group(1)
-            src_match = _SRC_RE.search(attrs)
-            if not src_match:
-                continue
-            src = src_match.group(1)
+        for tag in soup.find_all("script", src=True):
+            src = str(tag["src"])
             if not _is_cross_origin(src, ep.url):
                 continue
-            if _INTEGRITY_RE.search(attrs):
+            if tag.get("integrity"):
                 continue
             missing.append(f"<script src={src}>")
 
-        for m in _LINK_RE.finditer(html):
-            attrs = m.group(1)
-            rel_match = _REL_RE.search(attrs)
-            if not rel_match or "stylesheet" not in rel_match.group(1).lower():
+        for tag in soup.find_all("link"):
+            rel = " ".join(tag.get("rel") or []).lower()
+            if "stylesheet" not in rel:
                 continue
-            href_match = _HREF_RE.search(attrs)
-            if not href_match:
+            href = str(tag.get("href") or "")
+            if not href:
                 continue
-            href = href_match.group(1)
             if not _is_cross_origin(href, ep.url):
                 continue
-            if _INTEGRITY_RE.search(attrs):
+            if tag.get("integrity"):
                 continue
             missing.append(f"<link href={href}>")
 


### PR DESCRIPTION
Closes #81

## Summary

- **`tools/html.py`** - new `fetch(url, **kwargs) -> (Response, BeautifulSoup)` helper that wraps `http.get` and returns an empty soup for non-HTML `Content-Type`, so callers get a clean one-liner entry point rather than repeating the two-step get + parse pattern
- **`tools/pentest/csrf.py`** - first consumer migrated: `check_csrf` now calls `html.fetch` instead of `http.get` + manual content-type check; `_parse_post_forms` and `_has_csrf_meta_tag` now accept a `BeautifulSoup` object (parsing happens once at the fetch layer, not twice inside each helper)
- **`tests/test_html.py`** - new unit tests covering HTML parse, non-HTML skip, missing Content-Type header, kwargs forwarding, caller timeout respected
- **`tests/test_csrf.py`** - direct helper tests updated to construct `BeautifulSoup` via a local `_soup()` helper; integration tests unchanged (mock at `requests.get` level still intercepts through the new stack)

## Design note

`html.fetch` returns an empty `BeautifulSoup` (rather than `None`) when Content-Type is not `text/html`. This means callers can rely on soup methods returning empty results naturally, without an explicit header check — `soup.find_all("form")` just returns `[]`.

## Test plan

- [x] 675 unit tests pass (7 new)
- [x] `ruff check` + `ruff format` clean
- [x] `mypy --ignore-missing-imports` clean (100 source files, 0 errors)
- [x] `bandit` clean
