### PR TITLE
chore(coverage): raise fail_under from 70 to 90, backed by squad @tool wrapper tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ H1_API_USERNAME=test H1_API_TOKEN=test CYBERSQUAD_CONTACT_EMAIL=test@example.inv
 H1_API_USERNAME=test H1_API_TOKEN=test CYBERSQUAD_CONTACT_EMAIL=test@example.invalid pytest -m unit --cov --cov-report=term-missing
 ```
 
-Coverage floor is **70%**. Every new public function in `tools/` requires a unit test. Every bug fix requires a regression test.
+Coverage floor is **90%**. Every new public function in `tools/` requires a unit test. Every bug fix requires a regression test.
 
 ### Full CI stack (run before every push)
 
@@ -208,7 +208,7 @@ Edit any of the five prose files in `squad/<member>/`: `role.md`, `goal.md`, `ba
 | Job | Tools |
 |---|---|
 | `lint` | ruff, mypy |
-| `test` | pytest (70% coverage floor) |
+| `test` | pytest (90% coverage floor) |
 | `sast` | bandit, semgrep |
 
 ---

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,6 +1,6 @@
 # CI
 
-Three jobs run on every push: `lint` (ruff + mypy), `test` (pytest, 70% coverage floor), and `sast` (bandit + semgrep). The local commands in the pre-commit checklist in `CLAUDE.md` mirror them exactly - use those.
+Three jobs run on every push: `lint` (ruff + mypy), `test` (pytest, 90% coverage floor), and `sast` (bandit + semgrep). The local commands in the pre-commit checklist in `CLAUDE.md` mirror them exactly - use those.
 
 ## Notes on fixing findings
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,7 +8,7 @@ H1_API_USERNAME=test H1_API_TOKEN=test pytest -m unit
 
 Tests that reload modules for config isolation use `importlib.reload()` - this is the correct pattern for testing env-var-backed dataclasses.
 
-Coverage floor is 85%. Every new public function in `tools/` needs a test. Every bug fix needs a regression test.
+Coverage floor is 90%. Every new public function in `tools/` needs a test. Every bug fix needs a regression test.
 
 ## Shared fixtures
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ source = ["."]
 omit = ["tests/*", ".venv/*"]
 
 [tool.coverage.report]
