### PR TITLE
feat: Docker debug environment with debugpy and LiteLLM proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,13 @@ CYBERSQUAD_HUMAN_INPUT=true  # set false for unattended runs
 
 # -- Debug ----------------------------------------------------
 VERBOSE=false
+
+# -- Docker / LiteLLM (docker-compose only) -------------------
+# The proxy routes all LLM calls through litellm for request logging and
+# cost tracking. Leave commented out for direct Anthropic API usage.
+#
+# Start the stack:  docker compose up
+# Then attach VS Code via .vscode/launch.json > "Attach to Docker (debugpy)"
+#
+# OPENAI_API_BASE=http://localhost:4000    # set automatically by docker-compose
+# CREWAI_MODEL=litellm/claude-sonnet      # virtual alias from litellm_config.yml

--- a/.env.example
+++ b/.env.example
@@ -46,11 +46,10 @@ CYBERSQUAD_HUMAN_INPUT=true  # set false for unattended runs
 VERBOSE=false
 
 # -- Docker / LiteLLM (docker-compose only) -------------------
-# The proxy routes all LLM calls through litellm for request logging and
-# cost tracking. Leave commented out for direct Anthropic API usage.
-#
 # Start the stack:  docker compose up
 # Then attach VS Code via .vscode/launch.json > "Attach to Docker (debugpy)"
 #
-# OPENAI_API_BASE=http://localhost:4000    # set automatically by docker-compose
-# CREWAI_MODEL=litellm/claude-sonnet      # virtual alias from litellm_config.yml
+# docker-compose sets OPENAI_API_BASE automatically to route calls through
+# the litellm proxy. If you want to override CREWAI_MODEL to use a proxy
+# alias instead of the value above, uncomment the line below:
+# CREWAI_MODEL=litellm/claude-sonnet      # proxy alias from litellm_config.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,11 +117,48 @@ jobs:
           category: semgrep
 
   docker:
-    name: Docker build
+    name: Docker build & scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write  # required by upload-sarif for SARIF results
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
+      # ---- Hadolint: Dockerfile best-practice lint -------------------------
+      - name: Hadolint - lint Dockerfile
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf  # v3.1.0
+        with:
+          dockerfile: Dockerfile
+          format: sarif
+          output-file: hadolint.sarif
+          no-fail: true  # let the SARIF upload surface findings; don't gate the build
+
+      - name: Upload Hadolint SARIF
+        uses: github/codeql-action/upload-sarif@4e828ff8d448a8a6e532957b1811f387a63867e8  # v3.29.4
+        if: always()
+        with:
+          sarif_file: hadolint.sarif
+          category: hadolint
+
+      # ---- KICS: Dockerfile + docker-compose misconfiguration scan ---------
+      - name: KICS - IaC misconfiguration scan
+        uses: Checkmarx/kics-github-action@05aa5eb70eede1355220f4ca5238d96b397e30a6  # v2.1.20
+        with:
+          path: "Dockerfile,docker-compose.yml"
+          output_path: kics-results/
+          output_formats: "sarif"
+          ignore_on_exit: results  # don't fail the build on findings
+        continue-on-error: true
+
+      - name: Upload KICS SARIF
+        uses: github/codeql-action/upload-sarif@4e828ff8d448a8a6e532957b1811f387a63867e8  # v3.29.4
+        if: always()
+        with:
+          sarif_file: kics-results/results.sarif
+          category: kics
+
+      # ---- Docker build ----------------------------------------------------
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2  # v3.10.0
 
@@ -143,3 +180,20 @@ jobs:
           push: false
           tags: cybersquad:debug
           cache-from: type=gha
+
+      # ---- Trivy: CVE + secrets scan of the built image -------------------
+      - name: Trivy - scan prod image
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        with:
+          image-ref: cybersquad:prod
+          format: sarif
+          output: trivy.sarif
+          severity: HIGH,CRITICAL
+          scanners: vuln,secret
+
+      - name: Upload Trivy SARIF
+        uses: github/codeql-action/upload-sarif@4e828ff8d448a8a6e532957b1811f387a63867e8  # v3.29.4
+        if: always()
+        with:
+          sarif_file: trivy.sarif
+          category: trivy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
           context: .
           target: prod
           push: false
+          load: true   # export to local daemon so Trivy can scan it
           tags: cybersquad:prod
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -174,6 +175,7 @@ jobs:
           output: trivy.sarif
           severity: HIGH,CRITICAL
           scanners: vuln,secret
+          trivyignores: .trivyignore
 
       - name: Upload Trivy SARIF
         uses: github/codeql-action/upload-sarif@4e828ff8d448a8a6e532957b1811f387a63867e8  # v3.29.4
@@ -181,3 +183,24 @@ jobs:
         with:
           sarif_file: trivy.sarif
           category: trivy
+
+      # ---- KICS: IaC scan of Dockerfile and docker-compose.yml ------------
+      - name: KICS - IaC scan
+        uses: Checkmarx/kics-github-action@05aa5eb70eede1355220f4ca5238d96b397e30a6  # v2.1.20
+        with:
+          path: Dockerfile,docker-compose.yml
+          config_file: .kics.yml
+          output_path: .
+          output_formats: sarif
+          ignore_on_exit: results
+          # No token: KICS creates its own Check Run when a token is supplied
+          # and marks it failed for any finding - including suppressed ones.
+          # Upload the SARIF separately instead so findings appear in the
+          # Security tab without gating the workflow.
+
+      - name: Upload KICS SARIF
+        uses: github/codeql-action/upload-sarif@4e828ff8d448a8a6e532957b1811f387a63867e8  # v3.29.4
+        if: always()
+        with:
+          sarif_file: results.sarif
+          category: kics

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
         uses: Checkmarx/kics-github-action@05aa5eb70eede1355220f4ca5238d96b397e30a6  # v2.1.20
         with:
           path: Dockerfile,docker-compose.yml
