### PR TITLE
chore(coverage): raise fail_under from 70 to 88 and reconcile docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ H1_API_USERNAME=test H1_API_TOKEN=test CYBERSQUAD_CONTACT_EMAIL=test@example.inv
 H1_API_USERNAME=test H1_API_TOKEN=test CYBERSQUAD_CONTACT_EMAIL=test@example.invalid pytest -m unit --cov --cov-report=term-missing
 ```
 
-Coverage floor is **70%**. Every new public function in `tools/` requires a unit test. Every bug fix requires a regression test.
+Coverage floor is **88%**. Every new public function in `tools/` requires a unit test. Every bug fix requires a regression test.
 
 ### Full CI stack (run before every push)
 
@@ -208,7 +208,7 @@ Edit any of the five prose files in `squad/<member>/`: `role.md`, `goal.md`, `ba
 | Job | Tools |
 |---|---|
 | `lint` | ruff, mypy |
-| `test` | pytest (70% coverage floor) |
+| `test` | pytest (88% coverage floor) |
 | `sast` | bandit, semgrep |
 
 ---

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,6 +1,6 @@
 # CI
 
-Three jobs run on every push: `lint` (ruff + mypy), `test` (pytest, 70% coverage floor), and `sast` (bandit + semgrep). The local commands in the pre-commit checklist in `CLAUDE.md` mirror them exactly - use those.
+Three jobs run on every push: `lint` (ruff + mypy), `test` (pytest, 88% coverage floor), and `sast` (bandit + semgrep). The local commands in the pre-commit checklist in `CLAUDE.md` mirror them exactly - use those.
 
 ## Notes on fixing findings
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,7 +8,7 @@ H1_API_USERNAME=test H1_API_TOKEN=test pytest -m unit
 
 Tests that reload modules for config isolation use `importlib.reload()` - this is the correct pattern for testing env-var-backed dataclasses.
 
-Coverage floor is 85%. Every new public function in `tools/` needs a test. Every bug fix needs a regression test.
+Coverage floor is 88%. Every new public function in `tools/` needs a test. Every bug fix needs a regression test.
 
 ## Shared fixtures
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ source = ["."]
 omit = ["tests/*", ".venv/*"]
 
 [tool.coverage.report]
-fail_under = 70
+fail_under = 88
 show_missing = true
 exclude_lines = [
     "pragma: no cover",


### PR DESCRIPTION
> **SUPERSEDED by #101** - the floor is now 90%, backed by new `@tool` wrapper tests rather than just slack to the existing actual. Closed in favour of #101.

---

## Summary

- Bumps `tool.coverage.report.fail_under` in `pyproject.toml` from `70` to `88`. Current actual coverage is **89.19%**; the new floor leaves ~1.2 points of headroom under it so a real regression triggers CI failure rather than slow drift.
- Reconciles four documentation references to the old floor in the same commit (in-scope, not drive-by):
  - `README.md` line 172 (`Coverage floor is **70%**` -> **88%**)
  - `README.md` line 211 (`pytest (70% coverage floor)` -> `pytest (88% coverage floor)`)
  - `docs/ci.md` line 3 (`pytest, 70% coverage floor` -> `pytest, 88% coverage floor`)
  - `docs/testing.md` line 11 (`Coverage floor is 85%` -> `Coverage floor is 88%`; the 85 was a stale aspirational value that never matched the actual 70 gate - PR #95 flagged this as out-of-scope at the time)

No code, tests, prompts, or runtime behaviour changed.

## What this PR is not

This is **not** per-PR coverage ratcheting. A real "no drops allowed" gate needs either `diff-cover` against the changed lines or comparing coverage artifacts between main and the PR head - more moving parts, more failure modes, separate issue. This PR is the absolute-floor version: 88% is the line, regressions below it fail CI.

The ratcheting follow-up will be filed as a separate issue.

## Test plan

- [x] `.venv/bin/ruff check .` - All checks passed
- [x] `.venv/bin/ruff format --check .` - 102 files already formatted
- [x] `.venv/bin/mypy . --ignore-missing-imports` - Success: no issues found in 102 source files
- [x] `pytest -m unit --cov` with the new gate - `Required test coverage of 88.0% reached. Total coverage: 89.19%`, 693 passed
- [x] `bandit -c pyproject.toml -r . -q` - no new findings
- [ ] CI run on the PR confirms the gate is being enforced (not just locally)