-fail_under = 70
+fail_under = 90
 show_missing = true
 exclude_lines = [
     "pragma: no cover",

--- a/tests/test_squad_tools.py
+++ b/tests/test_squad_tools.py
@@ -1,0 +1,433 @@
+"""
+tests/test_squad_tools.py - exercise the @tool wrappers on each squad member.
+
+The wrappers are thin: unmarshal JSON, call into tools/* helpers, serialise
+the result. Coverage here is regression coverage of the wrapping itself; the
+underlying helpers are exercised in their own dedicated test files.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ----------------------------------------------------------------------------
+# Programme Manager
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestProgrammeManagerTools:
+    def test_list_programmes_tool(self) -> None:
+        from squad.programme_manager import list_programmes_tool
+
+        sentinel = [{"handle": "acme"}]
+        with patch("squad.programme_manager.h1.list_programmes", return_value=sentinel) as m:
+            result = list_programmes_tool.func(page_size=5)
+
+        assert result == sentinel
+        m.assert_called_once_with(page_size=5)
+
+    def test_get_scope_tool(self) -> None:
+        from squad.programme_manager import get_scope_tool
+
+        with (
+            patch(
+                "squad.programme_manager.h1.get_programme_policy",
+                return_value={"data": {"x": 1}},
+            ) as mp,
+            patch(
+                "squad.programme_manager.h1.get_structured_scope",
+                return_value={"items": []},
+            ) as ms,
+        ):
+            result = get_scope_tool.func("acme")
+
+        assert result == {"policy": {"data": {"x": 1}}, "scope": {"items": []}}
+        mp.assert_called_once_with("acme")
+        ms.assert_called_once_with("acme")
+
+    def test_get_programme_stats_tool(self) -> None:
+        from squad.programme_manager import get_programme_stats_tool
+
+        sentinel = {"reports_received": 100}
+        with patch(
+            "squad.programme_manager.h1.get_programme_stats",
+            return_value=sentinel,
+        ) as m:
+            result = get_programme_stats_tool.func("acme")
+
+        assert result == sentinel
+        m.assert_called_once_with("acme")
+
+
+# ----------------------------------------------------------------------------
+# OSINT Analyst
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOsintAnalystTools:
+    def test_recon_tool(self, programme, recon_result) -> None:
+        from squad.osint_analyst import recon_tool
+
+        with (
+            patch("squad.osint_analyst.http.set_programme") as mhttp,
+            patch(
+                "squad.osint_analyst.h1.get_programme_policy",
+                return_value={"data": {}},
+            ),
+            patch("squad.osint_analyst.h1.get_structured_scope", return_value={}),
+            patch("squad.osint_analyst.h1.parse_programme", return_value=programme),
+            patch("squad.osint_analyst.run_recon", return_value=recon_result) as mrun,
+        ):
+            result = recon_tool.func("acme")
+
+        assert result == recon_result.model_dump()
+        mhttp.assert_called_once_with("acme")
+        mrun.assert_called_once_with(programme)
+
+    def test_cert_transparency_tool(self) -> None:
+        from squad.osint_analyst import cert_transparency_tool
+
+        sentinel = ["api.example.com", "admin.example.com"]
+        with patch(
+            "squad.osint_analyst.cert_transparency",
+            return_value=sentinel,
+        ) as m:
+            result = cert_transparency_tool.func("example.com")
+
+        assert result == sentinel
+        m.assert_called_once_with("example.com")
+
+    def test_historical_urls_tool(self) -> None:
+        from squad.osint_analyst import historical_urls_tool
+
+        sentinel = ["https://example.com/old"]
+        with patch(
+            "squad.osint_analyst.historical_urls",
+            return_value=sentinel,
+        ) as m:
+            result = historical_urls_tool.func("example.com")
+
+        assert result == sentinel
+        m.assert_called_once_with("example.com")
+
+    def test_llm_detection_tool(self, endpoint) -> None:
+        from squad.osint_analyst import llm_detection_tool
+
+        endpoints_json = json.dumps([endpoint.model_dump(mode="json")])
+        with patch(
+            "squad.osint_analyst.detect_llm_endpoints",
+            return_value=[endpoint],
+        ) as m:
+            result = llm_detection_tool.func(endpoints_json)
+
+        assert result == [endpoint.model_dump()]
+        assert len(m.call_args[0][0]) == 1
+
+
+# ----------------------------------------------------------------------------
+# Vulnerability Researcher
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestVulnerabilityResearcherTools:
+    def test_triage_tool(self, raw_finding_high, programme, verified_vuln) -> None:
+        from squad.vulnerability_researcher import triage_tool
+
+        raw_json = json.dumps([raw_finding_high.model_dump(mode="json")])
+        with (
+            patch("squad.vulnerability_researcher.http.set_programme") as mhttp,
+            patch(
+                "squad.vulnerability_researcher.h1.get_programme_policy",
+                return_value={"data": {}},
+            ),
+            patch(
+                "squad.vulnerability_researcher.h1.get_structured_scope",
+                return_value={},
+            ),
+            patch(
+                "squad.vulnerability_researcher.h1.parse_programme",
+                return_value=programme,
+            ),
+            patch(
+                "squad.vulnerability_researcher.triage_findings",
+                return_value=[verified_vuln],
+            ),
+        ):
+            result = triage_tool.func(raw_json, "acme")
+
+        assert result == [verified_vuln.model_dump()]
+        mhttp.assert_called_once_with("acme")
+
+    def test_lookup_cve_tool(self) -> None:
+        from squad.vulnerability_researcher import lookup_cve_tool
+
+        sentinel = [{"cve_id": "CVE-2024-1234"}]
+        with patch(
+            "squad.vulnerability_researcher.lookup_cve",
+            return_value=sentinel,
+        ) as m:
+            result = lookup_cve_tool.func("sql injection")
+
+        assert result == sentinel
+        m.assert_called_once_with("sql injection")
+
+    def test_check_duplicate_tool_matches(self) -> None:
+        from squad.vulnerability_researcher import check_duplicate_tool
+
+        reports = [
+            {
+                "id": "1",
+                "attributes": {"title": "SQL Injection in search", "state": "open"},
+            },
+            {
+                "id": "2",
+                "attributes": {"title": "XSS in admin panel", "state": "triaged"},
+            },
+        ]
+        with (
+            patch("squad.vulnerability_researcher.http.set_programme"),
+            patch(
+                "squad.vulnerability_researcher.h1.list_reports",
+                return_value=reports,
+            ),
+        ):
+            result = check_duplicate_tool.func("acme", "SQL Injection in search")
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["report_id"] == "1"
+
+    def test_check_duplicate_tool_handles_missing_title(self) -> None:
+        from squad.vulnerability_researcher import check_duplicate_tool
+
+        reports = [{"id": "3", "attributes": {"state": "closed"}}]
+        with (
+            patch("squad.vulnerability_researcher.http.set_programme"),
+            patch(
+                "squad.vulnerability_researcher.h1.list_reports",
+                return_value=reports,
+            ),
+        ):
+            result = check_duplicate_tool.func("acme", "Anything")
+
+        assert result == []
+
+
+# ----------------------------------------------------------------------------
+# Technical Author
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTechnicalAuthorTools:
+    def test_create_report_tool(self, verified_vuln, disclosure_report) -> None:
+        from squad.technical_author import create_report_tool
+
+        vuln_json = verified_vuln.model_dump_json()
+        with (
+            patch("squad.technical_author.http.set_programme") as mhttp,
+            patch(
+                "squad.technical_author.create_disclosure_report",
+                return_value=disclosure_report,
+            ),
+            patch("squad.technical_author.save_report") as msave,
+        ):
+            result = create_report_tool.func("acme", vuln_json, "summary line")
+
+        assert result == disclosure_report.model_dump()
+        mhttp.assert_called_once_with("acme")
+        msave.assert_called_once_with(disclosure_report)
+
+    def test_calculate_cvss_tool(self) -> None:
+        from squad.technical_author import calculate_cvss_tool
+
+        with patch(
+            "squad.technical_author.calculate_cvss_score",
+            return_value=8.8,
+        ) as m:
+            result = calculate_cvss_tool.func("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
+
+        assert result == 8.8
+        m.assert_called_once_with("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
+
+
+# ----------------------------------------------------------------------------
+# Disclosure Coordinator
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDisclosureCoordinatorTools:
+    def test_submit_report_tool(self, disclosure_report) -> None:
+        from squad.disclosure_coordinator import submit_report_tool
+
+        report_json = disclosure_report.model_dump_json()
+        submission = MagicMock()
+        submission.model_dump.return_value = {"submitted": True, "id": "h1-42"}
+
+        with (
+            patch("squad.disclosure_coordinator.http.set_programme") as mhttp,
+            patch("squad.disclosure_coordinator.save_report") as msave,
+            patch(
+                "squad.disclosure_coordinator.h1.submit_report",
+                return_value=submission,
+            ) as msub,
+        ):
+            result = submit_report_tool.func(report_json)
+
+        assert result == {"submitted": True, "id": "h1-42"}
+        mhttp.assert_called_once_with(disclosure_report.programme_handle)
+        msave.assert_called_once()
+        msub.assert_called_once()
+
+    def test_check_duplicate_tool(self) -> None:
+        from squad.disclosure_coordinator import check_duplicate_tool
+
+        reports = [
+            {
+                "id": "1",
+                "attributes": {"title": "SQL Injection in search", "state": "open"},
+            },
+        ]
+        with (
+            patch("squad.disclosure_coordinator.http.set_programme"),
+            patch(
+                "squad.disclosure_coordinator.h1.list_reports",
+                return_value=reports,
+            ),
+        ):
+            result = check_duplicate_tool.func("acme", "SQL Injection in search")
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["title"] == "SQL Injection in search"
+
+
+# ----------------------------------------------------------------------------
+# Penetration Tester - sample of @tool wrappers
+#
+# 42 tools live on this agent; the bodies are near-identical thin wrappers,
+# so a representative sample is enough for regression value without inflating
+# the test suite to no benefit.
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPenetrationTesterTools:
+    def test_nuclei_scan_tool(self, endpoint, raw_finding_low) -> None:
+        from squad.penetration_tester import nuclei_scan_tool
+
+        endpoints_json = json.dumps([endpoint.model_dump(mode="json")])
+        with patch(
+            "squad.penetration_tester.run_nuclei",
+            return_value=[raw_finding_low],
+        ):
+            result = nuclei_scan_tool.func(endpoints_json, '["wordpress"]')
+
+        assert result == [raw_finding_low.model_dump()]
+
+    def test_sqlmap_tool(self, endpoint, raw_finding_low) -> None:
+        from squad.penetration_tester import sqlmap_tool
+
+        endpoints_json = json.dumps([endpoint.model_dump(mode="json")])
+        with patch(
+            "squad.penetration_tester.run_sqlmap",
+            return_value=[raw_finding_low],
+        ):
+            result = sqlmap_tool.func(endpoints_json)
+
+        assert result == [raw_finding_low.model_dump()]
+
+    def test_cookie_check_tool(self, recon_result, raw_finding_low) -> None:
+        from squad.penetration_tester import cookie_check_tool
+
+        recon_json = recon_result.model_dump_json()
+        with (
+            patch("squad.penetration_tester.http.set_programme") as mhttp,
+            patch(
+                "squad.penetration_tester.check_cookies",
+                return_value=[raw_finding_low],
+            ),
+        ):
+            result = cookie_check_tool.func(recon_json)
+
+        assert result == [raw_finding_low.model_dump()]
+        mhttp.assert_called_once_with(recon_result.programme.handle)
+
+    def test_cors_check_tool(self, recon_result, raw_finding_low) -> None:
+        from squad.penetration_tester import cors_check_tool
+
+        recon_json = recon_result.model_dump_json()
+        with (
+            patch("squad.penetration_tester.http.set_programme"),
+            patch(
+                "squad.penetration_tester.check_cors_misconfiguration",
+                return_value=[raw_finding_low],
+            ),
+        ):
+            result = cors_check_tool.func(recon_json)
+
+        assert result == [raw_finding_low.model_dump()]
+
+    def test_csrf_check_tool(self, recon_result, raw_finding_low) -> None:
+        from squad.penetration_tester import csrf_check_tool
+
+        recon_json = recon_result.model_dump_json()
+        with (
+            patch("squad.penetration_tester.http.set_programme"),
+            patch(
+                "squad.penetration_tester.check_csrf",
+                return_value=[raw_finding_low],
+            ),
+        ):
+            result = csrf_check_tool.func(recon_json)
+
+        assert result == [raw_finding_low.model_dump()]
+
+    def test_ssrf_probe_tool(self, endpoint, raw_finding_low) -> None:
+        from squad.penetration_tester import ssrf_probe_tool
+
+        endpoints_json = json.dumps([endpoint.model_dump(mode="json")])
+        with patch(
+            "squad.penetration_tester.check_ssrf",
+            return_value=[raw_finding_low],
+        ):
+            result = ssrf_probe_tool.func(endpoints_json, None)
+
+        assert result == [raw_finding_low.model_dump()]
+
+    def test_header_injection_tool(self, recon_result, raw_finding_low) -> None:
+        from squad.penetration_tester import header_injection_tool
+
+        recon_json = recon_result.model_dump_json()
+        with (
+            patch("squad.penetration_tester.http.set_programme"),
+            patch(
+                "squad.penetration_tester.check_header_injection",
+                return_value=[raw_finding_low],
+            ),
+        ):
+            result = header_injection_tool.func(recon_json)
+
+        assert result == [raw_finding_low.model_dump()]
+
+    def test_host_header_tool(self, recon_result, raw_finding_low) -> None:
+        from squad.penetration_tester import host_header_tool
+
+        recon_json = recon_result.model_dump_json()
+        with (
+            patch("squad.penetration_tester.http.set_programme"),
+            patch(
+                "squad.penetration_tester.check_host_headers",
+                return_value=[raw_finding_low],
+            ),
+        ):
+            result = host_header_tool.func(recon_json)
+
+        assert result == [raw_finding_low.model_dump()]


### PR DESCRIPTION
## Summary

Lifts the coverage gate from 70% to **90%**, backed by new tests rather than a paper floor.

Two commits:

1. **`test(squad)`**: adds `tests/test_squad_tools.py` exercising the `@tool` wrappers on every squad member - Programme Manager (3), OSINT Analyst (4), Vulnerability Researcher (3), Technical Author (2), Disclosure Coordinator (2), and a representative sample of the Penetration Tester's 42 wrappers (8). The wrappers are intentionally thin - JSON unmarshalling, a call into `tools/*` helpers, result serialisation - so this is regression coverage of the wrapping layer specifically. The underlying helpers stay tested in their own dedicated files.

2. **`chore(coverage)`**: bumps `tool.coverage.report.fail_under` from `70` to `90` in `pyproject.toml` and reconciles four doc references in the same commit (`README.md` x2, `docs/ci.md`, `docs/testing.md` which had a stale 85 that never matched the actual 70 gate).

## Coverage delta

| | Before | After |
|---|---|---|
| Total | 89.19% | **91.22%** |
| Floor | 70% | **90%** |
| Headroom | 19.19 pts | 1.22 pts |

No production code, prompts, or runtime behaviour changed. Only new tests and the gate bump.

## Supersedes

Replaces #96, which set the floor at 88%. Closed in favour of this PR after the 88 number was rejected on aesthetic grounds (legitimately - 90 is a nicer line). The new floor is backed by real new coverage rather than just slack to the existing actual.

## What this PR is not

This is still **not** per-PR coverage ratcheting. A real "no drops allowed" gate against the PR's actual diff is tracked at #98 - that remains the correct follow-up.

## Test plan

- [x] `.venv/bin/ruff check .` - All checks passed
- [x] `.venv/bin/ruff format --check .` - 103 files already formatted
- [x] `.venv/bin/mypy . --ignore-missing-imports` - Success: no issues found in 103 source files
- [x] `pytest -m unit --cov` with the new gate - `Required test coverage of 90.0% reached. Total coverage: 91.22%`, **716 passed** (was 693; +23 new tests)
- [x] `bandit -c pyproject.toml -r . -q` - no new findings
- [x] `git diff --stat origin/main` confirms only the five intended files changed (tests/test_squad_tools.py + pyproject.toml + README.md + docs/ci.md + docs/testing.md)
- [ ] CI run on the PR confirms the gate is being enforced (not just locally)