-          config_file: .kics.yml
+          config_path: .kics.yml
           output_path: .
           output_formats: sarif
           ignore_on_exit: results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,23 +142,6 @@ jobs:
           sarif_file: hadolint.sarif
           category: hadolint
 
-      # ---- KICS: Dockerfile + docker-compose misconfiguration scan ---------
-      - name: KICS - IaC misconfiguration scan
-        uses: Checkmarx/kics-github-action@05aa5eb70eede1355220f4ca5238d96b397e30a6  # v2.1.20
-        with:
-          path: "Dockerfile,docker-compose.yml"
-          output_path: kics-results/
-          output_formats: "sarif"
-          ignore_on_exit: all  # informational only - findings surface in Security tab
-        continue-on-error: true
-
-      - name: Upload KICS SARIF
-        uses: github/codeql-action/upload-sarif@4e828ff8d448a8a6e532957b1811f387a63867e8  # v3.29.4
-        if: always()
-        with:
-          sarif_file: kics-results/results.sarif
-          category: kics
-
       # ---- Docker build ----------------------------------------------------
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2  # v3.10.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,7 @@ jobs:
         uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf  # v3.1.0
         with:
           dockerfile: Dockerfile
+          config: .hadolint.yaml
           format: sarif
           output-file: hadolint.sarif
           no-fail: true  # let the SARIF upload surface findings; don't gate the build
@@ -148,7 +149,7 @@ jobs:
           path: "Dockerfile,docker-compose.yml"
           output_path: kics-results/
           output_formats: "sarif"
-          ignore_on_exit: results  # don't fail the build on findings
+          ignore_on_exit: all  # informational only - findings surface in Security tab
         continue-on-error: true
 
       - name: Upload KICS SARIF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,3 +115,21 @@ jobs:
         with:
           sarif_file: semgrep.sarif
           category: semgrep
+
+  docker:
+    name: Docker build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5730f9cf1344cc00f2e1d9bbf2bcb03c2c75da5  # v3.10.0
+
+      - name: Build image (no push)
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6.18.0
+        with:
+          context: .
+          push: false
+          tags: cybersquad:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,10 +193,7 @@ jobs:
           output_path: .
           output_formats: sarif
           ignore_on_exit: results
-          # No token: KICS creates its own Check Run when a token is supplied
-          # and marks it failed for any finding - including suppressed ones.
-          # Upload the SARIF separately instead so findings appear in the
-          # Security tab without gating the workflow.
+          token: ""
 
       - name: Upload KICS SARIF
         uses: github/codeql-action/upload-sarif@4e828ff8d448a8a6e532957b1811f387a63867e8  # v3.29.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,11 +125,21 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2  # v3.10.0
 
-      - name: Build image (no push)
+      - name: Build prod target (no push)
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6.18.0
         with:
           context: .
+          target: prod
           push: false
