### PR TITLE
refactor(docs): slim CLAUDE.md to non-negotiables + index, extract docs and skills

### DIFF
--- a/.claude/skills/cybersquad-agent-llm/SKILL.md
+++ b/.claude/skills/cybersquad-agent-llm/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: cybersquad-agent-llm
+description: Construct CrewAI Agents in cybersquad with the correct LLM. Always use crewai.LLM(model=..., temperature=..., max_tokens=...) with a litellm provider prefix on the model name. Passing a bare model string to Agent(llm=...) silently ignores temperature and max_tokens. Use when editing crew.py or any code that constructs a CrewAI Agent or LLM.
+---
+
+# Agent LLM construction
+
+## The rule
+
+Always construct the LLM explicitly using `crewai.LLM`:
+
+```python
+from crewai import LLM
+
+llm = LLM(
+    model=config.llm.model,
+    temperature=config.llm.temperature,
+    max_tokens=config.llm.max_tokens,
+)
+```
+
+Then pass that `llm` into the `Agent(llm=...)` keyword. Never pass a bare model string to `Agent(llm=...)` directly - CrewAI silently ignores `temperature` and `max_tokens` in that path, and the agent runs with defaults that do not match `config.llm`.
+
+## The model prefix
+
+The model name must include the litellm provider prefix:
+
+```python
+# correct
+config.llm.model == "anthropic/claude-sonnet-4-20250514"
+
+# wrong - litellm cannot route this
+config.llm.model == "claude-sonnet-4-20250514"
+```
+
+If you change the default model in `config.py`, keep the `anthropic/` (or other provider) prefix on it. If a test asserts on cost estimation or token counting, the prefix-aware code path in `tools/metrics.py` strips everything up to and including the first `/` before the pricing-table lookup - do not regress that.
+
+## Trigger checklist
+
+Apply this skill whenever you are:
+
+- editing `crew.py`
+- editing anything that imports `crewai.Agent`
+- changing `config.llm.model`, `config.llm.temperature`, or `config.llm.max_tokens`
+- writing a test that instantiates an `LLM` or an `Agent`

--- a/.claude/skills/cybersquad-change-discipline/SKILL.md
+++ b/.claude/skills/cybersquad-change-discipline/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: cybersquad-change-discipline
+description: Apply change-discipline when editing existing code in this repo. Keep diffs minimal and in-scope, preserve comments and symbol names unless the rename is intentional and in scope, treat linter and SAST findings as engineering signal rather than noise to suppress, and surface blockers via question or a well-formed FIXME/TODO rather than silently working around them. Use when editing existing files, about to add `# noqa` / `# type: ignore` / `# nosec`, considering a rename or refactor outside the stated task, or encountering a CI failure.
+---
+
+# Change discipline
+
+The goal of any PR is to satisfy its acceptance criteria with the smallest, most inarguable diff possible. Reviewer attention is the bottleneck; every byte of unrelated change is friction.
+
+## Minimal diff
+
+Inspired by Google's "Small CLs" guidance: a PR should do one thing. Before any commit:
+
+- Run `git diff origin/main --stat` and ask: does every changed file relate to the stated task? If not, revert the unrelated change or move it to its own branch.
+- Leave whitespace, formatting, and import order alone unless the linter required the change.
+- Do not rewrite working code to a "cleaner" form unless cleanliness was the task.
+
+## Preserve names, comments, and structure unless the change is the task
+
+Code carries intent. Symbol names, comment wording, and file layout all encode what the original author understood. A drive-by rename inside an unrelated PR:
+
+- breaks `git blame` continuity
+- loses the author's framing
+- makes the diff argue about two things at once (the rename *and* the actual change)
+
+Rules:
+
+- **Comments**: leave them alone unless they are actively incorrect (lying about what the code does). Reword for "style" elsewhere.
+- **Symbol names**: rename only when (a) the new name is materially clearer, *and* (b) renaming is in scope for this PR. A deliberate "rename `X` to `Y`" PR is fine. A bug-fix PR with a sneaky rename is not.
+- **Structure**: moving code between files, splitting functions, extracting helpers - all valid, all out of scope unless that *is* the task.
+
+Counterexample to internalise: the `parse_llm` method on PR #42, where churn during an unrelated change cost real progress.
+
+## Linter and SAST signal is engineering signal
+
+ruff / mypy / bandit / semgrep findings are not bureaucracy. Each one is the tool flagging an assumption it could not verify. Before suppressing:
+
+1. **Read the finding.** What is the tool worried about?
+2. **Identify the unstated assumption.** Why is the code actually safe / correct? Write that down.
+3. **Choose the cheaper fix.** Often making the assumption explicit in code is cheaper and clearer than suppressing the warning.
+4. **If you must suppress**: the suppression must carry a one-line comment explaining the why. No bare `# noqa`, `# type: ignore`, or `# nosec`.
+
+```python
+# acceptable - the why is in the comment
+os.getenv("FOO", "/tmp/bar")  # nosec B108  # noqa: S108 - intentional dev default, prod requires FOO
+```
+
+```python
+# not acceptable - what is being silenced and why?
+result = something_dangerous()  # nosec
+```
+
+Even a bandit finding that is "not a real security issue" usually points at an unidentified assumption (e.g. "this string is always trusted because..."). Make the assumption explicit, then decide.
+
+## Surface concerns, do not silently override
+
+When you find yourself wanting to break a stated rule (rename for clarity in a non-rename PR, suppress a linter finding you do not understand, change a comment that might actually be correct), stop. The options are, in order of preference:
+
+1. **Ask.** A one-line question to the human is cheap and prevents wrong work.
+2. **Note it.** Add a `# FIXME` or `# TODO` (see grammar below) and proceed with the original task untouched.
+3. **Defer it.** Open a follow-up issue and link it.
+
+### FIXME / TODO grammar
+
+Use a consistent shape so these are greppable and actionable:
+
+```python
+# FIXME: this swallows ConnectTimeout but should retry once - tracked in #NN
+# TODO: extract the cookie-jar logic when test_csrf.py stabilises
+```
+
+- `FIXME` means the code is wrong or incomplete in a way that should be fixed.
+- `TODO` means the code is fine but improvement is possible later.
+- Include enough context that another contributor could act on it without scrolling git history. If you cannot phrase the FIXME/TODO clearly, the right answer is "ask" not "note it".
+
+## Chesterton's Fence
+
+Before deleting or simplifying anything that looks redundant, find out why it was put there. Examples that look removable but are not:
+
+- The `host == pattern or host.endswith("." + pattern)` check in `tools/recon/scope.py` (would let `evil.notexample.com` match `example.com` if simplified).
+- The `default_factory=lambda` pattern in `config.py` (preserves `monkeypatch.setenv` semantics in tests).
+- The `check_env()` call before `build_crew()` import in `main.py` (env vars are read at import time).
+
+These are documented in `CLAUDE.md` as safety invariants. They exist for reasons that are not obvious from the code alone. Same principle applies to undocumented oddities: read git history, ask the author, or leave it.

