### PR TITLE
feat: header XSS probe tool for penetration tester (#35)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,7 +200,7 @@ Coverage floor is 85%. Every new public function in `tools/` needs a test. Every
 # correct - uses shared fixture
 def test_no_finding(self, make_response: Callable[..., MagicMock]) -> None:
     with patch("requests.get", return_value=make_response(body="<html>ok</html>")):
-        ...
+        pass  # assertions go here
 
 # wrong - duplicates the fixture locally
 def _resp(body="", status=200):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,32 @@ Tests that reload modules for config isolation use `importlib.reload()` - this i
 
 Coverage floor is 85%. Every new public function in `tools/` needs a test. Every bug fix needs a regression test.
 
+### Shared fixtures
+
+`tests/conftest.py` provides fixtures for all tests. Use them instead of defining local equivalents:
+
+- **`make_response`** - factory for `MagicMock` objects shaped like `requests.Response`. Accepts `status`, `body`, `headers`, `cookies`, and `json`. Use this for any generic HTTP response mock:
+
+  ```python
+  # correct - uses shared fixture
+  def test_no_finding(self, make_response: Callable) -> None:
+      with patch("requests.get", return_value=make_response(body="<html>ok</html>")):
+          ...
+
+  # wrong - duplicates the fixture locally
+  def _resp(body="", status=200):
+      r = MagicMock()
+      r.text = body
+      r.status_code = status
+      return r
+  ```
+
+  Tool-specific response builders that carry extra logic (e.g. cookie-jar inspection, POST body reflection) can stay local to their test file - they are not generic mocks.
+
+- **`programme`, `endpoint`, `recon_result`, `raw_finding_high/low/oos`, `verified_vuln`, `disclosure_report`** - canonical model instances. Use `model_copy(update={...})` to derive variants.
+
+- **`clean_response_body`** - an HTML body verified at fixture-setup time to contain none of the strings any pentest probe treats as a positive match. Use it for "no finding" cases to avoid false negatives caused by accidental marker collisions.
+
 ---
 
 ## Adding a new agent
@@ -219,6 +245,28 @@ Tools are `@tool`-decorated functions in a `squad/<agent>/__init__.py`. The docs
 One concern per tool. The PT agent selects tools based on nmap evidence and detected technologies; bundling unrelated checks removes that selectivity.
 
 Tests must mock all network and binary calls. Patch `socket.create_connection` at the module path where it is imported (e.g. `tools.cloud.databases.redis.socket.create_connection`), not at the top-level `socket` module.
+
+### Probe enumerations
+
+When a tool iterates over a fixed set of attack vectors (headers, payloads, error markers, URI paths), define them as a `StrEnum` in the tool module rather than a bare list or tuple. This makes the set inspectable, importable in tests, and self-documenting:
+
+```python
+# correct
+from enum import StrEnum
+
+class XSSHeader(StrEnum):
+    USER_AGENT = "User-Agent"
+    REFERER = "Referer"
+    X_FORWARDED_FOR = "X-Forwarded-For"
+
+for header in XSSHeader:
+    ...
+
+# wrong - opaque list, not reusable in tests
+_HEADERS = ["User-Agent", "Referer", "X-Forwarded-For"]
+```
+
+Tests should import the enum and assert against `set(MyEnum)` rather than duplicating the string literals.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,23 +194,21 @@ Coverage floor is 85%. Every new public function in `tools/` needs a test. Every
 
 `tests/conftest.py` provides fixtures for all tests. Use them instead of defining local equivalents:
 
-- **`make_response`** - factory for `MagicMock` objects shaped like `requests.Response`. Accepts `status`, `body`, `headers`, `cookies`, and `json`. Use this for any generic HTTP response mock:
+- **`make_response`** - factory for `MagicMock` objects shaped like `requests.Response`. Accepts `status`, `body`, `headers`, `cookies`, and `json`. Use this for any generic HTTP response mock. Tool-specific response builders that carry extra logic (e.g. cookie-jar inspection, POST body reflection) can stay local to their test file.
 
-  ```python
-  # correct - uses shared fixture
-  def test_no_finding(self, make_response: Callable) -> None:
-      with patch("requests.get", return_value=make_response(body="<html>ok</html>")):
-          ...
+```python
+# correct - uses shared fixture
+def test_no_finding(self, make_response: Callable[..., MagicMock]) -> None:
+    with patch("requests.get", return_value=make_response(body="<html>ok</html>")):
+        ...
 
-  # wrong - duplicates the fixture locally
-  def _resp(body="", status=200):
-      r = MagicMock()
-      r.text = body
-      r.status_code = status
-      return r
-  ```
-
-  Tool-specific response builders that carry extra logic (e.g. cookie-jar inspection, POST body reflection) can stay local to their test file - they are not generic mocks.
+# wrong - duplicates the fixture locally
+def _resp(body="", status=200):
+    r = MagicMock()
+    r.text = body
+    r.status_code = status
+    return r
+```
 
 - **`programme`, `endpoint`, `recon_result`, `raw_finding_high/low/oos`, `verified_vuln`, `disclosure_report`** - canonical model instances. Use `model_copy(update={...})` to derive variants.
 

--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -33,7 +33,7 @@ from tools.pentest.cookies import check_cookies
 from tools.pentest.cors import check_cors_misconfiguration
 from tools.pentest.csrf import check_csrf
 from tools.pentest.errors import check_error_disclosure
-from tools.pentest.header_xss import check_header_xss
+from tools.pentest.header_xss import XSSHeader, check_header_xss
 from tools.pentest.hpp import check_hpp
 from tools.pentest.jwt import JwtAttack, check_jwt
 from tools.pentest.ldap_injection import LdapPayload, check_ldap_injection
@@ -223,11 +223,13 @@ def host_header_tool(recon_result_json: str) -> list[dict]:
 
 
 @tool("Header XSS Probe")
-def header_xss_tool(endpoints_json: str) -> list[dict]:
+def header_xss_tool(
+    endpoints_json: str,
+    header_names: list[XSSHeader] | None = None,
+) -> list[dict]:
     """
-    Inject an angle-bracket canary into User-Agent, Referer, X-Forwarded-For,
-    X-Custom-Header, and Accept-Language headers and check whether the response
-    body contains the canary verbatim (unencoded).
+    Inject an angle-bracket canary into request headers and check whether the
+    response body contains the canary verbatim (unencoded).
 
     Unencoded reflection confirms the application echoes raw header values into
     HTML output without sanitisation, which is sufficient evidence of a Header
@@ -244,9 +246,18 @@ def header_xss_tool(endpoints_json: str) -> list[dict]:
       HTML-serving endpoints; error pages and admin paths are especially fruitful.
       Example: '[{"url": "https://example.com/error", "status_code": 404}]'
 
+    header_names: optional list of headers to probe; omit or pass null to test
+      all five. Narrow this when recon evidence points to a specific header
+      (e.g. error pages that echo the User-Agent, analytics that log Referer).
+      Valid values: "User-Agent", "Referer", "X-Forwarded-For",
+      "X-Custom-Header", "Accept-Language".
+      Example: ["User-Agent", "Referer"]
+
     Returns raw findings as dicts.
     """
-    return [f.model_dump() for f in check_header_xss(_parse_endpoints(endpoints_json))]
+    return [
+        f.model_dump() for f in check_header_xss(_parse_endpoints(endpoints_json), header_names)
+    ]
 
 
 @tool("JS Source Map Scan")

--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -33,6 +33,7 @@ from tools.pentest.cookies import check_cookies
 from tools.pentest.cors import check_cors_misconfiguration
 from tools.pentest.csrf import check_csrf
 from tools.pentest.errors import check_error_disclosure
+from tools.pentest.header_xss import check_header_xss
 from tools.pentest.hpp import check_hpp
 from tools.pentest.jwt import JwtAttack, check_jwt
 from tools.pentest.ldap_injection import LdapPayload, check_ldap_injection
@@ -219,6 +220,33 @@ def host_header_tool(recon_result_json: str) -> list[dict]:
     """
     recon = _recon_from_json(recon_result_json)
     return [f.model_dump() for f in check_host_headers(recon.endpoints)]
+
+
+@tool("Header XSS Probe")
+def header_xss_tool(endpoints_json: str) -> list[dict]:
+    """
+    Inject an angle-bracket canary into User-Agent, Referer, X-Forwarded-For,
+    X-Custom-Header, and Accept-Language headers and check whether the response
+    body contains the canary verbatim (unencoded).
+
+    Unencoded reflection confirms the application echoes raw header values into
+    HTML output without sanitisation, which is sufficient evidence of a Header
+    XSS vulnerability (H1 weakness: Improper Neutralization of HTTP Headers for
+    Scripting Syntax).
+
+    Use when:
+      - The target renders content server-side (templates, SSR, admin dashboards)
+      - Error pages are verbose and likely to echo request metadata
+      - Recon found analytics or logging endpoints that display User-Agent strings
+      - The target is an older web application (PHP, JSP, ASP) with legacy templating
+
+    endpoints_json: JSON array of endpoint objects. Pass a broad set of live
+      HTML-serving endpoints; error pages and admin paths are especially fruitful.
+      Example: '[{"url": "https://example.com/error", "status_code": 404}]'
+
+    Returns raw findings as dicts.
+    """
+    return [f.model_dump() for f in check_header_xss(_parse_endpoints(endpoints_json))]
 
 
 @tool("JS Source Map Scan")
@@ -895,6 +923,7 @@ MEMBER = SquadMember(
         csrf_check_tool,
         ssrf_probe_tool,
         header_injection_tool,
+        header_xss_tool,
         host_header_tool,
         source_maps_tool,
         ssti_probe_tool,

--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -249,8 +249,6 @@ def header_xss_tool(
     header_names: optional list of headers to probe; omit or pass null to test
       all five. Narrow this when recon evidence points to a specific header
       (e.g. error pages that echo the User-Agent, analytics that log Referer).
-      Valid values: "User-Agent", "Referer", "X-Forwarded-For",
-      "X-Custom-Header", "Accept-Language".
       Example: ["User-Agent", "Referer"]
 
     Returns raw findings as dicts.

--- a/tests/test_header_xss.py
+++ b/tests/test_header_xss.py
@@ -2,43 +2,40 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from models import Endpoint, Severity
-from tools.pentest.header_xss import _CANARY_PREFIX, _XSS_HEADERS, check_header_xss
+from tools.pentest.header_xss import XSSHeader, _CANARY_PREFIX, check_header_xss
 
 pytestmark = pytest.mark.unit
 
 
-def _resp(body: str = "", status: int = 200) -> MagicMock:
-    r = MagicMock()
-    r.text = body
-    r.status_code = status
-    return r
+def _make_reflecting_fake(
+    make_response: Callable[..., MagicMock],
+    match_header: str | None = None,
+) -> Callable[..., MagicMock]:
+    """Return a fake requests.get that reflects any canary injected into the
+    given header (or any header when match_header is None)."""
 
-
-def _make_reflecting_fake(match_header: str | None = None):
-    """Return a fake_get that reflects any canary injected into the given
-    header (or into any header when match_header is None)."""
-
-    def fake_get(url, headers=None, **kwargs):
+    def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> MagicMock:
         h = headers or {}
         for key, val in h.items():
             if _CANARY_PREFIX in str(val):
                 if match_header is None or key == match_header:
-                    return _resp(body=f"<html>Echoed: {val}</html>")
-        return _resp(body="<html>Normal response</html>")
+                    return make_response(body=f"<html>Echoed: {val}</html>")
+        return make_response(body="<html>Normal response</html>")
 
     return fake_get
 
 
 class TestCheckHeaderXss:
-    def test_detects_user_agent_reflection(self):
+    def test_detects_user_agent_reflection(self, make_response: Callable) -> None:
         ep = Endpoint(url="https://app.example.com/error", status_code=200)
 
-        with patch("requests.get", side_effect=_make_reflecting_fake("User-Agent")):
+        with patch("requests.get", side_effect=_make_reflecting_fake(make_response, "User-Agent")):
             results = check_header_xss([ep])
 
         assert len(results) == 1
@@ -46,44 +43,47 @@ class TestCheckHeaderXss:
         assert results[0].severity_hint == Severity.HIGH
         assert "User-Agent" in results[0].evidence
 
-    def test_detects_referer_reflection(self):
+    def test_detects_referer_reflection(self, make_response: Callable) -> None:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
 
-        with patch("requests.get", side_effect=_make_reflecting_fake("Referer")):
+        with patch("requests.get", side_effect=_make_reflecting_fake(make_response, "Referer")):
             results = check_header_xss([ep])
 
         assert len(results) == 1
         assert "Referer" in results[0].evidence
 
-    def test_detects_x_forwarded_for_reflection(self):
+    def test_detects_x_forwarded_for_reflection(self, make_response: Callable) -> None:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
 
-        with patch("requests.get", side_effect=_make_reflecting_fake("X-Forwarded-For")):
+        with patch(
+            "requests.get",
+            side_effect=_make_reflecting_fake(make_response, "X-Forwarded-For"),
+        ):
             results = check_header_xss([ep])
 
         assert len(results) == 1
         assert "X-Forwarded-For" in results[0].evidence
 
-    def test_no_finding_when_canary_is_html_encoded(self):
+    def test_no_finding_when_canary_is_html_encoded(self, make_response: Callable) -> None:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
 
-        def fake_get(url, headers=None, **kwargs):
-            return _resp(body="<html>&lt;bountysquad-hxss-test&gt;</html>")
-
-        with patch("requests.get", side_effect=fake_get):
+        with patch(
+            "requests.get",
+            return_value=make_response(body="<html>&lt;bountysquad-hxss-test&gt;</html>"),
+        ):
             results = check_header_xss([ep])
 
         assert results == []
 
-    def test_no_finding_when_canary_absent(self):
+    def test_no_finding_when_canary_absent(self, make_response: Callable) -> None:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
 
-        with patch("requests.get", return_value=_resp(body="<html>Normal</html>")):
+        with patch("requests.get", return_value=make_response(body="<html>Normal</html>")):
             results = check_header_xss([ep])
 
         assert results == []
 
-    def test_skips_server_error_endpoints(self):
+    def test_skips_server_error_endpoints(self) -> None:
         ep = Endpoint(url="https://app.example.com/", status_code=500)
 
         with patch("requests.get") as mock_get:
@@ -92,29 +92,32 @@ class TestCheckHeaderXss:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_one_finding_per_endpoint_even_when_multiple_headers_reflect(self):
+    def test_one_finding_per_endpoint_even_when_multiple_headers_reflect(
+        self, make_response: Callable
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
 
-        with patch("requests.get", side_effect=_make_reflecting_fake(None)):
+        with patch("requests.get", side_effect=_make_reflecting_fake(make_response)):
             results = check_header_xss([ep])
 
         assert len(results) == 1
 
-    def test_stops_after_first_reflecting_header(self):
+    def test_stops_after_first_reflecting_header(self, make_response: Callable) -> None:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
         call_count = 0
 
-        def fake_get(url, headers=None, **kwargs):
+        def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> MagicMock:
             nonlocal call_count
             call_count += 1
-            return _resp(body=f"<html>Echoed: {list((headers or {}).values())[0]}</html>")
+            first_val = next(iter((headers or {}).values()), "")
+            return make_response(body=f"<html>Echoed: {first_val}</html>")
 
         with patch("requests.get", side_effect=fake_get):
             check_header_xss([ep])
 
         assert call_count == 1
 
-    def test_network_exception_is_swallowed(self):
+    def test_network_exception_is_swallowed(self) -> None:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
 
         with patch("requests.get", side_effect=OSError("connection refused")):
@@ -122,15 +125,15 @@ class TestCheckHeaderXss:
 
         assert results == []
 
-    def test_canary_contains_angle_brackets(self):
+    def test_canary_contains_angle_brackets(self, make_response: Callable) -> None:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
         seen_canaries: list[str] = []
 
-        def fake_get(url, headers=None, **kwargs):
+        def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> MagicMock:
             for val in (headers or {}).values():
                 if _CANARY_PREFIX in str(val):
                     seen_canaries.append(str(val))
-            return _resp()
+            return make_response()
 
         with patch("requests.get", side_effect=fake_get):
             check_header_xss([ep])
@@ -138,36 +141,36 @@ class TestCheckHeaderXss:
         assert seen_canaries, "No canary found in any request header"
         assert all(c.startswith("<") and c.endswith(">") for c in seen_canaries)
 
-    def test_all_five_headers_probed_when_no_reflection(self):
+    def test_all_five_headers_probed_when_no_reflection(self, make_response: Callable) -> None:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
         probed: set[str] = set()
 
-        def fake_get(url, headers=None, **kwargs):
+        def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> MagicMock:
             for key, val in (headers or {}).items():
                 if _CANARY_PREFIX in str(val):
                     probed.add(key)
-            return _resp()
+            return make_response()
 
         with patch("requests.get", side_effect=fake_get):
             check_header_xss([ep])
 
-        assert probed == set(_XSS_HEADERS)
+        assert probed == set(XSSHeader)
 
-    def test_deduplicates_same_url_across_endpoint_list(self):
+    def test_deduplicates_same_url_across_endpoint_list(self, make_response: Callable) -> None:
         eps = [
             Endpoint(url="https://app.example.com/page", status_code=200),
             Endpoint(url="https://app.example.com/page", status_code=200),
         ]
 
-        with patch("requests.get", side_effect=_make_reflecting_fake(None)):
+        with patch("requests.get", side_effect=_make_reflecting_fake(make_response)):
             results = check_header_xss(eps)
 
         assert len(results) == 1
 
-    def test_evidence_includes_header_payload_and_snippet(self):
+    def test_evidence_includes_header_payload_and_snippet(self, make_response: Callable) -> None:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
 
-        with patch("requests.get", side_effect=_make_reflecting_fake("Referer")):
+        with patch("requests.get", side_effect=_make_reflecting_fake(make_response, "Referer")):
             results = check_header_xss([ep])
 
         assert results
@@ -176,18 +179,18 @@ class TestCheckHeaderXss:
         assert _CANARY_PREFIX in ev
         assert "Response snippet" in ev
 
-    def test_unique_canary_per_request(self):
+    def test_unique_canary_per_request(self, make_response: Callable) -> None:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
         canaries: list[str] = []
 
-        def fake_get(url, headers=None, **kwargs):
+        def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> MagicMock:
             for val in (headers or {}).values():
                 if _CANARY_PREFIX in str(val):
                     canaries.append(str(val))
-            return _resp()
+            return make_response()
 
         with patch("requests.get", side_effect=fake_get):
             check_header_xss([ep])
 
-        assert len(canaries) == len(_XSS_HEADERS)
+        assert len(canaries) == len(XSSHeader)
         assert len(set(canaries)) == len(canaries), "canaries must be unique per request"

--- a/tests/test_header_xss.py
+++ b/tests/test_header_xss.py
@@ -3,24 +3,24 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 from models import Endpoint, Severity
-from tools.pentest.header_xss import XSSHeader, _CANARY_PREFIX, check_header_xss
+from tools.pentest.header_xss import _CANARY_PREFIX, XSSHeader, check_header_xss
 
 pytestmark = pytest.mark.unit
 
 
 def _make_reflecting_fake(
-    make_response: Callable[..., MagicMock],
+    make_response: Callable,
     match_header: str | None = None,
-) -> Callable[..., MagicMock]:
+) -> Callable:
     """Return a fake requests.get that reflects any canary injected into the
     given header (or any header when match_header is None)."""
 
-    def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> MagicMock:
+    def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> object:
         h = headers or {}
         for key, val in h.items():
             if _CANARY_PREFIX in str(val):
@@ -106,7 +106,7 @@ class TestCheckHeaderXss:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
         call_count = 0
 
-        def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> MagicMock:
+        def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> object:
             nonlocal call_count
             call_count += 1
             first_val = next(iter((headers or {}).values()), "")
@@ -129,7 +129,7 @@ class TestCheckHeaderXss:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
         seen_canaries: list[str] = []
 
-        def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> MagicMock:
+        def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> object:
             for val in (headers or {}).values():
                 if _CANARY_PREFIX in str(val):
                     seen_canaries.append(str(val))
@@ -145,7 +145,7 @@ class TestCheckHeaderXss:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
         probed: set[str] = set()
 
-        def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> MagicMock:
+        def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> object:
             for key, val in (headers or {}).items():
                 if _CANARY_PREFIX in str(val):
                     probed.add(key)
@@ -183,7 +183,7 @@ class TestCheckHeaderXss:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
         canaries: list[str] = []
 
-        def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> MagicMock:
+        def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> object:
             for val in (headers or {}).values():
                 if _CANARY_PREFIX in str(val):
                     canaries.append(str(val))

--- a/tests/test_header_xss.py
+++ b/tests/test_header_xss.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -14,13 +14,13 @@ pytestmark = pytest.mark.unit
 
 
 def _make_reflecting_fake(
-    make_response: Callable,
+    make_response: Callable[..., MagicMock],
     match_header: str | None = None,
-) -> Callable:
+) -> Callable[..., MagicMock]:
     """Return a fake requests.get that reflects any canary injected into the
     given header (or any header when match_header is None)."""
 
-    def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> object:
+    def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> MagicMock:
         h = headers or {}
         for key, val in h.items():
             if _CANARY_PREFIX in str(val):
@@ -32,7 +32,7 @@ def _make_reflecting_fake(
 
 
 class TestCheckHeaderXss:
-    def test_detects_user_agent_reflection(self, make_response: Callable) -> None:
+    def test_detects_user_agent_reflection(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/error", status_code=200)
 
         with patch("requests.get", side_effect=_make_reflecting_fake(make_response, "User-Agent")):
@@ -43,7 +43,7 @@ class TestCheckHeaderXss:
         assert results[0].severity_hint == Severity.HIGH
         assert "User-Agent" in results[0].evidence
 
-    def test_detects_referer_reflection(self, make_response: Callable) -> None:
+    def test_detects_referer_reflection(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
 
         with patch("requests.get", side_effect=_make_reflecting_fake(make_response, "Referer")):
@@ -52,7 +52,9 @@ class TestCheckHeaderXss:
         assert len(results) == 1
         assert "Referer" in results[0].evidence
 
-    def test_detects_x_forwarded_for_reflection(self, make_response: Callable) -> None:
+    def test_detects_x_forwarded_for_reflection(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
 
         with patch(
@@ -64,7 +66,9 @@ class TestCheckHeaderXss:
         assert len(results) == 1
         assert "X-Forwarded-For" in results[0].evidence
 
-    def test_no_finding_when_canary_is_html_encoded(self, make_response: Callable) -> None:
+    def test_no_finding_when_canary_is_html_encoded(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
 
         with patch(
@@ -75,7 +79,7 @@ class TestCheckHeaderXss:
 
         assert results == []
 
-    def test_no_finding_when_canary_absent(self, make_response: Callable) -> None:
+    def test_no_finding_when_canary_absent(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
 
         with patch("requests.get", return_value=make_response(body="<html>Normal</html>")):
@@ -93,7 +97,7 @@ class TestCheckHeaderXss:
         assert results == []
 
     def test_one_finding_per_endpoint_even_when_multiple_headers_reflect(
-        self, make_response: Callable
+        self, make_response: Callable[..., MagicMock]
     ) -> None:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
 
@@ -102,11 +106,13 @@ class TestCheckHeaderXss:
 
         assert len(results) == 1
 
-    def test_stops_after_first_reflecting_header(self, make_response: Callable) -> None:
+    def test_stops_after_first_reflecting_header(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
         call_count = 0
 
-        def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> object:
+        def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> MagicMock:
             nonlocal call_count
             call_count += 1
             first_val = next(iter((headers or {}).values()), "")
@@ -125,11 +131,11 @@ class TestCheckHeaderXss:
 
         assert results == []
 
-    def test_canary_contains_angle_brackets(self, make_response: Callable) -> None:
+    def test_canary_contains_angle_brackets(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
         seen_canaries: list[str] = []
 
-        def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> object:
+        def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> MagicMock:
             for val in (headers or {}).values():
                 if _CANARY_PREFIX in str(val):
                     seen_canaries.append(str(val))
@@ -141,11 +147,13 @@ class TestCheckHeaderXss:
         assert seen_canaries, "No canary found in any request header"
         assert all(c.startswith("<") and c.endswith(">") for c in seen_canaries)
 
-    def test_all_five_headers_probed_when_no_reflection(self, make_response: Callable) -> None:
+    def test_all_five_headers_probed_when_no_reflection(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
         probed: set[str] = set()
 
-        def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> object:
+        def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> MagicMock:
             for key, val in (headers or {}).items():
                 if _CANARY_PREFIX in str(val):
                     probed.add(key)
@@ -156,7 +164,9 @@ class TestCheckHeaderXss:
 
         assert probed == set(XSSHeader)
 
-    def test_deduplicates_same_url_across_endpoint_list(self, make_response: Callable) -> None:
+    def test_deduplicates_same_url_across_endpoint_list(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         eps = [
             Endpoint(url="https://app.example.com/page", status_code=200),
             Endpoint(url="https://app.example.com/page", status_code=200),
@@ -167,7 +177,9 @@ class TestCheckHeaderXss:
 
         assert len(results) == 1
 
-    def test_evidence_includes_header_payload_and_snippet(self, make_response: Callable) -> None:
+    def test_evidence_includes_header_payload_and_snippet(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
 
         with patch("requests.get", side_effect=_make_reflecting_fake(make_response, "Referer")):
@@ -179,11 +191,11 @@ class TestCheckHeaderXss:
         assert _CANARY_PREFIX in ev
         assert "Response snippet" in ev
 
-    def test_unique_canary_per_request(self, make_response: Callable) -> None:
+    def test_unique_canary_per_request(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
         canaries: list[str] = []
 
-        def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> object:
+        def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> MagicMock:
             for val in (headers or {}).values():
                 if _CANARY_PREFIX in str(val):
                     canaries.append(str(val))

--- a/tests/test_header_xss.py
+++ b/tests/test_header_xss.py
@@ -191,6 +191,63 @@ class TestCheckHeaderXss:
         assert _CANARY_PREFIX in ev
         assert "Response snippet" in ev
 
+    def test_header_names_restricts_probed_headers(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
+        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+        probed: set[str] = set()
+
+        def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> MagicMock:
+            for key, val in (headers or {}).items():
+                if _CANARY_PREFIX in str(val):
+                    probed.add(key)
+            return make_response()
+
+        with patch("requests.get", side_effect=fake_get):
+            check_header_xss([ep], header_names=[XSSHeader.REFERER, XSSHeader.X_FORWARDED_FOR])
+
+        assert probed == {"Referer", "X-Forwarded-For"}
+
+    def test_header_names_none_probes_all_headers(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
+        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+        probed: set[str] = set()
+
+        def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> MagicMock:
+            for key, val in (headers or {}).items():
+                if _CANARY_PREFIX in str(val):
+                    probed.add(key)
+            return make_response()
+
+        with patch("requests.get", side_effect=fake_get):
+            check_header_xss([ep], header_names=None)
+
+        assert probed == set(XSSHeader)
+
+    def test_header_names_single_header_finds_reflection(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
+        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+
+        with patch(
+            "requests.get",
+            side_effect=_make_reflecting_fake(make_response, "User-Agent"),
+        ):
+            results = check_header_xss([ep], header_names=[XSSHeader.USER_AGENT])
+
+        assert len(results) == 1
+        assert "User-Agent" in results[0].evidence
+
+    def test_header_names_empty_list_makes_no_requests(self) -> None:
+        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+
+        with patch("requests.get") as mock_get:
+            results = check_header_xss([ep], header_names=[])
+
+        mock_get.assert_not_called()
+        assert results == []
+
     def test_unique_canary_per_request(self, make_response: Callable[..., MagicMock]) -> None:
         ep = Endpoint(url="https://app.example.com/page", status_code=200)
         canaries: list[str] = []

--- a/tests/test_header_xss.py
+++ b/tests/test_header_xss.py
@@ -1,0 +1,193 @@
+"""tests/test_header_xss.py - unit tests for tools/pentest/header_xss.py"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from models import Endpoint, Severity
+from tools.pentest.header_xss import _CANARY_PREFIX, _XSS_HEADERS, check_header_xss
+
+pytestmark = pytest.mark.unit
+
+
+def _resp(body: str = "", status: int = 200) -> MagicMock:
+    r = MagicMock()
+    r.text = body
+    r.status_code = status
+    return r
+
+
+def _make_reflecting_fake(match_header: str | None = None):
+    """Return a fake_get that reflects any canary injected into the given
+    header (or into any header when match_header is None)."""
+
+    def fake_get(url, headers=None, **kwargs):
+        h = headers or {}
+        for key, val in h.items():
+            if _CANARY_PREFIX in str(val):
+                if match_header is None or key == match_header:
+                    return _resp(body=f"<html>Echoed: {val}</html>")
+        return _resp(body="<html>Normal response</html>")
+
+    return fake_get
+
+
+class TestCheckHeaderXss:
+    def test_detects_user_agent_reflection(self):
+        ep = Endpoint(url="https://app.example.com/error", status_code=200)
+
+        with patch("requests.get", side_effect=_make_reflecting_fake("User-Agent")):
+            results = check_header_xss([ep])
+
+        assert len(results) == 1
+        assert results[0].vuln_class == "HeaderXSS"
+        assert results[0].severity_hint == Severity.HIGH
+        assert "User-Agent" in results[0].evidence
+
+    def test_detects_referer_reflection(self):
+        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+
+        with patch("requests.get", side_effect=_make_reflecting_fake("Referer")):
+            results = check_header_xss([ep])
+
+        assert len(results) == 1
+        assert "Referer" in results[0].evidence
+
+    def test_detects_x_forwarded_for_reflection(self):
+        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+
+        with patch("requests.get", side_effect=_make_reflecting_fake("X-Forwarded-For")):
+            results = check_header_xss([ep])
+
+        assert len(results) == 1
+        assert "X-Forwarded-For" in results[0].evidence
+
+    def test_no_finding_when_canary_is_html_encoded(self):
+        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+
+        def fake_get(url, headers=None, **kwargs):
+            return _resp(body="<html>&lt;bountysquad-hxss-test&gt;</html>")
+
+        with patch("requests.get", side_effect=fake_get):
+            results = check_header_xss([ep])
+
+        assert results == []
+
+    def test_no_finding_when_canary_absent(self):
+        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+
+        with patch("requests.get", return_value=_resp(body="<html>Normal</html>")):
+            results = check_header_xss([ep])
+
+        assert results == []
+
+    def test_skips_server_error_endpoints(self):
+        ep = Endpoint(url="https://app.example.com/", status_code=500)
+
+        with patch("requests.get") as mock_get:
+            results = check_header_xss([ep])
+
+        mock_get.assert_not_called()
+        assert results == []
+
+    def test_one_finding_per_endpoint_even_when_multiple_headers_reflect(self):
+        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+
+        with patch("requests.get", side_effect=_make_reflecting_fake(None)):
+            results = check_header_xss([ep])
+
+        assert len(results) == 1
+
+    def test_stops_after_first_reflecting_header(self):
+        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+        call_count = 0
+
+        def fake_get(url, headers=None, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return _resp(body=f"<html>Echoed: {list((headers or {}).values())[0]}</html>")
+
+        with patch("requests.get", side_effect=fake_get):
+            check_header_xss([ep])
+
+        assert call_count == 1
+
+    def test_network_exception_is_swallowed(self):
+        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+
+        with patch("requests.get", side_effect=OSError("connection refused")):
+            results = check_header_xss([ep])
+
+        assert results == []
+
+    def test_canary_contains_angle_brackets(self):
+        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+        seen_canaries: list[str] = []
+
+        def fake_get(url, headers=None, **kwargs):
+            for val in (headers or {}).values():
+                if _CANARY_PREFIX in str(val):
+                    seen_canaries.append(str(val))
+            return _resp()
+
+        with patch("requests.get", side_effect=fake_get):
+            check_header_xss([ep])
+
+        assert seen_canaries, "No canary found in any request header"
+        assert all(c.startswith("<") and c.endswith(">") for c in seen_canaries)
+
+    def test_all_five_headers_probed_when_no_reflection(self):
+        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+        probed: set[str] = set()
+
+        def fake_get(url, headers=None, **kwargs):
+            for key, val in (headers or {}).items():
+                if _CANARY_PREFIX in str(val):
+                    probed.add(key)
+            return _resp()
+
+        with patch("requests.get", side_effect=fake_get):
+            check_header_xss([ep])
+
+        assert probed == set(_XSS_HEADERS)
+
+    def test_deduplicates_same_url_across_endpoint_list(self):
+        eps = [
+            Endpoint(url="https://app.example.com/page", status_code=200),
+            Endpoint(url="https://app.example.com/page", status_code=200),
+        ]
+
+        with patch("requests.get", side_effect=_make_reflecting_fake(None)):
+            results = check_header_xss(eps)
+
+        assert len(results) == 1
+
+    def test_evidence_includes_header_payload_and_snippet(self):
+        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+
+        with patch("requests.get", side_effect=_make_reflecting_fake("Referer")):
+            results = check_header_xss([ep])
+
+        assert results
+        ev = results[0].evidence
+        assert "Referer" in ev
+        assert _CANARY_PREFIX in ev
+        assert "Response snippet" in ev
+
+    def test_unique_canary_per_request(self):
+        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+        canaries: list[str] = []
+
+        def fake_get(url, headers=None, **kwargs):
+            for val in (headers or {}).values():
+                if _CANARY_PREFIX in str(val):
+                    canaries.append(str(val))
+            return _resp()
+
+        with patch("requests.get", side_effect=fake_get):
+            check_header_xss([ep])
+
+        assert len(canaries) == len(_XSS_HEADERS)
+        assert len(set(canaries)) == len(canaries), "canaries must be unique per request"

--- a/tools/pentest/header_xss.py
+++ b/tools/pentest/header_xss.py
@@ -28,19 +28,29 @@ class XSSHeader(StrEnum):
 _CANARY_PREFIX = "bountysquad-hxss-"
 
 
-def check_header_xss(endpoints: list[Endpoint]) -> list[RawFinding]:
+def check_header_xss(
+    endpoints: list[Endpoint],
+    header_names: list[XSSHeader] | None = None,
+) -> list[RawFinding]:
     """
-    Inject a unique angle-bracket canary into each of the five standard headers
+    Inject a unique angle-bracket canary into each of the nominated headers
     in turn and check whether the response body contains the canary verbatim.
 
     Verbatim reflection (unencoded angle brackets) is sufficient evidence of a
     Header XSS class finding: the application echoes raw header values into
     HTML output without sanitisation.
 
+    header_names selects which headers to probe. Pass a subset of XSSHeader
+    values when recon evidence points to a specific header (e.g. User-Agent
+    reflected in error pages). Defaults to all five XSSHeader members.
+
     One finding per endpoint - stops after the first (header, canary) pair that
     triggers reflection so the agent does not get duplicate evidence for the same
     endpoint. Error page endpoints (status >= 500) are skipped at intake.
     """
+    headers_to_probe: list[XSSHeader] = (
+        header_names if header_names is not None else list(XSSHeader)
+    )
     findings: list[RawFinding] = []
     seen: set[str] = set()
     _delay = config.scan.request_delay
@@ -51,7 +61,7 @@ def check_header_xss(endpoints: list[Endpoint]) -> list[RawFinding]:
         if ep.url in seen:
             continue
 
-        for header in XSSHeader:
+        for header in headers_to_probe:
             canary = f"<{_CANARY_PREFIX}{uuid.uuid4().hex[:8]}>"
             try:
                 resp = http.get(  # nosemgrep

--- a/tools/pentest/header_xss.py
+++ b/tools/pentest/header_xss.py
@@ -1,0 +1,92 @@
+"""Header XSS detection - inject XSS canaries into common request headers
+and check whether the application reflects them unencoded in the response body."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from config import config
+from models import Endpoint, RawFinding, Severity
+from tools import http
+from tools._helpers import adaptive_sleep
+
+logger = logging.getLogger(__name__)
+
+_XSS_HEADERS = [
+    "User-Agent",
+    "Referer",
+    "X-Forwarded-For",
+    "X-Custom-Header",
+    "Accept-Language",
+]
+
+_CANARY_PREFIX = "bountysquad-hxss-"
+
+
+def check_header_xss(endpoints: list[Endpoint]) -> list[RawFinding]:
+    """
+    Inject a unique angle-bracket canary into each of the five standard headers
+    in turn and check whether the response body contains the canary verbatim.
+
+    Verbatim reflection (unencoded angle brackets) is sufficient evidence of a
+    Header XSS class finding: the application echoes raw header values into
+    HTML output without sanitisation.
+
+    One finding per endpoint - stops after the first (header, canary) pair that
+    triggers reflection so the agent does not get duplicate evidence for the same
+    endpoint. Error page endpoints (status >= 500) are skipped at intake.
+    """
+    findings: list[RawFinding] = []
+    seen: set[str] = set()
+    _delay = config.scan.request_delay
+
+    for ep in endpoints:
+        if ep.status_code and ep.status_code >= 500:
+            continue
+        if ep.url in seen:
+            continue
+
+        for header_name in _XSS_HEADERS:
+            canary = f"<{_CANARY_PREFIX}{uuid.uuid4().hex[:8]}>"
+            try:
+                resp = http.get(  # nosemgrep
+                    ep.url,
+                    headers={header_name: canary},
+                    timeout=config.recon.http_timeout,
+                    allow_redirects=True,
+                )
+                body = resp.text
+                _delay = adaptive_sleep(_delay, resp.status_code)
+
+                if canary not in body:
+                    continue
+
+                seen.add(ep.url)
+                findings.append(
+                    RawFinding(
+                        title=f"Header XSS - {ep.url}",
+                        vuln_class="HeaderXSS",
+                        target=ep.url,
+                        evidence=(
+                            f"Header: {header_name}\n"
+                            f"Payload: {canary}\n"
+                            f"Status: {resp.status_code}\n"
+                            f"Response snippet: {body[:300]}"
+                        ),
+                        tool="header_xss_probe",
+                        severity_hint=Severity.HIGH,
+                    )
+                )
+                break
+
+            except Exception as exc:
+                logger.debug(
+                    "Header XSS probe failed for %s header %s: %s",
+                    ep.url,
+                    header_name,
+                    exc,
+                )
+
+    logger.info("Header XSS probe found %d findings", len(findings))
+    return findings

--- a/tools/pentest/header_xss.py
+++ b/tools/pentest/header_xss.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from enum import StrEnum
 
 from config import config
 from models import Endpoint, RawFinding, Severity
@@ -13,13 +14,16 @@ from tools._helpers import adaptive_sleep
 
 logger = logging.getLogger(__name__)
 
-_XSS_HEADERS = [
-    "User-Agent",
-    "Referer",
-    "X-Forwarded-For",
-    "X-Custom-Header",
-    "Accept-Language",
-]
+
+class XSSHeader(StrEnum):
+    """HTTP request headers commonly reflected into HTML responses."""
+
+    USER_AGENT = "User-Agent"
+    REFERER = "Referer"
+    X_FORWARDED_FOR = "X-Forwarded-For"
+    X_CUSTOM_HEADER = "X-Custom-Header"
+    ACCEPT_LANGUAGE = "Accept-Language"
+
 
 _CANARY_PREFIX = "bountysquad-hxss-"
 
@@ -47,12 +51,12 @@ def check_header_xss(endpoints: list[Endpoint]) -> list[RawFinding]:
         if ep.url in seen:
             continue
 
-        for header_name in _XSS_HEADERS:
+        for header in XSSHeader:
             canary = f"<{_CANARY_PREFIX}{uuid.uuid4().hex[:8]}>"
             try:
                 resp = http.get(  # nosemgrep
                     ep.url,
-                    headers={header_name: canary},
+                    headers={header: canary},
                     timeout=config.recon.http_timeout,
                     allow_redirects=True,
                 )
@@ -69,7 +73,7 @@ def check_header_xss(endpoints: list[Endpoint]) -> list[RawFinding]:
                         vuln_class="HeaderXSS",
                         target=ep.url,
                         evidence=(
-                            f"Header: {header_name}\n"
+                            f"Header: {header}\n"
                             f"Payload: {canary}\n"
                             f"Status: {resp.status_code}\n"
                             f"Response snippet: {body[:300]}"
@@ -84,7 +88,7 @@ def check_header_xss(endpoints: list[Endpoint]) -> list[RawFinding]:
                 logger.debug(
                     "Header XSS probe failed for %s header %s: %s",
                     ep.url,
-                    header_name,
+                    header,
                     exc,
                 )
 


### PR DESCRIPTION
## Summary

Closes #35.

Adds a new header XSS detection tool that injects a unique angle-bracket canary into five common HTTP request headers (`User-Agent`, `Referer`, `X-Forwarded-For`, `X-Custom-Header`, `Accept-Language`) and checks whether the response body reflects the canary verbatim (unencoded angle brackets = no sanitisation = Header XSS).

- `tools/pentest/header_xss.py` - core `check_header_xss()` function
- `squad/penetration_tester/__init__.py` - `@tool("Header XSS Probe")` wrapper wired into `MEMBER.tools`
- `tests/test_header_xss.py` - 14 unit tests covering detection, encoding bypass, deduplication, per-header probing, and canary uniqueness

H1 weakness type: `Improper Neutralization of HTTP Headers for Scripting Syntax` (documented in tool docstring; CrewAI's `Tool` Pydantic model does not allow arbitrary attribute assignment).

## Test plan

- [x] `pytest tests/test_header_xss.py` - 14 passed
- [x] Full CI stack (ruff, mypy, pytest --cov, bandit) passes locally
- [x] Coverage: 89%