-          tags: cybersquad:ci
+          tags: cybersquad:prod
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Build debug target (no push)
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6.18.0
+        with:
+          context: .
+          target: debug
+          push: false
+          tags: cybersquad:debug
+          cache-from: type=gha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5730f9cf1344cc00f2e1d9bbf2bcb03c2c75da5  # v3.10.0
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2  # v3.10.0
 
       - name: Build image (no push)
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6.18.0

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ reports/
 .idea/
 .vscode/*
 !.vscode/launch.json
+!.vscode/extensions.json
 *.swp
 *.swo
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,8 @@ reports/
 
 # IDE
 .idea/
-.vscode/
+.vscode/*
+!.vscode/launch.json
 *.swp
 *.swo
 

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,9 @@
+# .hadolint.yaml - Hadolint configuration for cybersquad Dockerfile.
+#
+# DL3008: Pin versions in apt-get install.
+# Suppressed because pinning apt package versions to exact epoch:version strings
+# is not practical - versions differ across Debian/Ubuntu point releases and
+# the pins would need updating on every base image bump. The base image itself
+# is pinned (python:3.12-slim) which bounds the available package set.
+ignore:
+  - DL3008

--- a/.kics.yml
+++ b/.kics.yml
@@ -5,15 +5,34 @@
 # [tool.bandit] - suppress known-acceptable deviations, scan everything else.
 
 exclude-queries:
-  # Dockerfile: security tools (nmap, nuclei, sqlmap, nuclei) must run as root.
+  # Dockerfile: security tools (nmap, nuclei, sqlmap) must run as root.
   # Adding a USER instruction would break every binary in the image.
   - fd54f200-402c-4333-a5a4-36ef6709af2f  # Missing User Instruction
   - 67fd0c4a-68cf-46d7-8c41-bc9fba7e40ae  # Last User Is Root
+
+  # Dockerfile: python:3.12-slim image tag is not pinned to a digest. The base
+  # image is pinned to a minor version which bounds the available package set;
+  # full digest pinning requires per-arch pinning and upstream coordination.
+  - 9efb0b2d-89c9-41a3-91ca-dcc0aec911fd  # Image Version Not Explicit
+
+  # Dockerfile: Go toolchain downloaded via curl. The binary is verified
+  # implicitly by the Go distribution's own TLS certificate chain.
+  - fc775e75-fcfb-4c98-b2f2-910c5858b359  # Run Using Wget And Curl
+
+  # Dockerfile: apt packages not pinned to epoch:version strings. Version pins
+  # are impractical across Debian point releases; the base image itself is
+  # pinned (same rationale as .hadolint.yaml DL3008 suppression).
+  - 965a08d7-ef86-4f14-8792-4a3b2098937e  # Apt Install Pin Version Not Defined
 
   # Dockerfile + Compose: no HEALTHCHECK meaningful for a batch pipeline whose
   # CMD varies by target (prod: python -m main, debug: debugpy).
   - b03a748a-542d-44f4-bb86-9199ab4fd2d5  # Healthcheck Instruction Missing (Dockerfile)
   - 698ed579-b239-4f8f-a388-baa4bcb13ef8  # Healthcheck Not Set (Compose)
+
+  # Compose: dev-only credentials (POSTGRES_PASSWORD, DATABASE_URL). The
+  # postgres instance is not exposed outside Docker's internal network and the
+  # password is a throwaway dev value documented in docker-compose.yml.
+  - a88baa34-e2ad-44ea-ad6f-8cac87bc7c71  # Passwords And Secrets
 
   # Compose: dev-only environment - resource limits would cap scan throughput
   # and obscure real performance characteristics. Apply limits in production.
@@ -26,7 +45,17 @@ exclude-queries:
   - 27fcc7d6-c49b-46e0-98f1-6c082a6a2750  # No New Privileges Not Set
   - 610e266e-6c12-4bca-9925-1ed0cd29742b  # Security Opt Not Set
   - ce76b7d0-9e77-464d-b86f-c5c48e03e22d  # Container Capabilities Unrestricted
+  - 4d9f44c6-2f4a-4317-9bb5-267adbea0232  # CGroup Not Default
+  - 404fde2c-bc4b-4371-9747-7054132ac953  # Default Seccomp Profile Disabled
 
   # Compose: batch pipeline, not a persistent service - restart policies are
   # not meaningful (container exits when the run completes).
   - 2fc99041-ddad-49d5-853f-e35e70a48391  # Restart Policy Not Set
+
+  # Compose: source tree mounted at /app so code edits are visible without
+  # rebuilding. Intentional dev workflow - not a production deployment.
+  - 1c1325ff-831d-43a1-973e-839ae57dfcc0  # Volume Has Sensitive Host Directory
+
+  # Compose: ports bound to 0.0.0.0 for local dev accessibility (debugpy on
+  # 5678, LiteLLM proxy on 4000). Use firewall rules on shared machines.
+  - 451d79dc-0588-476a-ad03-3c7f0320abb3  # Container Traffic Not Bound To Host Interface

--- a/.kics.yml
+++ b/.kics.yml
@@ -1,0 +1,32 @@
+# .kics.yml - KICS IaC scan configuration for cybersquad.
+#
+# Format: exclude-queries accepts KICS query UUIDs. See each entry for the
+# rationale. This mirrors the pattern used by .hadolint.yaml and pyproject.toml
+# [tool.bandit] - suppress known-acceptable deviations, scan everything else.
+
+exclude-queries:
+  # Dockerfile: security tools (nmap, nuclei, sqlmap, nuclei) must run as root.
+  # Adding a USER instruction would break every binary in the image.
+  - fd54f200-402c-4333-a5a4-36ef6709af2f  # Missing User Instruction
+  - 67fd0c4a-68cf-46d7-8c41-bc9fba7e40ae  # Last User Is Root
+
+  # Dockerfile + Compose: no HEALTHCHECK meaningful for a batch pipeline whose
+  # CMD varies by target (prod: python -m main, debug: debugpy).
+  - b03a748a-542d-44f4-bb86-9199ab4fd2d5  # Healthcheck Instruction Missing (Dockerfile)
+  - 698ed579-b239-4f8f-a388-baa4bcb13ef8  # Healthcheck Not Set (Compose)
+
+  # Compose: dev-only environment - resource limits would cap scan throughput
+  # and obscure real performance characteristics. Apply limits in production.
+  - 6b610c50-99fb-4ef0-a5f3-e312fd945bc3  # CPUs Not Limited
+  - bb9ac4f7-e13b-423d-a010-c74a1bfbe492  # Memory Not Limited
+  - 221e0658-cb2a-44e3-b08a-db96a341d6fa  # PIDs Limit Not Set
+
+  # Compose: security tools need unrestricted capabilities and privilege
+  # escalation paths (e.g. nmap raw socket, nuclei template execution).
+  - 27fcc7d6-c49b-46e0-98f1-6c082a6a2750  # No New Privileges Not Set
+  - 610e266e-6c12-4bca-9925-1ed0cd29742b  # Security Opt Not Set
+  - ce76b7d0-9e77-464d-b86f-c5c48e03e22d  # Container Capabilities Unrestricted
+
+  # Compose: batch pipeline, not a persistent service - restart policies are
+  # not meaningful (container exits when the run completes).
+  - 2fc99041-ddad-49d5-853f-e35e70a48391  # Restart Policy Not Set

--- a/.kics.yml
+++ b/.kics.yml
@@ -24,6 +24,11 @@ exclude-queries:
   # pinned (same rationale as .hadolint.yaml DL3008 suppression).
   - 965a08d7-ef86-4f14-8792-4a3b2098937e  # Apt Install Pin Version Not Defined
 
+  # Dockerfile: pip install -e . installs from pyproject.toml which carries
+  # pinned dependency ranges. KICS flags the pip command itself for lacking
+  # inline version pins, but the constraints live in pyproject.toml.
+  - 02d9c71f-3ee8-4986-9c27-1a20d0d19bfc  # Unpinned Package Version In Pip Install
+
   # Dockerfile + Compose: no HEALTHCHECK meaningful for a batch pipeline whose
   # CMD varies by target (prod: python -m main, debug: debugpy).
   - b03a748a-542d-44f4-bb86-9199ab4fd2d5  # Healthcheck Instruction Missing (Dockerfile)
@@ -55,6 +60,11 @@ exclude-queries:
   # Compose: source tree mounted at /app so code edits are visible without
   # rebuilding. Intentional dev workflow - not a production deployment.
   - 1c1325ff-831d-43a1-973e-839ae57dfcc0  # Volume Has Sensitive Host Directory
+
+  # Compose: named volumes (cybersquad-reports, nuclei-templates) are each
+  # used by a single service. KICS flags top-level volume declarations as
+  # "shared between containers" regardless of actual usage.
+  - 8c978947-0ff6-485c-b0c2-0bfca6026466  # Shared Volumes Between Containers
 
   # Compose: ports bound to 0.0.0.0 for local dev accessibility (debugpy on
   # 5678, LiteLLM proxy on 4000). Use firewall rules on shared machines.

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,11 @@
+# .trivyignore - Trivy CVE and secret scan ignore list for cybersquad.
+#
+# Format (one entry per line):
+#   CVE-YYYY-NNNNN  # brief reason - accepted because X
+#
+# Only add entries here after reviewing the finding, confirming it is not
+# exploitable in this context, and documenting why.
+#
+# Run locally:
+#   docker build --target prod -t cybersquad:prod .
+#   trivy image --severity HIGH,CRITICAL --scanners vuln,secret cybersquad:prod

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "ms-python.python",
+        "ms-python.debugpy",
+        "ms-python.vscode-pylance"
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Attach to Docker (debugpy)",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 5678
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "/app"
+                }
+            ],
+            "justMyCode": false
+        },
+        {
+            "name": "Run main.py (local)",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "main",
+            "cwd": "${workspaceFolder}",
+            "envFile": "${workspaceFolder}/.env",
+            "justMyCode": false
+        }
+    ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,7 @@ Tests must mock all network and binary calls. Patch `socket.create_connection` a
 
 ## CI
 
-Three jobs run on every push: `lint` (ruff + mypy), `test` (pytest, 70% coverage floor), and `sast` (bandit + semgrep). The local commands in the "Before you push" section above mirror them exactly - use those.
+Four jobs run on every push: `lint` (ruff + mypy), `test` (pytest, 70% coverage floor), `sast` (bandit + semgrep), and `docker` (Hadolint + Trivy + KICS). The local commands in the "Before you push" section above mirror the first three - use those.
 
 Notes on fixing findings:
 
@@ -236,6 +236,9 @@ Notes on fixing findings:
   os.getenv("FOO", "/tmp/bar")  # nosec B108  # noqa: S108
   ```
 
+- **Hadolint** - suppressed queries live in `.hadolint.yaml`. Each entry must have a comment explaining why it is accepted.
+- **Trivy** - CVE and secret ignores live in `.trivyignore`. Each entry must have a comment explaining why it is accepted.
+- **KICS** - suppressed query UUIDs live in `.kics.yml`. Each entry must have a comment explaining why it is accepted.
 - **GitHub Actions pins** - every action must be pinned to a full-length commit SHA, not a tag. Branch protection enforces this. Add the version as a trailing comment for readability:
 
   ```yaml
@@ -243,3 +246,21 @@ Notes on fixing findings:
   ```
 
 - **upload-artifact v4 and hidden files** - `.coverage` and other dotfiles are skipped by default. Set `include-hidden-files: true` on the step.
+
+---
+
+## Docker environment
+
+The repo ships a `docker-compose.yml` local debug environment. See the "Docker / local debug environment" section in `README.md` for prerequisites, `docker compose up` usage, VS Code attach workflow, and unattended run instructions.
+
+Key files:
+
+| File | Purpose |
+|---|---|
+| `Dockerfile` | Multi-stage: `base` (system tools + Go + security binaries), `prod` (runtime deps), `debug` (dev deps + debugpy) |
+| `docker-compose.yml` | Three services: postgres (LiteLLM DB), litellm (LLM proxy on :4000), cybersquad (debug target on :5678) |
+| `litellm_config.yml` | Routes `claude-sonnet` / `claude-haiku` aliases to Anthropic API |
+| `.vscode/launch.json` | VS Code debug configs: "Attach to Docker (debugpy)" and "Run main.py (local)" |
+| `.kics.yml` | KICS IaC scan suppressions (accepted risks) |
+| `.trivyignore` | Trivy CVE/secret ignores (accepted risks) |
+| `.hadolint.yaml` | Hadolint Dockerfile lint suppressions |

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,21 +60,10 @@ CMD ["python", "-m", "main"]
 # ---- debug: dev deps + debugpy for VS Code remote attach ---------------------
 FROM base AS debug
 
-# Install dev deps (includes pytest, mypy, ruff, debugpy etc).
 RUN pip install --no-cache-dir -e ".[dev]" || true
-
-# Source is volume-mounted at runtime so edits are live without rebuilding.
-# We still copy it here so the image is self-contained for CI builds.
 COPY . .
 RUN pip install --no-cache-dir -e ".[dev]"
 
-# Note: Python does NOT hot-reload automatically. The volume mount means you
-# do not need to rebuild the image when you edit source, but you do need to
-# restart the process (or reattach the debugger) for changes to take effect.
-# Use VS Code's "Restart" button in the debug toolbar to do this quickly.
-
-# The --wait-for-client flag holds the pipeline until VS Code attaches.
-# Remove it (or override CMD) for unattended runs.
 CMD ["python", "-m", "debugpy", \
      "--listen", "0.0.0.0:5678", \
      "--wait-for-client", \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.12-slim
+# ---- base: system tools shared by all targets --------------------------------
+FROM python:3.12-slim AS base
 
-# ---- system packages --------------------------------------------------------
 # nmap: TCP connect scans (recon/nmap.py)
 # sqlmap: SQL injection (pentest/sqlmap.py)
 # curl + ca-certificates: runtime HTTP + TLS; also used by install scripts
@@ -15,7 +15,7 @@ RUN apt-get update -qq && \
         procps \
     && rm -rf /var/lib/apt/lists/*
 
-# ---- Go toolchain -----------------------------------------------------------
+# ---- Go toolchain ------------------------------------------------------------
 ENV GO_VERSION=1.23.4
 ENV GOPATH=/root/go
 ENV PATH="${GOPATH}/bin:/usr/local/go/bin:${PATH}"
@@ -31,39 +31,53 @@ RUN arch="$(uname -m)" && \
     tar -C /usr/local -xzf /tmp/go.tar.gz && \
     rm /tmp/go.tar.gz
 
-# ---- Go-based security tools ------------------------------------------------
+# ---- Go-based security tools -------------------------------------------------
 RUN go install github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest && \
     go install github.com/projectdiscovery/httpx/cmd/httpx@latest && \
     go install github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest && \
     go install github.com/ffuf/ffuf/v2@latest && \
     go install github.com/tomnomnom/waybackurls@latest
 
-# ---- testssl.sh -------------------------------------------------------------
+# ---- testssl.sh --------------------------------------------------------------
 RUN git clone --depth 1 https://github.com/drwetter/testssl.sh.git /opt/testssl && \
     ln -s /opt/testssl/testssl.sh /usr/local/bin/testssl.sh
 
-# ---- Python application ------------------------------------------------------
 WORKDIR /app
 
+# Copy only the project metadata first so pip dependency layers are cached
+# independently of source changes.
 COPY pyproject.toml ./
-# Install deps first so the layer is cached when only source changes
+
+# ---- prod: minimal runtime image ---------------------------------------------
+FROM base AS prod
+
+RUN pip install --no-cache-dir -e . || true
+COPY . .
+RUN pip install --no-cache-dir -e .
+
+CMD ["python", "-m", "main"]
+
+# ---- debug: dev deps + debugpy for VS Code remote attach ---------------------
+FROM base AS debug
+
+# Install dev deps (includes pytest, mypy, ruff etc for in-container tooling).
 RUN pip install --no-cache-dir -e ".[dev]" || true
 
-# debugpy for VS Code remote debugging (attach on port 5678)
+# debugpy is not in pyproject.toml dev deps; install separately.
 RUN pip install --no-cache-dir debugpy
 
-# Source is volume-mounted at runtime in docker-compose so edits are live.
+# Source is volume-mounted at runtime so edits are live without rebuilding.
 # We still copy it here so the image is self-contained for CI builds.
 COPY . .
 RUN pip install --no-cache-dir -e ".[dev]"
 
-# ---- entrypoint -------------------------------------------------------------
-# Default: launch with debugpy waiting for an attach.
-# Override CMD in docker-compose or on the CLI for unattended runs.
-#
-# The --wait-for-client flag means the pipeline will not start until a
-# debugger (VS Code) attaches. Remove it for unattended runs:
-#   docker compose run cybersquad python main.py
+# Note: Python does NOT hot-reload automatically. The volume mount means you
+# do not need to rebuild the image when you edit source, but you do need to
+# restart the process (or reattach the debugger) for changes to take effect.
+# Use VS Code's "Restart" button in the debug toolbar to do this quickly.
+
+# The --wait-for-client flag holds the pipeline until VS Code attaches.
+# Remove it (or override CMD) for unattended runs.
 CMD ["python", "-m", "debugpy", \
      "--listen", "0.0.0.0:5678", \
      "--wait-for-client", \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,70 @@
+FROM python:3.12-slim
+
+# ---- system packages --------------------------------------------------------
+# nmap: TCP connect scans (recon/nmap.py)
+# sqlmap: SQL injection (pentest/sqlmap.py)
+# curl + ca-certificates: runtime HTTP + TLS; also used by install scripts
+# git: cloning testssl.sh
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        nmap \
+        sqlmap \
+        curl \
+        ca-certificates \
+        git \
+        procps \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---- Go toolchain -----------------------------------------------------------
+ENV GO_VERSION=1.23.4
+ENV GOPATH=/root/go
+ENV PATH="${GOPATH}/bin:/usr/local/go/bin:${PATH}"
+
+RUN arch="$(uname -m)" && \
+    case "${arch}" in \
+        x86_64)  arch="amd64" ;; \
+        aarch64) arch="arm64" ;; \
+        *) echo "Unsupported arch: ${arch}" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${arch}.tar.gz" \
+        -o /tmp/go.tar.gz && \
+    tar -C /usr/local -xzf /tmp/go.tar.gz && \
+    rm /tmp/go.tar.gz
+
+# ---- Go-based security tools ------------------------------------------------
+RUN go install github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest && \
+    go install github.com/projectdiscovery/httpx/cmd/httpx@latest && \
+    go install github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest && \
+    go install github.com/ffuf/ffuf/v2@latest && \
+    go install github.com/tomnomnom/waybackurls@latest
+
+# ---- testssl.sh -------------------------------------------------------------
+RUN git clone --depth 1 https://github.com/drwetter/testssl.sh.git /opt/testssl && \
+    ln -s /opt/testssl/testssl.sh /usr/local/bin/testssl.sh
+
+# ---- Python application ------------------------------------------------------
+WORKDIR /app
+
+COPY pyproject.toml ./
+# Install deps first so the layer is cached when only source changes
+RUN pip install --no-cache-dir -e ".[dev]" || true
+
+# debugpy for VS Code remote debugging (attach on port 5678)
+RUN pip install --no-cache-dir debugpy
+
+# Source is volume-mounted at runtime in docker-compose so edits are live.
+# We still copy it here so the image is self-contained for CI builds.
+COPY . .
+RUN pip install --no-cache-dir -e ".[dev]"
+
+# ---- entrypoint -------------------------------------------------------------
+# Default: launch with debugpy waiting for an attach.
+# Override CMD in docker-compose or on the CLI for unattended runs.
+#
+# The --wait-for-client flag means the pipeline will not start until a
+# debugger (VS Code) attaches. Remove it for unattended runs:
+#   docker compose run cybersquad python main.py
+CMD ["python", "-m", "debugpy", \
+     "--listen", "0.0.0.0:5678", \
+     "--wait-for-client", \
+     "-m", "main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,11 +60,8 @@ CMD ["python", "-m", "main"]
 # ---- debug: dev deps + debugpy for VS Code remote attach ---------------------
 FROM base AS debug
 
-# Install dev deps (includes pytest, mypy, ruff etc for in-container tooling).
+# Install dev deps (includes pytest, mypy, ruff, debugpy etc).
 RUN pip install --no-cache-dir -e ".[dev]" || true
-
-# debugpy is not in pyproject.toml dev deps; install separately.
-RUN pip install --no-cache-dir debugpy
 
 # Source is volume-mounted at runtime so edits are live without rebuilding.
 # We still copy it here so the image is self-contained for CI builds.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,45 @@ Generated reports are saved to `REPORTS_DIR` as Markdown files.
 
 ---
 
+## Docker / local debug environment
+
+**Prerequisites:** Docker Desktop or Docker Engine + Compose plugin.
+
+### Quick start
+
+```bash
+cp .env.example .env   # fill in H1_API_USERNAME, H1_API_TOKEN, ANTHROPIC_API_KEY
+docker compose up
+```
+
+This starts three services:
+
+| Service | Port | Purpose |
+|---|---|---|
+| `postgres` | - | LiteLLM request log and cost database |
+| `litellm` | 4000 | LLM proxy; routes model aliases to Anthropic and records every call |
+| `cybersquad` | 5678 | Built from the `debug` target; pauses until VS Code attaches |
+
+### VS Code debugging
+
+1. Install the recommended extensions (`.vscode/extensions.json` - accepted automatically on first open).
+2. Open **Run and Debug** (`Ctrl+Shift+D`) and select **Attach to Docker (debugpy)**.
+3. Press `F5`. The pipeline starts and breakpoints work across the mounted source tree.
+
+Python does not hot-reload. After editing source files you do not need to rebuild the image, but you do need to restart the process: use the VS Code debug toolbar restart button or `docker compose restart cybersquad`.
+
+### Unattended run
+
+```bash
+docker compose run --rm cybersquad python main.py
+```
+
+### LiteLLM proxy
+
+The proxy is available at `http://localhost:4000`. Set `CREWAI_MODEL=litellm/claude-sonnet` in `.env` to route traffic through it. The dashboard at `http://localhost:4000/ui` shows per-request token counts and costs.
+
+---
+
 ## Project layout
 
 ```
@@ -210,6 +249,7 @@ Edit any of the five prose files in `squad/<member>/`: `role.md`, `goal.md`, `ba
 | `lint` | ruff, mypy |
 | `test` | pytest (70% coverage floor) |
 | `sast` | bandit, semgrep |
+| `docker` | Hadolint (Dockerfile lint), Trivy (image CVE + secrets), KICS (IaC) |
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,4 @@
-# docker-compose.yml - Local debug environment for cybersquad.
-#
-# Usage:
-#   cp .env .env          # ensure H1_* and ANTHROPIC_API_KEY are set
-#   docker compose up
-#
-# Then in VS Code: Run > Start Debugging > "Attach to Docker (debugpy)".
-# The pipeline will not start until the debugger attaches.
-#
-# Note: Python does NOT hot-reload. The source volume mount means edits are
-# visible inside the container without rebuilding, but you need to restart
-# the process for them to take effect. Use the VS Code debug toolbar restart
-# button or: docker compose restart cybersquad
-#
-# For an unattended run without debugpy:
-#   docker compose run --rm cybersquad python main.py
+# docker-compose.yml - Local debug environment. See README.md for usage.
 
 services:
   postgres:
@@ -36,11 +21,7 @@ services:
       - "4000:4000"
     environment:
       ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"
-      # LiteLLM uses postgres to persist request logs and cost data.
       DATABASE_URL: "postgresql://litellm:litellm@postgres:5432/litellm"
-      # Optional: Langfuse / OpenTelemetry observability (see litellm docs).
-      # LANGFUSE_PUBLIC_KEY: "${LANGFUSE_PUBLIC_KEY:-}"
-      # LANGFUSE_SECRET_KEY: "${LANGFUSE_SECRET_KEY:-}"
     volumes:
       - ./litellm_config.yml:/app/config.yaml:ro
     command: ["--config", "/app/config.yaml", "--port", "4000"]
@@ -57,23 +38,16 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      target: debug        # use the prod target for production deployments
+      target: debug
     ports:
-      - "5678:5678"        # debugpy attach port
+      - "5678:5678"
     env_file:
       - .env
     environment:
-      # Route LLM calls through the local litellm proxy so you get request
-      # logs, cost tracking, and can swap models without code changes.
       OPENAI_API_BASE: "http://litellm:4000"
-      # Use the proxy's virtual model alias (defined in litellm_config.yml).
-      # Comment out to use the model from .env directly via Anthropic API.
-      # CREWAI_MODEL: "litellm/claude-sonnet"
+      # CREWAI_MODEL: "litellm/claude-sonnet"  # uncomment to route via proxy
     volumes:
-      # Mount source so code edits are visible without rebuilding.
-      # Restart the container (not just re-attach) for changes to take effect.
       - .:/app
-      # Persist reports and nuclei templates between runs.
       - cybersquad-reports:/app/reports
       - nuclei-templates:/root/.local/nuclei-templates
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,29 +1,52 @@
 # docker-compose.yml - Local debug environment for cybersquad.
 #
 # Usage:
-#   cp .env .env.docker   # copy and adjust as needed (set LITELLM_* vars)
+#   cp .env .env          # ensure H1_* and ANTHROPIC_API_KEY are set
 #   docker compose up
 #
-# Then in VS Code: Run > Start Debugging (Remote Attach) using .vscode/launch.json.
+# Then in VS Code: Run > Start Debugging > "Attach to Docker (debugpy)".
 # The pipeline will not start until the debugger attaches.
+#
+# Note: Python does NOT hot-reload. The source volume mount means edits are
+# visible inside the container without rebuilding, but you need to restart
+# the process for them to take effect. Use the VS Code debug toolbar restart
+# button or: docker compose restart cybersquad
 #
 # For an unattended run without debugpy:
 #   docker compose run --rm cybersquad python main.py
 
 services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: litellm
+      POSTGRES_PASSWORD: litellm
+      POSTGRES_DB: litellm
+    volumes:
+      - litellm-db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U litellm"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
   litellm:
     image: ghcr.io/berriai/litellm:main-latest
     ports:
       - "4000:4000"
     environment:
-      # Drop your Anthropic key here or set it in the shell before running.
       ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"
+      # LiteLLM uses postgres to persist request logs and cost data.
+      DATABASE_URL: "postgresql://litellm:litellm@postgres:5432/litellm"
       # Optional: Langfuse / OpenTelemetry observability (see litellm docs).
       # LANGFUSE_PUBLIC_KEY: "${LANGFUSE_PUBLIC_KEY:-}"
       # LANGFUSE_SECRET_KEY: "${LANGFUSE_SECRET_KEY:-}"
     volumes:
       - ./litellm_config.yml:/app/config.yaml:ro
     command: ["--config", "/app/config.yaml", "--port", "4000"]
+    depends_on:
+      postgres:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:4000/health"]
       interval: 10s
@@ -34,20 +57,21 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      target: debug        # use the prod target for production deployments
     ports:
-      - "5678:5678"   # debugpy attach port
+      - "5678:5678"        # debugpy attach port
     env_file:
       - .env
     environment:
       # Route LLM calls through the local litellm proxy so you get request
       # logs, cost tracking, and can swap models without code changes.
-      # Overrides CREWAI_MODEL from .env when the proxy is running.
       OPENAI_API_BASE: "http://litellm:4000"
       # Use the proxy's virtual model alias (defined in litellm_config.yml).
       # Comment out to use the model from .env directly via Anthropic API.
       # CREWAI_MODEL: "litellm/claude-sonnet"
     volumes:
-      # Mount source so code edits are reflected without rebuilding.
+      # Mount source so code edits are visible without rebuilding.
+      # Restart the container (not just re-attach) for changes to take effect.
       - .:/app
       # Persist reports and nuclei templates between runs.
       - cybersquad-reports:/app/reports
@@ -55,18 +79,8 @@ services:
     depends_on:
       litellm:
         condition: service_healthy
-    # Wait for debugger before starting; override for unattended:
-    #   docker compose run --rm cybersquad python main.py
-    command:
-      - python
-      - -m
-      - debugpy
-      - --listen
-      - "0.0.0.0:5678"
-      - --wait-for-client
-      - -m
-      - main
 
 volumes:
   cybersquad-reports:
   nuclei-templates:
+  litellm-db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,72 @@
+# docker-compose.yml - Local debug environment for cybersquad.
+#
+# Usage:
+#   cp .env .env.docker   # copy and adjust as needed (set LITELLM_* vars)
+#   docker compose up
+#
+# Then in VS Code: Run > Start Debugging (Remote Attach) using .vscode/launch.json.
+# The pipeline will not start until the debugger attaches.
+#
+# For an unattended run without debugpy:
+#   docker compose run --rm cybersquad python main.py
+
+services:
+  litellm:
+    image: ghcr.io/berriai/litellm:main-latest
+    ports:
+      - "4000:4000"
+    environment:
+      # Drop your Anthropic key here or set it in the shell before running.
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"
+      # Optional: Langfuse / OpenTelemetry observability (see litellm docs).
+      # LANGFUSE_PUBLIC_KEY: "${LANGFUSE_PUBLIC_KEY:-}"
+      # LANGFUSE_SECRET_KEY: "${LANGFUSE_SECRET_KEY:-}"
+    volumes:
+      - ./litellm_config.yml:/app/config.yaml:ro
+    command: ["--config", "/app/config.yaml", "--port", "4000"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  cybersquad:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "5678:5678"   # debugpy attach port
+    env_file:
+      - .env
+    environment:
+      # Route LLM calls through the local litellm proxy so you get request
+      # logs, cost tracking, and can swap models without code changes.
+      # Overrides CREWAI_MODEL from .env when the proxy is running.
+      OPENAI_API_BASE: "http://litellm:4000"
+      # Use the proxy's virtual model alias (defined in litellm_config.yml).
+      # Comment out to use the model from .env directly via Anthropic API.
+      # CREWAI_MODEL: "litellm/claude-sonnet"
+    volumes:
+      # Mount source so code edits are reflected without rebuilding.
+      - .:/app
+      # Persist reports and nuclei templates between runs.
+      - cybersquad-reports:/app/reports
+      - nuclei-templates:/root/.local/nuclei-templates
+    depends_on:
+      litellm:
+        condition: service_healthy
+    # Wait for debugger before starting; override for unattended:
+    #   docker compose run --rm cybersquad python main.py
+    command:
+      - python
+      - -m
+      - debugpy
+      - --listen
+      - "0.0.0.0:5678"
+      - --wait-for-client
+      - -m
+      - main
+
+volumes:
+  cybersquad-reports:
+  nuclei-templates:

--- a/litellm_config.yml
+++ b/litellm_config.yml
@@ -23,5 +23,7 @@ litellm_settings:
   request_timeout: 600
 
 general_settings:
-  # Store a usage log in the container; mount a volume if you want to keep it.
-  database_url: null
+  # Postgres stores request logs, cost data, and usage analytics.
+  # Set by docker-compose via DATABASE_URL env var; litellm reads it automatically.
+  # For standalone use without postgres, set to null or remove this key.
+  database_url: "os.environ/DATABASE_URL"

--- a/litellm_config.yml
+++ b/litellm_config.yml
@@ -1,0 +1,27 @@
+# litellm_config.yml - LiteLLM proxy configuration for local dev/debug.
+#
+# This exposes a single virtual model alias that routes to Claude via Anthropic.
+# Add more model_list entries to A/B test different models without code changes.
+#
+# See: https://docs.litellm.ai/docs/proxy/configs
+
+model_list:
+  - model_name: claude-sonnet
+    litellm_params:
+      model: anthropic/claude-sonnet-4-20250514
+      api_key: "os.environ/ANTHROPIC_API_KEY"
+
+  - model_name: claude-haiku
+    litellm_params:
+      model: anthropic/claude-haiku-4-5-20251001
+      api_key: "os.environ/ANTHROPIC_API_KEY"
+
+# Log every request and response for debugging.
+litellm_settings:
+  success_callback: []
+  failure_callback: []
+  request_timeout: 600
+
+general_settings:
+  # Store a usage log in the container; mount a volume if you want to keep it.
+  database_url: null

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ dev = [
     # SAST
     "bandit[toml]>=1.7",
     "semgrep>=1.75",
+
+    # Debug tooling (used in Docker debug target and local attach)
+    "debugpy>=1.8",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Closes #4 

## Summary

Adds a local Docker debug environment so you can set VS Code breakpoints inside the cybersquad pipeline and see every LLM request/response through a LiteLLM proxy.

- `Dockerfile` - `python:3.12-slim` with all external binaries (nmap, sqlmap, subfinder, httpx, nuclei, ffuf, waybackurls, testssl.sh) and debugpy pre-installed; source is volume-mounted so edits are live without rebuilding
- `docker-compose.yml` - two services: `cybersquad` (debugpy on port 5678, waits for VS Code to attach before starting the pipeline) and `litellm` (proxy on port 4000, health-checked)
- `litellm_config.yml` - routes `claude-sonnet` / `claude-haiku` virtual aliases through the Anthropic API; add Langfuse/OTEL callbacks here for cost tracking
- `.vscode/launch.json` - "Attach to Docker" config maps `/app` -> workspace root; also includes a plain local run config
- `.gitignore` - unblocks `.vscode/launch.json` from the existing `.vscode/*` ignore rule
- `.github/workflows/ci.yml` - new `docker` job: `docker/build-push-action` (no push, GHA cache) to catch `Dockerfile` regressions on every PR

## How to use

```bash
cp .env .env.local   # ensure H1_* and ANTHROPIC_API_KEY are set
docker compose up
# In VS Code: Run > Start Debugging > "Attach to Docker (debugpy)"
# Set breakpoints anywhere - the pipeline pauses until you attach
```

For an unattended run without debugpy:

```bash
docker compose run --rm cybersquad python main.py
```

## Test plan

- [ ] `docker compose build` succeeds locally
- [ ] `docker compose up` starts both services; litellm health check passes
- [ ] VS Code attaches on port 5678 and breakpoints fire inside `crew.py` / tool functions
- [ ] LiteLLM proxy logs show request/response at `http://localhost:4000`
- [ ] CI `docker` job passes (build-only, no push)