--- a/.claude/skills/cybersquad-conventions/SKILL.md
+++ b/.claude/skills/cybersquad-conventions/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: cybersquad-conventions
+description: Enforce cybersquad code conventions when editing Python or Markdown files in this repo. Covers ASCII-only source, StrEnum over (str, Enum), X | None over Optional[X], model_copy(update=...) over Pydantic constructor kwargs in tests, and the five-file prompt layout under squad/<member>/. Use when editing any .py or .md file in the cybersquad codebase.
+---
+
+# cybersquad conventions
+
+Apply these rules to every edit. They are catch-at-review rules; the goal is to never make a reviewer ask for them.
+
+## ASCII only
+
+All source files, comments, docstrings, and prose (`.md`) files must use plain ASCII. No Unicode decorative characters: no em dashes, en dashes, curly quotes, box-drawing characters, arrows, bullets, or emoji. Use `-` not em-dash or en-dash, `->` not the Unicode arrow, `|` not the Unicode pipe. This is not a style preference - Unicode in source files inflates token counts for every AI tool that reads this codebase, wasting money and energy.
+
+When writing a new file or editing an existing one: if your text contains anything outside the printable ASCII range, replace it before saving.
+
+## StrEnum over (str, Enum)
+
+Ruff rule UP042 enforces `StrEnum`. Use it for any string enumeration:
+
+```python
+# correct
+from enum import StrEnum
+
+class Severity(StrEnum):
+    LOW = "low"
+    HIGH = "high"
+
+# wrong
+class Severity(str, Enum):
+    LOW = "low"
+    HIGH = "high"
+```
+
+## X | None over Optional[X]
+
+Use PEP 604 union syntax for optional types:
+
+```python
+# correct
+def fetch(token: str | None = None) -> Programme | None: ...
+
+# wrong
+from typing import Optional
+def fetch(token: Optional[str] = None) -> Optional[Programme]: ...
+```
+
+## model_copy(update=...) in tests
+
+When deriving a test variant from a canonical fixture model, use `model_copy(update={...})` rather than reconstructing via the constructor:
+
+```python
+# correct
+out_of_scope = programme.model_copy(update={"in_scope_assets": []})
+
+# wrong - duplicates every other field
+out_of_scope = Programme(handle=programme.handle, name=programme.name, ...)
+```
+
+## Five-file prompt layout
+
+Each agent's prose lives in exactly five single-purpose markdown files inside its package:
+
+```
+squad/<member>/
+    role.md
+    goal.md
+    backstory.md
+    description.md
+    expected_output.md
+```
+
+`SquadMember.read("<name>")` loads `<name>.md` and strips whitespace. Missing files raise `FileNotFoundError` at agent/task build time. No separators, no parsing, no other prompt files. If you need to add expertise to an agent, do it inside one of these five files, not by introducing a sixth.

