### PR TITLE
docs(git-workflow): adopt Conventional Commits nomenclature

### DIFF
--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -9,9 +9,36 @@ git pull origin main
 git checkout -b feat/your-branch-name
 ```
 
-For bugs use `bug/your-branch-name` for the branch name, for refactors and ci (non-breaking, non-bugfix) changes use `task/your-branch-name`.
+Substitute `feat/` for the appropriate prefix from the type table below.
 
 A `git diff origin/main --stat` before any push is a fast sanity check that only your intended changes are included.
+
+## Commit and branch type prefixes
+
+This repo follows [Conventional Commits](https://www.conventionalcommits.org/). Branch prefixes match commit types so the two stay in lockstep and `commitizen` lands cleanly when it's wired up.
+
+Format: `<type>(<scope>)?: <subject>` for commit messages, `<type>/<short-description>` for branch names. Scope is optional but encouraged when it sharpens the subject - e.g. `chore(coverage):`, `fix(recon):`, `docs(git-workflow):`.
+
+| Type | When to use |
+|---|---|
+| `feat` | A new feature visible to a user or another agent |
+| `fix` | A bug fix |
+| `docs` | Documentation only - no code or test change |
+| `style` | Formatting, whitespace, missing semicolons - no logic change |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `perf` | A change that improves performance |
+| `test` | Adding or correcting tests - no production code change |
+| `build` | Build system or dependency changes (`pyproject.toml` deps, packaging) |
+| `ci` | CI configuration only (`.github/workflows/`, pre-commit hooks) |
+| `chore` | Maintenance that doesn't fit the above - bumping a gate value, tidying a config |
+| `revert` | Reverts a previous commit; subject is the reverted commit's subject |
+
+Examples:
+
+- `feat(squad/triage): add CVSS sanity-check pass after vulnerability researcher`
+- `fix(recon/scope): treat sub.example.com as in-scope when pattern is example.com`
+- `chore(coverage): raise fail_under from 70 to 88`
+- `docs(git-workflow): document --force-with-lease policy`
 
 ## One issue, one branch, one PR
 


### PR DESCRIPTION
## Summary

Adopts [Conventional Commits](https://www.conventionalcommits.org/) nomenclature in `docs/git-workflow.md`:

- Adds a **"Commit and branch type prefixes"** section listing the canonical types and the `<type>(<scope>)?: <subject>` shape.
- Branch prefixes match commit types so the two stay in lockstep and `commitizen` lands cleanly when it's wired up (currently in the backlog).
- Includes four worked examples drawn from real commits in this repo.

Replaces the ad-hoc "feat / bug / task" trio that was in the doc with the wider commitizen-aligned set:

`feat` / `fix` / `docs` / `style` / `refactor` / `perf` / `test` / `build` / `ci` / `chore` / `revert`

## Out of scope (deliberately)

`README.md` has a `Contributing > Branch naming` line that lists `feat/`, `fix/`, `chore/`, `docs/` - a subset of the canonical types. It's not wrong, just incomplete. Touching it now would conflict with the upcoming README -> docs/ canonicalisation PR, which will defer that whole section to `docs/git-workflow.md`. So it stays as-is for now.

`CLAUDE.md`'s index entry for `docs/git-workflow.md` already says "commit-message rules", which covers this addition at the right granularity for an index entry.

## Test plan

- [x] `.venv/bin/ruff check .` - All checks passed
- [x] `.venv/bin/ruff format --check .` - 102 files already formatted
- [x] `.venv/bin/mypy . --ignore-missing-imports` - Success: no issues found
- [x] `pytest -m unit --cov` - 693 passed, coverage 89.19% (above 70% floor; PR #96 lifts it to 88)
- [x] `bandit -c pyproject.toml -r . -q` - no new findings
- [x] Manually re-read the rendered table for typos and column alignment