--- a/.claude/skills/cybersquad-test-fixtures/SKILL.md
+++ b/.claude/skills/cybersquad-test-fixtures/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: cybersquad-test-fixtures
+description: Use the shared pytest fixtures in tests/conftest.py instead of defining local equivalents when writing or editing cybersquad tests. Covers make_response (HTTP response factory), canonical model fixtures (programme, endpoint, recon_result, raw_finding_high/low/oos, verified_vuln, disclosure_report), and clean_response_body (false-positive-safe HTML). Use when editing any file under tests/.
+---
+
+# cybersquad test fixtures
+
+`tests/conftest.py` provides fixtures for all tests. Use them. Do not redefine local equivalents - duplicates drift, hide accidental marker collisions, and make refactors of the canonical models painful.
+
+## make_response
+
+Factory for `MagicMock` objects shaped like `requests.Response`. Accepts `status`, `body`, `headers`, `cookies`, and `json`. Use this for any generic HTTP response mock.
+
+```python
+# correct - uses shared fixture
+def test_no_finding(self, make_response: Callable[..., MagicMock]) -> None:
+    with patch("requests.get", return_value=make_response(body="<html>ok</html>")):
+        pass  # assertions go here
+
+# wrong - duplicates the fixture locally
+def _resp(body="", status=200):
+    r = MagicMock()
+    r.text = body
+    r.status_code = status
+    return r
+```
+
+Tool-specific response builders that carry extra logic (e.g. cookie-jar inspection, POST body reflection) can stay local to their test file. The rule is: if a local helper is just constructing a generic mock response, replace it with `make_response`.
+
+## Canonical model fixtures
+
+Use these as starting points and derive variants with `model_copy(update={...})`:
+
+- `programme` - a `Programme` model instance
+- `endpoint` - an `Endpoint` model instance
+- `recon_result` - a `ReconResult` model instance
+- `raw_finding_high`, `raw_finding_low`, `raw_finding_oos` - `RawFinding` instances at each severity / scope tier
+- `verified_vuln` - a `VerifiedVuln` model instance
+- `disclosure_report` - a `DisclosureReport` model instance
+
+```python
+# correct - derive a variant
+def test_excludes_out_of_scope(programme):
+    oos = programme.model_copy(update={"in_scope_assets": []})
+    ...
+
+# wrong - reconstruct from scratch
+def test_excludes_out_of_scope():
+    oos = Programme(handle="x", name="y", ...)
+```
+
+## clean_response_body
+
+An HTML body verified at fixture-setup time to contain none of the strings any pentest probe treats as a positive match. Use it for "no finding" cases to avoid false negatives caused by accidental marker collisions in hand-rolled HTML.
+
+```python
+def test_no_finding(make_response, clean_response_body):
+    with patch("requests.get", return_value=make_response(body=clean_response_body)):
+        result = my_probe("https://target.invalid")
+    assert result is None
+```
+
+## When in doubt
+
+Read `tests/conftest.py` - it is the source of truth for what is available.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,3 +54,4 @@ Skills under `.claude/skills/` fire automatically when relevant files are edited
 - `cybersquad-conventions` - ASCII-only, `StrEnum`, `X | None`, `model_copy`, five-file prompt layout. Trigger: `.py` / `.md` edits.
 - `cybersquad-agent-llm` - `crewai.LLM(...)` construction + `anthropic/` model prefix. Trigger: `crew.py` / `Agent` construction.
 - `cybersquad-test-fixtures` - the `conftest.py` fixture catalogue. Trigger: edits under `tests/`.
+- `cybersquad-change-discipline` - minimal-diff philosophy, intentional renames, linter-as-signal, FIXME/TODO grammar, Chesterton's Fence. Trigger: editing existing code, suppressing a linter finding, or considering an out-of-scope rename/refactor.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,59 +1,14 @@
 # cybersquad - AI Contributor Guide
 
-This file is for AI assistants working on this codebase. It covers the architecture, conventions, safety invariants, and the things most likely to trip you up.
+This file carries only the rules that must hold on every turn. Anything situational lives under `docs/` or in a `.claude/skills/` skill that loads on demand.
 
-**Read `README.md` first.** Setup, install, env vars, and how to run the pipeline all live there. This file only covers what the README doesn't.
-
----
-
-## Required Skills and MCP Servers
-
-To work effectively on this repository, you (Claude) must have the following capabilities enabled. If you do not have these skills installed, pause and inform the user to install them before proceeding.
-
-### Required Skills
-
-* **CrewAI Skill**
-    * **Purpose:** Essential for understanding, debugging, and writing valid CrewAI architecture, agents, tasks, and tools.
-    * **Reference:** [CrewAI Skills Docs](https://docs.crewai.com/en/skills)
-* **Skill Creator (`skill-creator`)**
-    * **Purpose:** Used to create, iteratively improve, and evaluate new custom skills for the agents in this repository.
-    * **Reference:** [Anthropic skill-creator SKILL.md](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md)
-
-### MCP Server Specification (Reference)
-
-This project relies on MCP servers for local execution and file management. Below is a reference configuration. Ensure this is added to your `claude_desktop_config.json` file.
-
-* **Filesystem MCP Server**
-    * **Purpose:** Allows Claude to safely read, write, and traverse the `cybersquad` directory.
-
-**Configuration:**
-```json
-{
-  "mcpServers": {
-    "filesystem": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-filesystem",
-        "/absolute/path/to/cybersquad"
-      ]
-    }
-  }
-}
-```
+**Read `README.md` first.** Setup, install, env vars, and how to run the pipeline live there.
 
 ## Before you commit - non-negotiable
 
-1. **Work inside a virtualenv with the full dev deps installed.**
+1. **Work inside a virtualenv with full dev deps.** Without `python -m venv .venv && .venv/bin/pip install -e ".[dev]"`, `mypy` silently passes locally because it cannot resolve `crewai`, `crewai.tools`, or `langchain_anthropic`. No venv, no valid local signal.
 
-   ```bash
-   python -m venv .venv
-   .venv/bin/pip install -e ".[dev]"
-   ```
-
-   If you skip this, `mypy` will silently pass locally because it can't resolve `crewai`, `crewai.tools`, or `langchain_anthropic` - and CI will then fail on type errors you never saw. Every other tool is similarly affected. **No venv, no valid local signal.**
-
-2. **Run the entire CI stack locally, in order, before every push.** A ruff pass alone is not enough. The full set:
+2. **Run the full CI stack locally, in order, before every push.** Ruff alone is not enough:
 
    ```bash
    .venv/bin/ruff check .
@@ -63,229 +18,39 @@ This project relies on MCP servers for local execution and file management. Belo
    .venv/bin/bandit -c pyproject.toml -r . -q
    ```
 
-   All five must pass. If any fail, fix before committing and definitely before pushing - never "push and let CI tell me".
+   All five must pass. Fix locally - never "push and let CI tell me".
 
-3. **Never push a change you haven't actually executed.** A passing mypy run after a `type: ignore` removal means nothing if the file wasn't reachable. Run the tests.
+3. **Never push a change you haven't actually executed.** A passing mypy run after a `type: ignore` removal means nothing if the file wasn't reachable.
 
-4. **Read the relevant source files and docs before planning any change.** Do not rely on a summary or prior context. Read the actual file. Check `proposals/` for in-flight design work that may affect your approach.
+4. **Read the actual file before planning any change.** Check `proposals/` for in-flight design work.
 
-5. **Never include session URLs in commit messages.** Links of the form `https://claude.ai/code/session_...` embed a reference to a private conversation and must not appear in commit history. Use a plain one- or two-sentence description instead.
+5. **Never include session URLs (`https://claude.ai/code/session_...`) in commit messages.** They reference private conversations.
 
----
+## Safety invariants - do not weaken
 
-## Git workflow
+- **Scope enforcement** in `tools/recon/scope.py`: `if host == pattern or host.endswith("." + pattern)`. A bare `host.endswith(pattern)` would let `evil.notexample.com` match `example.com`.
+- **Automated-scanning gate** in `tools/h1_api.py:parse_programme()`: sets `allows_automated_scanning=False` on policy text like "no automated" / "automated scanning prohibited". The PM discards such programmes.
+- **Import order in `main.py`**: `check_env()` must run before `build_crew()` is imported. The crew import chain reads env vars; `check_env()` must exit cleanly first.
+- **No module-level side effects in `crew.py`**. The old `crew = build_crew()` at module level was deliberately removed.
 
-Always cut branches fresh from a current main. Do not reuse or rebase a branch that was used for a previous PR - once a PR merges, its commits are in main and rebasing on top of them causes conflicts that require skipping commits. Place the branch in a folder depending on the semantics of the change. The correct flow every time for a feature:
+## Required skills and MCP
 
-```bash
-git fetch origin
-git checkout main
-git pull origin main
-git checkout -b feat/your-branch-name
-```
+- **CrewAI skill** ([docs](https://docs.crewai.com/en/skills)) - understand/write valid CrewAI agents, tasks, tools.
+- **skill-creator** ([SKILL.md](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md)) - author skills under `.claude/skills/`.
+- **Filesystem MCP** - configure `@modelcontextprotocol/server-filesystem` with this repo's absolute path in `claude_desktop_config.json`.
 
-For bugs use `bug/your-branch-name` for the branch name, for refactors and ci (non-breaking, non-bugfix) changes use `task/your-branch-name`.
+## Index
 
-A `git diff origin/main --stat` before any push is a fast sanity check that only your intended changes are included.
+Reference docs (read on demand):
 
----
+- `docs/architecture.md` - what the project does, key files
+- `docs/git-workflow.md` - branch naming, fresh-from-main flow, commit-message rules
+- `docs/testing.md` - pytest invocation, coverage floor, shared fixtures
+- `docs/ci.md` - ruff/mypy/bandit guidance, SHA pinning, `upload-artifact` gotcha
+- `docs/contributing/{adding-an-agent,adding-a-tool,adding-config}.md` - includes probe-`StrEnum` and `default_factory=lambda` rules
 
-## What this project does
+Skills under `.claude/skills/` fire automatically when relevant files are edited:
 
-cybersquad is a six-agent CrewAI pipeline that autonomously selects HackerOne bug bounty programmes, maps their attack surface, runs vulnerability scans, triages findings, writes professional disclosure reports, and submits them via the H1 API. Agents run sequentially; each passes structured output to the next via CrewAI's `context` chaining.
-
----
-
-## Key files
-
-| File | Purpose |
-|---|---|
-| `main.py` | CLI entrypoint. Calls `check_env()` before importing crew - keep it that way. |
-| `config.py` | All env-var reading lives here. Singleton: `from config import config`. |
-| `models.py` | Pydantic contracts between agents. Change these carefully - they cross agent boundaries. |
-| `crew.py` | Assembles the `Crew`: builds LLM, agents, tasks. No module-level side effects. |
-| `tasks.py` | Pipeline wiring - context dependencies and `human_input` gates. Thin - keep it that way. |
-| `squad/__init__.py` | `SquadMember` dataclass + `build_agent()` / `build_task()` helpers. Each helper reads prose from a single-purpose `.md` file. |
-| `squad/<member>/{role,goal,backstory}.md` | Three single-purpose files driving the CrewAI Agent. Edit to tune agent behaviour. |
-| `squad/<member>/{description,expected_output}.md` | Two single-purpose files driving the Task description and expected output. |
-| `squad/<member>/__init__.py` | Tool functions (`@tool`) + a module-level `MEMBER = SquadMember(...)` constant. |
-| `tools/h1_api.py` | HackerOne REST client. Singleton: `from tools.h1_api import h1`. |
-| `tools/recon/` | Recon tools: subfinder, httpx, nmap, TLS, DNS, dirfuzz, waybackurls, cert transparency, traceroute, scope guard. |
-| `tools/recon/scope.py` | `filter_in_scope()` - hard scope enforcement boundary. Do not weaken. |
-| `tools/pentest/` | Pentest tools: nuclei, sqlmap, CORS, SSRF, XSS, SRI, header injection, source maps, error disclosure. |
-| `tools/cloud/` | Cloud/service checks: S3, Azure Blob, per-engine databases, admin panels, branded panels. |
-| `tools/cloud/databases/` | Per-engine unauthenticated database checks: one file per engine. |
-| `tools/report_tools.py` | Renders Markdown reports and writes them to disk. |
-
----
-
-## Conventions
-
-### ASCII only
-
-All source files, comments, docstrings, and prose (.md) files must use plain ASCII. No Unicode decorative characters: no em dashes, en dashes, curly quotes, box-drawing characters, arrows, bullets, or emoji. Use `-` not `--` or `-`, `->` not `->`, `|` not `|`. This is not a style preference - Unicode in source files inflates token counts for every AI tool that reads this codebase, wasting money and energy. Violations will be caught in code review.
-
-### Config
-
-All environment variables are read in `config.py` using `field(default_factory=lambda: ...)`. This is intentional - it means values are read at instantiation time, not at class-definition time, which lets `monkeypatch.setenv()` work correctly in tests. Do not change field defaults to bare expressions.
-
-```python
-# correct
-max_programmes: int = field(default_factory=lambda: int(os.getenv("H1_MAX_PROGRAMMES", "10")))
-
-# wrong - evaluated once at import time, monkeypatch has no effect
-max_programmes: int = int(os.getenv("H1_MAX_PROGRAMMES", "10"))
-```
-
-### Models
-
-Use `StrEnum` (not `(str, Enum)`) for string enumerations - ruff rule UP042 enforces this. Use `X | None` not `Optional[X]`. Use `model_copy(update={...})` in tests to create variants.
-
-### Agents
-
-Always construct the LLM explicitly using `crewai.LLM`:
-
-```python
-from crewai import LLM
-llm = LLM(model=config.llm.model, temperature=config.llm.temperature, max_tokens=config.llm.max_tokens)
-```
-
-The model name must include the provider prefix for litellm routing, e.g.
-`anthropic/claude-sonnet-4-20250514`. Passing a bare model string directly to
-`Agent(llm=...)` silently ignores `temperature` and `max_tokens`.
-
-### Prompts
-
-Each agent's prose lives in five single-purpose markdown files inside its package: `role.md`, `goal.md`, `backstory.md`, `description.md`, `expected_output.md`. `SquadMember.read("<name>")` loads `<name>.md` and strips whitespace. Missing files raise `FileNotFoundError` at agent/task build time. No separators, no parsing.
-
----
-
-## Safety invariants - do not break these
-
-**Scope enforcement** - `filter_in_scope()` in `tools/recon/scope.py` uses an exact-match or dot-boundary check:
-
-```python
-if host == pattern or host.endswith("." + pattern):
-```
-
-A bare `host.endswith(pattern)` would allow `evil.notexample.com` to match `example.com`. Do not simplify this.
-
-**Automated-scanning gate** - `parse_programme()` in `h1_api.py` sets `allows_automated_scanning=False` when the policy text contains keywords like "no automated" or "automated scanning prohibited". The Programme Manager is instructed to discard such programmes. Do not remove or weaken this check.
-
-**Import order in `main.py`** - `check_env()` must run before `build_crew()` is imported or called. The crew import triggers `crew.py`, which imports `config`, which reads env vars. If credentials are missing, `check_env()` should exit cleanly before that happens.
-
-**No module-level side effects in `crew.py`** - the old `crew = build_crew()` at module level has been deliberately removed. Do not re-introduce it.
-
----
-
-## Testing
-
-All tests are marked `@pytest.mark.unit` and must run without network access, real API credentials, or external binaries. Use `monkeypatch` and `unittest.mock` to isolate.
-
-```bash
-H1_API_USERNAME=test H1_API_TOKEN=test pytest -m unit
-```
-
-Tests that reload modules for config isolation use `importlib.reload()` - this is the correct pattern for testing env-var-backed dataclasses.
-
-Coverage floor is 85%. Every new public function in `tools/` needs a test. Every bug fix needs a regression test.
-
-### Shared fixtures
-
-`tests/conftest.py` provides fixtures for all tests. Use them instead of defining local equivalents:
-
-- **`make_response`** - factory for `MagicMock` objects shaped like `requests.Response`. Accepts `status`, `body`, `headers`, `cookies`, and `json`. Use this for any generic HTTP response mock. Tool-specific response builders that carry extra logic (e.g. cookie-jar inspection, POST body reflection) can stay local to their test file.
-
-```python
-# correct - uses shared fixture
-def test_no_finding(self, make_response: Callable[..., MagicMock]) -> None:
-    with patch("requests.get", return_value=make_response(body="<html>ok</html>")):
-        pass  # assertions go here
-
-# wrong - duplicates the fixture locally
-def _resp(body="", status=200):
-    r = MagicMock()
-    r.text = body
-    r.status_code = status
-    return r
-```
-
-- **`programme`, `endpoint`, `recon_result`, `raw_finding_high/low/oos`, `verified_vuln`, `disclosure_report`** - canonical model instances. Use `model_copy(update={...})` to derive variants.
-
-- **`clean_response_body`** - an HTML body verified at fixture-setup time to contain none of the strings any pentest probe treats as a positive match. Use it for "no finding" cases to avoid false negatives caused by accidental marker collisions.
-
----
-
-## Adding a new agent
-
-1. Create `squad/<role-name>/` with:
-   - `__init__.py` - `@tool` functions + `MEMBER = SquadMember(slug=..., dir=Path(__file__).parent, tools=[...])`
-   - `role.md`, `goal.md`, `backstory.md` - drive the CrewAI Agent
-   - `description.md`, `expected_output.md` - drive the Task
-2. Import the new `MEMBER` into `_SQUAD` in `crew.py`.
-3. Wire its task into `build_tasks()` in `tasks.py` with correct `context` dependencies.
-4. Add unit tests covering the new tool's logic.
-
----
-
-## Adding a new config value
-
-1. Add a field to the appropriate dataclass in `config.py` using `default_factory=lambda: os.getenv(...)`.
-2. Document it in `.env.example` with a comment explaining valid values.
-3. If the value is used in a tool, thread it through via `config.<section>.<field>` - do not hardcode fallback values in the tool.
-
----
-
-## Adding a new tool
-
-Tools are `@tool`-decorated functions in a `squad/<agent>/__init__.py`. The docstring is the agent's only guidance for when and how to call the tool - write it as an instruction, not a description.
-
-One concern per tool. The PT agent selects tools based on nmap evidence and detected technologies; bundling unrelated checks removes that selectivity.
-
-Tests must mock all network and binary calls. Patch `socket.create_connection` at the module path where it is imported (e.g. `tools.cloud.databases.redis.socket.create_connection`), not at the top-level `socket` module.
-
-### Probe enumerations
-
-When a tool iterates over a fixed set of attack vectors (headers, payloads, error markers, URI paths), define them as a `StrEnum` in the tool module rather than a bare list or tuple. This makes the set inspectable, importable in tests, and self-documenting:
-
-```python
-# correct
-from enum import StrEnum
-
-class XSSHeader(StrEnum):
-    USER_AGENT = "User-Agent"
-    REFERER = "Referer"
-    X_FORWARDED_FOR = "X-Forwarded-For"
-
-for header in XSSHeader:
-    ...
-
-# wrong - opaque list, not reusable in tests
-_HEADERS = ["User-Agent", "Referer", "X-Forwarded-For"]
-```
-
-Tests should import the enum and assert against `set(MyEnum)` rather than duplicating the string literals.
-
----
-
-## CI
-
-Three jobs run on every push: `lint` (ruff + mypy), `test` (pytest, 70% coverage floor), and `sast` (bandit + semgrep). The local commands in the "Before you push" section above mirror them exactly - use those.
-
-Notes on fixing findings:
-
-- **ruff** - `ruff check --fix` and `ruff format` resolve most issues automatically.
-- **mypy** - ensure all public functions have annotated parameters and return types. If a real dep (crewai, pydantic) has incomplete stubs and you need to suppress a false positive, use a targeted `# type: ignore[<code>]` rather than a blanket ignore.
-- **bandit** - suppress with `# nosec B<code>` (bandit's own directive, *not* `# noqa`). Keep the accompanying `# noqa: S<code>` for ruff - both are needed:
-
-  ```python
-  os.getenv("FOO", "/tmp/bar")  # nosec B108  # noqa: S108
-  ```
-
-- **GitHub Actions pins** - every action must be pinned to a full-length commit SHA, not a tag. Branch protection enforces this. Add the version as a trailing comment for readability:
-
-  ```yaml
-  - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
-  ```
-
-- **upload-artifact v4 and hidden files** - `.coverage` and other dotfiles are skipped by default. Set `include-hidden-files: true` on the step.
+- `cybersquad-conventions` - ASCII-only, `StrEnum`, `X | None`, `model_copy`, five-file prompt layout. Trigger: `.py` / `.md` edits.
+- `cybersquad-agent-llm` - `crewai.LLM(...)` construction + `anthropic/` model prefix. Trigger: `crew.py` / `Agent` construction.
+- `cybersquad-test-fixtures` - the `conftest.py` fixture catalogue. Trigger: edits under `tests/`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,26 @@
+# Architecture
+
+## What this project does
+
+cybersquad is a six-agent CrewAI pipeline that autonomously selects HackerOne bug bounty programmes, maps their attack surface, runs vulnerability scans, triages findings, writes professional disclosure reports, and submits them via the H1 API. Agents run sequentially; each passes structured output to the next via CrewAI's `context` chaining.
+
+## Key files
+
+| File | Purpose |
+|---|---|
+| `main.py` | CLI entrypoint. Calls `check_env()` before importing crew - keep it that way. |
+| `config.py` | All env-var reading lives here. Singleton: `from config import config`. |
+| `models.py` | Pydantic contracts between agents. Change these carefully - they cross agent boundaries. |
+| `crew.py` | Assembles the `Crew`: builds LLM, agents, tasks. No module-level side effects. |
+| `tasks.py` | Pipeline wiring - context dependencies and `human_input` gates. Thin - keep it that way. |
+| `squad/__init__.py` | `SquadMember` dataclass + `build_agent()` / `build_task()` helpers. Each helper reads prose from a single-purpose `.md` file. |
+| `squad/<member>/{role,goal,backstory}.md` | Three single-purpose files driving the CrewAI Agent. Edit to tune agent behaviour. |
+| `squad/<member>/{description,expected_output}.md` | Two single-purpose files driving the Task description and expected output. |
+| `squad/<member>/__init__.py` | Tool functions (`@tool`) + a module-level `MEMBER = SquadMember(...)` constant. |
+| `tools/h1_api.py` | HackerOne REST client. Singleton: `from tools.h1_api import h1`. |
+| `tools/recon/` | Recon tools: subfinder, httpx, nmap, TLS, DNS, dirfuzz, waybackurls, cert transparency, traceroute, scope guard. |
+| `tools/recon/scope.py` | `filter_in_scope()` - hard scope enforcement boundary. Do not weaken. |
+| `tools/pentest/` | Pentest tools: nuclei, sqlmap, CORS, SSRF, XSS, SRI, header injection, source maps, error disclosure. |
+| `tools/cloud/` | Cloud/service checks: S3, Azure Blob, per-engine databases, admin panels, branded panels. |
+| `tools/cloud/databases/` | Per-engine unauthenticated database checks: one file per engine. |
+| `tools/report_tools.py` | Renders Markdown reports and writes them to disk. |

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,33 @@
+# CI
+
+Three jobs run on every push: `lint` (ruff + mypy), `test` (pytest, 70% coverage floor), and `sast` (bandit + semgrep). The local commands in the pre-commit checklist in `CLAUDE.md` mirror them exactly - use those.
+
+## Notes on fixing findings
+
+### ruff
+
+`ruff check --fix` and `ruff format` resolve most issues automatically.
+
+### mypy
+
+Ensure all public functions have annotated parameters and return types. If a real dep (crewai, pydantic) has incomplete stubs and you need to suppress a false positive, use a targeted `# type: ignore[<code>]` rather than a blanket ignore.
+
+### bandit
+
+Suppress with `# nosec B<code>` (bandit's own directive, *not* `# noqa`). Keep the accompanying `# noqa: S<code>` for ruff - both are needed:
+
+```python
+os.getenv("FOO", "/tmp/bar")  # nosec B108  # noqa: S108
+```
+
+### GitHub Actions pins
+
+Every action must be pinned to a full-length commit SHA, not a tag. Branch protection enforces this. Add the version as a trailing comment for readability:
+
+```yaml
+- uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+```
+
+### upload-artifact v4 and hidden files
+
+`.coverage` and other dotfiles are skipped by default. Set `include-hidden-files: true` on the step.

--- a/docs/contributing/adding-a-tool.md
+++ b/docs/contributing/adding-a-tool.md
@@ -1,0 +1,29 @@
+# Adding a new tool
+
+Tools are `@tool`-decorated functions in a `squad/<agent>/__init__.py`. The docstring is the agent's only guidance for when and how to call the tool - write it as an instruction, not a description.
+
+One concern per tool. The PT agent selects tools based on nmap evidence and detected technologies; bundling unrelated checks removes that selectivity.
+
+Tests must mock all network and binary calls. Patch `socket.create_connection` at the module path where it is imported (e.g. `tools.cloud.databases.redis.socket.create_connection`), not at the top-level `socket` module.
+
+## Probe enumerations
+
+When a tool iterates over a fixed set of attack vectors (headers, payloads, error markers, URI paths), define them as a `StrEnum` in the tool module rather than a bare list or tuple. This makes the set inspectable, importable in tests, and self-documenting:
+
+```python
+# correct
+from enum import StrEnum
+
+class XSSHeader(StrEnum):
+    USER_AGENT = "User-Agent"
+    REFERER = "Referer"
+    X_FORWARDED_FOR = "X-Forwarded-For"
+
+for header in XSSHeader:
+    ...
+
+# wrong - opaque list, not reusable in tests
+_HEADERS = ["User-Agent", "Referer", "X-Forwarded-For"]
+```
+
+Tests should import the enum and assert against `set(MyEnum)` rather than duplicating the string literals.

--- a/docs/contributing/adding-an-agent.md
+++ b/docs/contributing/adding-an-agent.md
@@ -1,0 +1,13 @@
+# Adding a new agent
+
+1. Create `squad/<role-name>/` with:
+   - `__init__.py` - `@tool` functions + `MEMBER = SquadMember(slug=..., dir=Path(__file__).parent, tools=[...])`
+   - `role.md`, `goal.md`, `backstory.md` - drive the CrewAI Agent
+   - `description.md`, `expected_output.md` - drive the Task
+2. Import the new `MEMBER` into `_SQUAD` in `crew.py`.
+3. Wire its task into `build_tasks()` in `tasks.py` with correct `context` dependencies.
+4. Add unit tests covering the new tool's logic.
+
+## Prompt-file rules
+
+Each agent's prose lives in five single-purpose markdown files inside its package: `role.md`, `goal.md`, `backstory.md`, `description.md`, `expected_output.md`. `SquadMember.read("<name>")` loads `<name>.md` and strips whitespace. Missing files raise `FileNotFoundError` at agent/task build time. No separators, no parsing.

--- a/docs/contributing/adding-config.md
+++ b/docs/contributing/adding-config.md
@@ -1,0 +1,17 @@
+# Adding a new config value
+
+1. Add a field to the appropriate dataclass in `config.py` using `default_factory=lambda: os.getenv(...)`.
+2. Document it in `.env.example` with a comment explaining valid values.
+3. If the value is used in a tool, thread it through via `config.<section>.<field>` - do not hardcode fallback values in the tool.
+
+## Why `default_factory=lambda`
+
+All environment variables are read in `config.py` using `field(default_factory=lambda: ...)`. This is intentional - it means values are read at instantiation time, not at class-definition time, which lets `monkeypatch.setenv()` work correctly in tests. Do not change field defaults to bare expressions.
+
+```python
+# correct
+max_programmes: int = field(default_factory=lambda: int(os.getenv("H1_MAX_PROGRAMMES", "10")))
+
+# wrong - evaluated once at import time, monkeypatch has no effect
+max_programmes: int = int(os.getenv("H1_MAX_PROGRAMMES", "10"))
+```

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -1,0 +1,18 @@
+# Git workflow
+
+Always cut branches fresh from a current main. Do not reuse or rebase a branch that was used for a previous PR - once a PR merges, its commits are in main and rebasing on top of them causes conflicts that require skipping commits. Place the branch in a folder depending on the semantics of the change. The correct flow every time for a feature:
+
+```bash
+git fetch origin
+git checkout main
+git pull origin main
+git checkout -b feat/your-branch-name
+```
+
+For bugs use `bug/your-branch-name` for the branch name, for refactors and ci (non-breaking, non-bugfix) changes use `task/your-branch-name`.
+
+A `git diff origin/main --stat` before any push is a fast sanity check that only your intended changes are included.
+
+## Commit messages
+
+Never include session URLs in commit messages. Links of the form `https://claude.ai/code/session_...` embed a reference to a private conversation and must not appear in commit history. Use a plain one- or two-sentence description instead.

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -13,6 +13,16 @@ For bugs use `bug/your-branch-name` for the branch name, for refactors and ci (n
 
 A `git diff origin/main --stat` before any push is a fast sanity check that only your intended changes are included.
 
+## One issue, one branch, one PR
+
+For each GitHub issue worked on, present a single branch with a single PR for review. Do not bundle multiple issues into one PR even if they touch adjacent files - reviewer attention is the bottleneck, not branch count. If mid-task you discover unrelated work that needs doing, capture it as a `# FIXME` or `# TODO` (see `.claude/skills/cybersquad-change-discipline/SKILL.md`) or as a new issue, and finish the original task first.
+
+## Force-push policy
+
+- **Never** force-push to `main` or any protected/shared branch.
+- **Never** force-push to a PR branch while a review is in progress - it destroys review-comment anchors and reviewers lose context.
+- **Allowed**: `git push --force-with-lease` on your own PR branch *before* requesting review, to clean up history (e.g. after `git rebase origin/main`). Use `--force-with-lease`, never bare `--force` - the lease check fails safe if upstream moved.
+
 ## Commit messages
 
 Never include session URLs in commit messages. Links of the form `https://claude.ai/code/session_...` embed a reference to a private conversation and must not appear in commit history. Use a plain one- or two-sentence description instead.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,47 @@
+# Testing
+
+All tests are marked `@pytest.mark.unit` and must run without network access, real API credentials, or external binaries. Use `monkeypatch` and `unittest.mock` to isolate.
+
+```bash
+H1_API_USERNAME=test H1_API_TOKEN=test pytest -m unit
+```
+
+Tests that reload modules for config isolation use `importlib.reload()` - this is the correct pattern for testing env-var-backed dataclasses.
+
+Coverage floor is 85%. Every new public function in `tools/` needs a test. Every bug fix needs a regression test.
+
+## Shared fixtures
+
+`tests/conftest.py` provides fixtures for all tests. Use them instead of defining local equivalents.
+
+The `cybersquad-test-fixtures` skill at `.claude/skills/cybersquad-test-fixtures/SKILL.md` covers the same material in a form Claude Code can load on demand when editing test files. The reference below is the same information in human-readable prose.
+
+### `make_response`
+
+Factory for `MagicMock` objects shaped like `requests.Response`. Accepts `status`, `body`, `headers`, `cookies`, and `json`. Use this for any generic HTTP response mock. Tool-specific response builders that carry extra logic (e.g. cookie-jar inspection, POST body reflection) can stay local to their test file.
+
+```python
+# correct - uses shared fixture
+def test_no_finding(self, make_response: Callable[..., MagicMock]) -> None:
+    with patch("requests.get", return_value=make_response(body="<html>ok</html>")):
+        pass  # assertions go here
+
+# wrong - duplicates the fixture locally
+def _resp(body="", status=200):
+    r = MagicMock()
+    r.text = body
+    r.status_code = status
+    return r
+```
+
+### Model fixtures
+
+`programme`, `endpoint`, `recon_result`, `raw_finding_high/low/oos`, `verified_vuln`, `disclosure_report` - canonical model instances. Use `model_copy(update={...})` to derive variants.
+
+### `clean_response_body`
+
+An HTML body verified at fixture-setup time to contain none of the strings any pentest probe treats as a positive match. Use it for "no finding" cases to avoid false negatives caused by accidental marker collisions.
+
+## Mocking network and binaries
+
+Tests must mock all network and binary calls. Patch `socket.create_connection` at the module path where it is imported (e.g. `tools.cloud.databases.redis.socket.create_connection`), not at the top-level `socket` module.


### PR DESCRIPTION
Closes #94.

## Summary

- Slimmed `CLAUDE.md` from 292 lines to 57: kept only the pre-commit gate, safety invariants, required-skill pointers, and an index linking to the rest.
- Moved situational reference material to `docs/`:
  - `docs/architecture.md` (what the project does + key-files table)
  - `docs/git-workflow.md` (branch naming, fresh-from-main flow, one issue / one branch / one PR rule, `--force-with-lease` policy, commit-message rule)
  - `docs/testing.md` (pytest invocation, coverage floor, shared fixture catalogue)
  - `docs/ci.md` (ruff/mypy/bandit notes, SHA pinning, `upload-artifact` gotcha)
  - `docs/contributing/{adding-an-agent,adding-a-tool,adding-config}.md` (the three recipes, with the probe-`StrEnum` and `default_factory=lambda` rules co-located with their use case)
- Added four contributor-side skills under `.claude/skills/` that fire on relevant edits:
  - `cybersquad-conventions` (`.py` / `.md` edits) - ASCII-only, `StrEnum`, `X | None`, `model_copy`, five-file prompt layout
  - `cybersquad-agent-llm` (`crew.py` / `Agent` construction) - `crewai.LLM(...)` + `anthropic/` prefix
  - `cybersquad-test-fixtures` (edits under `tests/`) - the `conftest.py` fixture catalogue
  - `cybersquad-change-discipline` (editing existing code, suppressing a linter finding, or considering an out-of-scope rename/refactor) - minimal-diff philosophy, intentional renames, linter-as-signal, FIXME/TODO grammar, Chesterton's Fence

No code, tests, prompts, or runtime behaviour changed. Diff is documentation-only.

## Acceptance criteria (from #94)

- [x] `CLAUDE.md` under 60 lines, non-negotiables + index only (57 lines).
- [x] Removed content present and discoverable under `docs/` via the index.
- [x] Contributor skills drafted under `.claude/skills/` with `SKILL.md` files (four total - three original from the issue plus `cybersquad-change-discipline` added during review iteration).
- [x] Conventions trigger via skill descriptions rather than recall from `CLAUDE.md`.

## Test plan

- [x] `.venv/bin/ruff check .` - All checks passed
- [x] `.venv/bin/ruff format --check .` - 102 files already formatted
- [x] `.venv/bin/mypy . --ignore-missing-imports` - Success: no issues found in 102 source files
- [x] Full pytest stack with CI env vars - 693 passed, coverage 89.19% (above 70% floor)
- [x] `.venv/bin/bandit -c pyproject.toml -r . -q` - no new findings
- [x] Confirmed the harness discovers and lists the new `cybersquad-change-discipline` skill (auto-loaded in-session after the file was created)
- [ ] Cold-start a fresh session on a test edit and confirm `cybersquad-test-fixtures` surfaces without needing CLAUDE.md to recall it

## Out of scope (deliberately)

- The 85% / 70% coverage-floor inconsistency between the old testing section and CI section is preserved verbatim in `docs/testing.md` and `docs/ci.md` respectively rather than being silently reconciled. Worth a follow-up issue if you want it fixed.
- Runtime CrewAI agent skills - tracked separately in #62.