### PR TITLE
feat(pentest): IDOR probe tool + attack-classification skill (#63)

### DIFF
--- a/.claude/skills/cybersquad-pentest-tool/SKILL.md
+++ b/.claude/skills/cybersquad-pentest-tool/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: cybersquad-pentest-tool
+description: Enforce the attack-classification pattern when writing or editing cybersquad pentest tools. Every active-probe tool that injects multiple named payload variants must expose a StrEnum of attack strategies, wire it through the check function, and surface it on the squad @tool wrapper. Use when creating or editing any file under tools/pentest/ or squad/penetration_tester/__init__.py.
+---
+
+# cybersquad pentest tool conventions
+
+Every active-probe tool that injects multiple named payload variants must follow
+this pattern end-to-end. The goal is that the PT agent can always pick a targeted
+subset of strategies rather than being forced to run everything or nothing.
+
+## When the pattern applies
+
+Apply it when the tool:
+
+- Has a dict or list of **named probe variants** (`_PROBES`, `_PAYLOADS`,
+  `_VARIANTS`, etc.)
+- OR branches its probe logic based on the **type or encoding** of what is
+  injected (e.g. different encoding schemes, different injection vectors, different
+  attack classes)
+
+Do NOT apply it to:
+
+- Single-vector tools that always inject the same fixed payload (e.g. `xss.py`
+  uses one canary string; `cors.py` sends one Origin header - no meaningful choice
+  to expose)
+- Binary wrappers (`sqlmap.py`, `nosqli.py`) where variant selection is delegated
+  to the underlying tool
+- Structural/passive checkers (`cookies.py`, `sri.py`, `sourcemaps.py`) that
+  inspect responses rather than injecting payloads
+
+## The StrEnum
+
+Define one StrEnum per tool, named `<ToolName>Attack` or `<ToolName>Payload`.
+Use `StrEnum` (not `(str, Enum)`). Each member is one distinct strategy or
+encoding variant. The class docstring must explain when an agent would pick each:
+
+```python
+# correct
+from enum import StrEnum
+
+class SsrfPayload(StrEnum):
+    """Named SSRF payload variants - each targets a different internal
+    address class so the agent can pick what matches the suspected target."""
+
+    aws_imds = "aws-imds"       # Cloud IMDS (AWS/Azure/GCP) - use on cloud targets
+    localhost_ipv4 = "localhost-ipv4"  # Internal services via 127.0.0.1
+    localhost_ipv6 = "localhost-ipv6"  # Dual-stack bypass via [::1]
+
+# wrong - no docstring, no per-member guidance
+class SsrfPayload(StrEnum):
+    aws_imds = "aws-imds"
+    localhost_ipv4 = "localhost-ipv4"
+```
+
+Do NOT add an `all` member to the StrEnum. "Run all" is expressed by passing
+`None`, not by adding a synthetic member.
+
+## The check function signature
+
+The check function must accept an optional filter parameter:
+
+```python
+# correct
+def check_ssrf(
+    endpoints: list[Endpoint],
+    payload_names: list[SsrfPayload] | None = None,
+) -> list[RawFinding]:
+```
+
+`None` means "run all variants". Resolve it at the top of the function using
+`frozenset`:
+
+```python
+active = frozenset(payload_names) if payload_names is not None else frozenset(SsrfPayload)
+```
+
+An empty list `[]` is a no-op: no requests are made, an empty list is returned.
+This lets callers disable the tool in a pipeline branch without special-casing.
+
+Never use a boolean `run_all` flag or a separate `all` sentinel - the `None`
+convention is already established across all tools.
+
+## The squad @tool wrapper
+
+The tool wrapper in `squad/penetration_tester/__init__.py` must:
+
+1. Import the StrEnum from the module alongside the check function:
+
+```python
+from tools.pentest.ssrf import SsrfPayload, check_ssrf
+```
+
+2. Include the filter parameter in the `@tool` function signature with the
+   correct type (not bare `str`, not `list[str]`):
+
+```python
+@tool("SSRF Probe")
+def ssrf_probe_tool(
+    endpoints_json: str,
+    payloads: list[SsrfPayload] | None = None,
+) -> list[dict]:
+```
+
+3. Pass it through to the check function:
+
+```python
+    return [f.model_dump() for f in check_ssrf(_parse_endpoints(endpoints_json), payloads)]
+```
+
+4. Document each variant in the docstring so the agent knows when to use a
+   subset. Include: what the variant targets, when it is useful, the request-cost
+   implication of narrowing. Example structure:
+
+```
+payloads: optional list of internal-address variants to try; omit or pass
+  null to try all. Useful for stealth or when the cloud provider is known
+  (e.g. just "aws-imds" for an AWS-hosted target).
+```
+
+## Anti-patterns to catch
+
+- StrEnum defined in the tool file but not imported/re-exported in the squad
+  wrapper (the agent cannot see it)
+- Squad wrapper accepts `list[str]` instead of `list[ToolNameAttack]` (loses
+  type safety and documentation)
+- `attacks=None` handled with `if attacks is None: attacks = list(XxxAttack)`
+  (use `frozenset` to avoid mutating the default)
+- Variants that are semantically identical (two members that always produce the
+  same probe) - if the agent cannot decide between them, merge them
+- Missing per-variant docstring: the agent must be able to read the @tool
+  docstring and pick the right subset without reading the tool source
+
+## Canonical examples to read
+
+`tools/pentest/ssrf.py` + the `ssrf_probe_tool` entry in
+`squad/penetration_tester/__init__.py` - the shortest complete example.
+
+`tools/pentest/idor.py` + `idor_probe_tool` - shows the `_path_variants` /
+`_param_variants` split when the same StrEnum drives two different probe phases.

--- a/.claude/skills/cybersquad-pentest-tool/SKILL.md
+++ b/.claude/skills/cybersquad-pentest-tool/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cybersquad-pentest-tool
-description: Enforce the attack-classification pattern when writing or editing cybersquad pentest tools. Every active-probe tool that injects multiple named payload variants must expose a StrEnum of attack strategies, wire it through the check function, and surface it on the squad @tool wrapper. Use when creating or editing any file under tools/pentest/ or squad/penetration_tester/__init__.py.
+description: Enforce the attack-classification pattern for cybersquad pentest tools. Covers the StrEnum variant enum, check function filter parameter, and squad @tool wiring. Use when creating or editing any file under tools/pentest/ or squad/penetration_tester/__init__.py.
 ---
 
 # cybersquad pentest tool conventions

--- a/.claude/skills/cybersquad-test-fixtures/SKILL.md
+++ b/.claude/skills/cybersquad-test-fixtures/SKILL.md
@@ -60,6 +60,25 @@ def test_no_finding(make_response, clean_response_body):
     assert result is None
 ```
 
+## Domain fixtures
+
+Use these instead of ad-hoc hostnames so test intent is readable:
+
+- `victim_url` - `"https://victim.example.com"` - the scanning target
+- `callback_url` - `"https://callback.cybersquad.com"` - OOB receiver (placeholder until #77 lands)
+
+```python
+# correct
+def test_detects_injection(make_response, victim_url):
+    ep = Endpoint(url=f"{victim_url}/api/users/42", parameters=["id"])
+    ...
+
+# wrong - opaque hostname, no indication of role
+def test_detects_injection(make_response):
+    ep = Endpoint(url="https://app.example.com/api/users/42", parameters=["id"])
+    ...
+```
+
 ## When in doubt
 
 Read `tests/conftest.py` - it is the source of truth for what is available.

--- a/.claude/skills/cybersquad-test-fixtures/SKILL.md
+++ b/.claude/skills/cybersquad-test-fixtures/SKILL.md
@@ -79,6 +79,26 @@ def test_detects_injection(make_response):
     ...
 ```
 
+## make_html_page
+
+Factory for minimal HTML pages containing `<script>` tags. Returns a callable that accepts an optional `scripts` list; omitting it defaults to `[f"{victim_url}/app.js"]`.
+
+Use this wherever a test needs a generic HTML page with script references (e.g. sourcemap probes, SRI checks) rather than hand-rolling `<html><head><script ...></script></head></html>` strings.
+
+```python
+# correct
+def test_map_detected(victim_url, make_html_page):
+    def fake_get(url, **kwargs):
+        ...
+        resp.text = make_html_page()                          # default script
+        resp.text = make_html_page(scripts=["https://cdn.example.net/lib.js"])
+        ...
+
+# wrong - inline string duplicates the pattern and hard-codes the hostname
+def test_map_detected(victim_url):
+    html = f'<html><head><script src="{victim_url}/app.js"></script></head></html>'
+```
+
 ## When in doubt
 
 Read `tests/conftest.py` - it is the source of truth for what is available.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,3 +55,4 @@ Skills under `.claude/skills/` fire automatically when relevant files are edited
 - `cybersquad-agent-llm` - `crewai.LLM(...)` construction + `anthropic/` model prefix. Trigger: `crew.py` / `Agent` construction.
 - `cybersquad-test-fixtures` - the `conftest.py` fixture catalogue. Trigger: edits under `tests/`.
 - `cybersquad-change-discipline` - minimal-diff philosophy, intentional renames, linter-as-signal, FIXME/TODO grammar, Chesterton's Fence. Trigger: editing existing code, suppressing a linter finding, or considering an out-of-scope rename/refactor.
+- `cybersquad-pentest-tool` - attack-classification StrEnum pattern, check function filter parameter, squad @tool wiring and docstring requirements. Trigger: creating or editing files under `tools/pentest/` or `squad/penetration_tester/__init__.py`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,4 +55,4 @@ Skills under `.claude/skills/` fire automatically when relevant files are edited
 - `cybersquad-agent-llm` - `crewai.LLM(...)` construction + `anthropic/` model prefix. Trigger: `crew.py` / `Agent` construction.
 - `cybersquad-test-fixtures` - the `conftest.py` fixture catalogue. Trigger: edits under `tests/`.
 - `cybersquad-change-discipline` - minimal-diff philosophy, intentional renames, linter-as-signal, FIXME/TODO grammar, Chesterton's Fence. Trigger: editing existing code, suppressing a linter finding, or considering an out-of-scope rename/refactor.
-- `cybersquad-pentest-tool` - attack-classification StrEnum pattern, check function filter parameter, squad @tool wiring and docstring requirements. Trigger: creating or editing files under `tools/pentest/` or `squad/penetration_tester/__init__.py`.
+- `cybersquad-pentest-tool` - attack-classification StrEnum, check function filter parameter, squad @tool wiring. Trigger: creating or editing files under `tools/pentest/` or `squad/penetration_tester/__init__.py`.

--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -35,6 +35,7 @@ from tools.pentest.csrf import check_csrf
 from tools.pentest.errors import check_error_disclosure
 from tools.pentest.header_xss import XSSHeader, check_header_xss
 from tools.pentest.hpp import check_hpp
+from tools.pentest.idor import IDORAttack, check_idor
 from tools.pentest.jwt import JwtAttack, check_jwt
 from tools.pentest.ldap_injection import LdapPayload, check_ldap_injection
 from tools.pentest.nosqli import run_nosqli
@@ -884,6 +885,48 @@ def prototype_pollution_tool(
     ]
 
 
+@tool("IDOR Probe")
+def idor_probe_tool(
+    endpoints_json: str,
+    attacks: list[IDORAttack] | None = None,
+) -> list[dict]:
+    """
+    Probe ID-shaped URL path segments and parameters for Insecure Direct
+    Object Reference (IDOR) - the most-rewarded class on HackerOne (OWASP A01).
+
+    Numeric path segments (e.g. /users/12345) and ID-shaped parameters (id,
+    user_id, account_id, order_id, ...) are probed using the selected attack
+    strategies (omit or pass null to run all three):
+
+      sequential    - neighbour IDs: value-1, value+1, value-100 (numeric path
+                      segments where the current value is visible in the URL).
+                      For query parameters where no current value is known,
+                      probes 1 and 2 instead.
+      boundary      - 0 and -1; catches missing lower-bound checks.
+      type-juggling - 1.0, 1e1, 01; targets backends that accept loose numeric
+                      input and may bypass strict access-control comparisons.
+
+    Detection signals:
+      HIGH   - status changes from 401/403 to 200 (access-control bypass)
+      HIGH   - 200 response body contains a PII pattern (email, sensitive key)
+      MEDIUM - unexpected 200 for boundary ID (id=0 or id=-1)
+
+    endpoints_json: JSON array of endpoint objects. Prioritise endpoints where:
+      - The URL path includes numeric segments (/api/users/42, /orders/9)
+      - Parameters include id, user_id, account_id, order_id, or similar
+      - The endpoint handles authenticated or per-user data
+      Example: '[{"url": "https://example.com/api/users/42", "status_code": 200}]'
+
+    Use attacks=["boundary"] for a quiet reconnaissance pass (2 requests per
+    candidate). Use attacks=["sequential"] when you already know an ID and want
+    to probe adjacent objects. Use all three (default) for maximum coverage.
+
+    One finding per endpoint; stops after the first confirming probe. Does not
+    brute-force ID ranges. Returns raw findings as dicts.
+    """
+    return [f.model_dump() for f in check_idor(_parse_endpoints(endpoints_json), attacks)]
+
+
 @tool("JWT Vulnerability Check")
 def jwt_check_tool(
     token: str,
@@ -967,5 +1010,6 @@ MEMBER = SquadMember(
         xxe_probe_tool,
         prototype_pollution_tool,
         jwt_check_tool,
+        idor_probe_tool,
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,22 @@ from models import (  # noqa: E402
 )
 
 
+# Domain fixtures
+#
+# Use these instead of ad-hoc hostnames so test intent is readable at a glance.
+# victim_url  - the scanning target (an app we are testing)
+# callback_url - OOB receiver (a server we control, used for blind injection);
+#                placeholder until #77 lands real interactsh infrastructure.
+@pytest.fixture()
+def victim_url() -> str:
+    return "https://victim.example.com"
+
+
+@pytest.fixture()
+def callback_url() -> str:
+    return "https://callback.cybersquad.com"
+
+
 # Programme fixtures
 @pytest.fixture()
 def scope_item_url() -> ScopeItem:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,22 @@ def callback_url() -> str:
     return "https://callback.cybersquad.com"
 
 
+@pytest.fixture()
+def make_html_page(victim_url: str):
+    """Factory for minimal HTML pages containing script tags.
+
+    Returns a callable: make_html_page(scripts=[...]) -> str.
+    Defaults to a single <script> pointing at {victim_url}/app.js.
+    """
+
+    def _make(scripts: list[str] | None = None) -> str:
+        _scripts = scripts if scripts is not None else [f"{victim_url}/app.js"]
+        tags = "".join(f'<script src="{s}"></script>' for s in _scripts)
+        return f"<html><head>{tags}</head></html>"
+
+    return _make
+
+
 # Programme fixtures
 @pytest.fixture()
 def scope_item_url() -> ScopeItem:

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -368,10 +368,10 @@ class TestCheckSensitiveFiles:
         env = [r for r in results if ".env File" in r.title]
         assert len(env) == 1
 
-    def test_deduplicates_by_origin(self):
+    def test_deduplicates_by_origin(self, victim_url: str):
         endpoints = [
-            Endpoint(url="https://app.example.com/page1", status_code=200),
-            Endpoint(url="https://app.example.com/page2", status_code=200),
+            Endpoint(url=f"{victim_url}/page1", status_code=200),
+            Endpoint(url=f"{victim_url}/page2", status_code=200),
         ]
         call_count = 0
 

--- a/tests/test_cmd_injection.py
+++ b/tests/test_cmd_injection.py
@@ -14,8 +14,10 @@ pytestmark = pytest.mark.unit
 
 
 class TestCheckCmdInjection:
-    def test_detects_canary_in_response(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
+    def test_detects_canary_in_response(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/ping", status_code=200, parameters=["host"])
 
         with patch(
             "requests.get", return_value=make_response(body=f"PING output\n{_CANARY}\ndone")
@@ -29,17 +31,19 @@ class TestCheckCmdInjection:
         assert _CANARY in results[0].evidence
 
     def test_stops_after_first_matching_payload(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
+        ep = Endpoint(url=f"{victim_url}/ping", status_code=200, parameters=["host"])
 
         with patch("requests.get", return_value=make_response(body=f"{_CANARY}")) as mock_get:
             check_cmd_injection([ep])
 
         assert mock_get.call_count == 1
 
-    def test_no_finding_when_canary_absent(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
+    def test_no_finding_when_canary_absent(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/ping", status_code=200, parameters=["host"])
 
         with patch(
             "requests.get", return_value=make_response(body="PING 127.0.0.1: 56 data bytes")
@@ -49,10 +53,10 @@ class TestCheckCmdInjection:
         assert results == []
 
     def test_partial_canary_match_is_not_a_finding(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # A substring of the canary appearing coincidentally must not trigger.
-        ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
+        ep = Endpoint(url=f"{victim_url}/ping", status_code=200, parameters=["host"])
         partial = _CANARY[:6]
 
         with patch("requests.get", return_value=make_response(body=f"result: {partial} ok")):
@@ -60,8 +64,8 @@ class TestCheckCmdInjection:
 
         assert results == []
 
-    def test_skips_endpoints_without_parameters(self) -> None:
-        ep = Endpoint(url="https://app.example.com/ping", status_code=200)
+    def test_skips_endpoints_without_parameters(self, victim_url: str) -> None:
+        ep = Endpoint(url=f"{victim_url}/ping", status_code=200)
 
         with patch("requests.get") as mock_get:
             results = check_cmd_injection([ep])
@@ -69,8 +73,8 @@ class TestCheckCmdInjection:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_skips_server_error_endpoints(self) -> None:
-        ep = Endpoint(url="https://app.example.com/ping", status_code=500, parameters=["host"])
+    def test_skips_server_error_endpoints(self, victim_url: str) -> None:
+        ep = Endpoint(url=f"{victim_url}/ping", status_code=500, parameters=["host"])
 
         with patch("requests.get") as mock_get:
             results = check_cmd_injection([ep])
@@ -79,10 +83,10 @@ class TestCheckCmdInjection:
         assert results == []
 
     def test_one_finding_per_endpoint_multiple_params(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         ep = Endpoint(
-            url="https://app.example.com/ping",
+            url=f"{victim_url}/ping",
             status_code=200,
             parameters=["host", "port"],
         )
@@ -92,9 +96,11 @@ class TestCheckCmdInjection:
 
         assert len(results) == 1
 
-    def test_deduplicates_same_url(self, make_response: Callable[..., MagicMock]) -> None:
-        ep1 = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
-        ep2 = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["ip"])
+    def test_deduplicates_same_url(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep1 = Endpoint(url=f"{victim_url}/ping", status_code=200, parameters=["host"])
+        ep2 = Endpoint(url=f"{victim_url}/ping", status_code=200, parameters=["ip"])
 
         with patch("requests.get", return_value=make_response(body=_CANARY)):
             results = check_cmd_injection([ep1, ep2])
@@ -102,18 +108,18 @@ class TestCheckCmdInjection:
         assert len(results) == 1
 
     def test_multiple_distinct_endpoints_each_get_a_finding(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep1 = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
-        ep2 = Endpoint(url="https://app.example.com/exec", status_code=200, parameters=["cmd"])
+        ep1 = Endpoint(url=f"{victim_url}/ping", status_code=200, parameters=["host"])
+        ep2 = Endpoint(url=f"{victim_url}/exec", status_code=200, parameters=["cmd"])
 
         with patch("requests.get", return_value=make_response(body=_CANARY)):
             results = check_cmd_injection([ep1, ep2])
 
         assert len(results) == 2
 
-    def test_network_exception_is_swallowed(self) -> None:
-        ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
+    def test_network_exception_is_swallowed(self, victim_url: str) -> None:
+        ep = Endpoint(url=f"{victim_url}/ping", status_code=200, parameters=["host"])
 
         with patch("requests.get", side_effect=OSError("connection refused")):
             results = check_cmd_injection([ep])
@@ -136,12 +142,12 @@ class TestCheckCmdInjection:
             assert _CANARY in payload, f"canary missing from payload {label!r}"
 
     def test_payload_filter_runs_only_named_variants(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # When the agent passes a single payload name we should issue exactly
         # one request per parameter and use only that variant. This is the
         # core "be surgical" affordance for stealth and chained probes.
-        ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
+        ep = Endpoint(url=f"{victim_url}/ping", status_code=200, parameters=["host"])
 
         seen_urls: list[str] = []
 
@@ -157,11 +163,11 @@ class TestCheckCmdInjection:
         # The single request must have used the semicolon variant.
         assert "%3B" in seen_urls[0] or "; echo" in seen_urls[0]
 
-    def test_payload_filter_with_unknown_name_runs_no_payloads(self) -> None:
+    def test_payload_filter_with_unknown_name_runs_no_payloads(self, victim_url: str) -> None:
         # Pydantic validation already prevents invalid enum strings reaching
         # the function in production, but at the Python layer a wrong name
         # should be a no-op rather than a fallback to all-payloads.
-        ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
+        ep = Endpoint(url=f"{victim_url}/ping", status_code=200, parameters=["host"])
 
         with patch("requests.get") as mock_get:
             results = check_cmd_injection([ep], payload_names=[])
@@ -171,11 +177,11 @@ class TestCheckCmdInjection:
         mock_get.assert_not_called()
 
     def test_payload_filter_finding_evidence_names_the_variant(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # When a filtered probe fires, the evidence must name which variant
         # triggered - the agent needs that to chain follow-up requests.
-        ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
+        ep = Endpoint(url=f"{victim_url}/ping", status_code=200, parameters=["host"])
 
         with patch("requests.get", return_value=make_response(body=_CANARY)):
             results = check_cmd_injection([ep], payload_names=[CmdPayload.dollar_paren])
@@ -184,11 +190,11 @@ class TestCheckCmdInjection:
         assert "dollar-paren" in results[0].evidence
 
     def test_payload_filter_none_runs_all_variants(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Explicit None (the default) preserves the original behaviour:
         # every payload is tried until one matches.
-        ep = Endpoint(url="https://app.example.com/ping", status_code=200, parameters=["host"])
+        ep = Endpoint(url=f"{victim_url}/ping", status_code=200, parameters=["host"])
 
         seen_urls: list[str] = []
 

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -128,16 +128,16 @@ class TestScanValue:
 
 
 class TestCheckCookies:
-    def test_missing_secure_on_https_session_cookie_is_medium(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_missing_secure_on_https_session_cookie_is_medium(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         with patch("requests.get", return_value=_resp(["sid=abc; HttpOnly"])):
             findings = check_cookies([ep])
         assert len(findings) == 1
         assert findings[0].vuln_class == "CookieMissingSecure"
         assert findings[0].severity_hint == Severity.MEDIUM
 
-    def test_missing_secure_on_non_session_cookie_is_low(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_missing_secure_on_non_session_cookie_is_low(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         with patch("requests.get", return_value=_resp(["theme=dark"])):
             findings = check_cookies([ep])
         classes = {f.vuln_class for f in findings}
@@ -145,22 +145,22 @@ class TestCheckCookies:
         miss = next(f for f in findings if f.vuln_class == "CookieMissingSecure")
         assert miss.severity_hint == Severity.LOW
 
-    def test_missing_httponly_on_session_shaped(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_missing_httponly_on_session_shaped(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         with patch("requests.get", return_value=_resp(["sid=abc; Secure"])):
             findings = check_cookies([ep])
         classes = {f.vuln_class for f in findings}
         assert "CookieMissingHttpOnly" in classes
 
-    def test_samesite_none_without_secure(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_samesite_none_without_secure(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         with patch("requests.get", return_value=_resp(["sid=abc; HttpOnly; SameSite=None"])):
             findings = check_cookies([ep])
         classes = {f.vuln_class for f in findings}
         assert "CookieWeakSameSite" in classes
 
-    def test_domain_too_broad(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_domain_too_broad(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         with patch(
             "requests.get",
             return_value=_resp(["sid=abc; Secure; HttpOnly; Domain=.example.com; SameSite=Lax"]),
@@ -169,8 +169,8 @@ class TestCheckCookies:
         classes = {f.vuln_class for f in findings}
         assert "CookieDomainTooBroad" in classes
 
-    def test_domain_exact_match_is_fine(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_domain_exact_match_is_fine(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         with patch(
             "requests.get",
             return_value=_resp(["sid=abc; Secure; HttpOnly; Domain=app.example.com; SameSite=Lax"]),
@@ -179,8 +179,8 @@ class TestCheckCookies:
         classes = {f.vuln_class for f in findings}
         assert "CookieDomainTooBroad" not in classes
 
-    def test_persistent_session_cookie(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_persistent_session_cookie(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         with patch(
             "requests.get",
             return_value=_resp(["sid=abc; Secure; HttpOnly; SameSite=Lax; Max-Age=86400"]),
@@ -189,8 +189,8 @@ class TestCheckCookies:
         classes = {f.vuln_class for f in findings}
         assert "CookiePersistentSession" in classes
 
-    def test_high_severity_secret_in_cookie_value(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_high_severity_secret_in_cookie_value(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         with patch(
             "requests.get",
             return_value=_resp(["sid=AKIAIOSFODNN7EXAMPLE; Secure; HttpOnly; SameSite=Lax"]),

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -202,9 +202,9 @@ class TestCheckCSRF:
     # ------------------------------------------------------------------
 
     def test_detects_missing_csrf_token_medium(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200)
 
         with (
             patch(
@@ -224,9 +224,9 @@ class TestCheckCSRF:
         assert "/submit" in tier1[0].evidence
 
     def test_no_finding_when_csrf_token_present(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200)
 
         with patch(
             "requests.get",
@@ -238,8 +238,10 @@ class TestCheckCSRF:
 
         assert results == []
 
-    def test_skips_non_html_responses(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/api/data", status_code=200)
+    def test_skips_non_html_responses(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/api/data", status_code=200)
 
         with patch(
             "requests.get",
@@ -252,8 +254,8 @@ class TestCheckCSRF:
         mock_get.assert_called_once()
         assert results == []
 
-    def test_skips_5xx_endpoints(self) -> None:
-        ep = Endpoint(url="https://app.example.com/broken", status_code=500)
+    def test_skips_5xx_endpoints(self, victim_url: str) -> None:
+        ep = Endpoint(url=f"{victim_url}/broken", status_code=500)
 
         with patch("requests.get") as mock_get:
             results = check_csrf([ep])
@@ -262,9 +264,9 @@ class TestCheckCSRF:
         assert results == []
 
     def test_skips_endpoints_with_get_forms_only(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/search", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/search", status_code=200)
 
         with patch(
             "requests.get",
@@ -277,9 +279,9 @@ class TestCheckCSRF:
         assert results == []
 
     def test_no_finding_on_page_with_no_forms(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/about", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/about", status_code=200)
 
         with patch(
             "requests.get",
@@ -291,8 +293,8 @@ class TestCheckCSRF:
 
         assert results == []
 
-    def test_network_exception_is_swallowed(self) -> None:
-        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+    def test_network_exception_is_swallowed(self, victim_url: str) -> None:
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200)
 
         with patch("requests.get", side_effect=OSError("connection refused")):
             results = check_csrf([ep])
@@ -300,11 +302,11 @@ class TestCheckCSRF:
         assert results == []
 
     def test_no_tier1_finding_when_xsrf_cookie_set(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Angular-style cookie suppresses the missing-input finding (Tier 1)
         # but Tier 2 still runs - a per-view bypass could expose the endpoint.
-        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200)
 
         with (
             patch(
@@ -322,10 +324,10 @@ class TestCheckCSRF:
         assert not any(r.severity_hint == Severity.MEDIUM for r in results)
 
     def test_no_tier1_finding_when_csrftoken_cookie_set(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Django pattern - Tier 1 suppressed, Tier 2 still runs.
-        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200)
 
         with (
             patch(
@@ -343,14 +345,14 @@ class TestCheckCSRF:
         assert not any(r.severity_hint == Severity.MEDIUM for r in results)
 
     def test_no_tier1_finding_when_csrf_meta_tag_present(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Rails-style meta tag suppresses Tier 1 but Tier 2 still runs.
         html = (
             '<html><head><meta name="csrf-token" content="abc"></head>'
             "<body>" + _HTML_POST_NO_TOKEN + "</body></html>"
         )
-        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200)
 
         with (
             patch(
@@ -366,10 +368,10 @@ class TestCheckCSRF:
         assert not any(r.severity_hint == Severity.MEDIUM for r in results)
 
     def test_tier2_fires_despite_csrf_cookie_bypass(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Cookie present but endpoint accepts cross-origin POST (e.g. @csrf_exempt).
-        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200)
 
         with (
             patch(
@@ -390,14 +392,14 @@ class TestCheckCSRF:
         assert not any(r.severity_hint == Severity.MEDIUM for r in results)
 
     def test_tier2_fires_despite_csrf_meta_tag_bypass(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Meta tag present but endpoint accepts cross-origin POST (e.g. skip_before_action).
         html = (
             '<html><head><meta name="csrf-token" content="abc"></head>'
             "<body>" + _HTML_POST_NO_TOKEN + "</body></html>"
         )
-        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200)
 
         with (
             patch(
@@ -415,10 +417,10 @@ class TestCheckCSRF:
         assert "skip_before_action" in tier2[0].evidence
 
     def test_session_cookies_do_not_suppress_finding(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Cookies that aren't CSRF-related shouldn't act as a free pass.
-        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200)
 
         with (
             patch(
@@ -441,9 +443,9 @@ class TestCheckCSRF:
     # ------------------------------------------------------------------
 
     def test_detects_origin_not_validated_high(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200)
 
         with (
             patch(
@@ -462,10 +464,10 @@ class TestCheckCSRF:
         assert "evil.example.com" in tier2[0].evidence
 
     def test_no_high_finding_when_origin_validated(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Evil origin gets 403, correct origin gets 200 -> origin is validated.
-        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200)
 
         def fake_post(url: str, **kw: object) -> MagicMock:
             headers = kw.get("headers", {})
@@ -489,10 +491,10 @@ class TestCheckCSRF:
         assert tier2 == []
 
     def test_no_high_finding_when_both_non_2xx(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Both origins rejected -> no HIGH finding (not exploitable).
-        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200)
 
         with (
             patch(
@@ -509,11 +511,11 @@ class TestCheckCSRF:
         assert tier2 == []
 
     def test_tier2_runs_even_when_form_has_token(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # A form with a hidden CSRF token passes Tier 1, but Tier 2 still
         # probes for Origin validation - those are independent checks.
-        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200)
 
         with (
             patch(
@@ -529,9 +531,11 @@ class TestCheckCSRF:
         mock_post.assert_called()
         assert not any(r.severity_hint == Severity.MEDIUM for r in results)
 
-    def test_tier2_exception_is_swallowed(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_tier2_exception_is_swallowed(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         # GET succeeds and Tier 1 fires, but Tier 2 POST raises.
-        ep = Endpoint(url="https://app.example.com/login", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200)
 
         with (
             patch(
@@ -552,13 +556,15 @@ class TestCheckCSRF:
     # One finding per endpoint per tier
     # ------------------------------------------------------------------
 
-    def test_one_tier1_finding_per_endpoint(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_one_tier1_finding_per_endpoint(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         # Page has two unprotected POST forms; still only one Tier-1 finding.
         html = """
         <form method="POST" action="/a"><input type="text" name="u"></form>
         <form method="POST" action="/b"><input type="text" name="v"></form>
         """
-        ep = Endpoint(url="https://app.example.com/multi", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/multi", status_code=200)
 
         with (
             patch(
@@ -574,9 +580,11 @@ class TestCheckCSRF:
         tier1 = [r for r in results if r.severity_hint == Severity.MEDIUM]
         assert len(tier1) == 1
 
-    def test_deduplicates_same_url(self, make_response: Callable[..., MagicMock]) -> None:
-        ep1 = Endpoint(url="https://app.example.com/login", status_code=200)
-        ep2 = Endpoint(url="https://app.example.com/login", status_code=200)
+    def test_deduplicates_same_url(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep1 = Endpoint(url=f"{victim_url}/login", status_code=200)
+        ep2 = Endpoint(url=f"{victim_url}/login", status_code=200)
 
         with (
             patch(
@@ -593,10 +601,10 @@ class TestCheckCSRF:
         assert len(tier1) == 1
 
     def test_multiple_distinct_endpoints_each_get_findings(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep1 = Endpoint(url="https://app.example.com/login", status_code=200)
-        ep2 = Endpoint(url="https://app.example.com/register", status_code=200)
+        ep1 = Endpoint(url=f"{victim_url}/login", status_code=200)
+        ep2 = Endpoint(url=f"{victim_url}/register", status_code=200)
 
         with (
             patch(
@@ -613,10 +621,10 @@ class TestCheckCSRF:
         assert len(tier1) == 2
 
     def test_endpoint_without_status_code_is_probed(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # status_code=None means recon did not record it - still probe.
-        ep = Endpoint(url="https://app.example.com/login")
+        ep = Endpoint(url=f"{victim_url}/login")
 
         with (
             patch(

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -23,8 +23,10 @@ _ASPNET_ERROR = "Server Error in '/' Application. Runtime Error"
 
 
 class TestCheckErrorDisclosure:
-    def test_detects_python_traceback(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/api", status_code=200, parameters=["id"])
+    def test_detects_python_traceback(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/api", status_code=200, parameters=["id"])
         with patch("requests.get", return_value=make_response(body=_PYTHON_TRACEBACK)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
@@ -32,89 +34,105 @@ class TestCheckErrorDisclosure:
         assert results[0].severity_hint == Severity.INFORMATIONAL
         assert "Python traceback" in results[0].evidence
 
-    def test_detects_django_debug(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/api", status_code=200, parameters=["id"])
+    def test_detects_django_debug(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/api", status_code=200, parameters=["id"])
         with patch("requests.get", return_value=make_response(body=_DJANGO_ERROR)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
         assert "Django debug" in results[0].evidence
 
-    def test_detects_php_fatal_error(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_detects_php_fatal_error(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         with patch("requests.get", return_value=make_response(body=_PHP_ERROR)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
         assert "PHP fatal error" in results[0].evidence
 
-    def test_detects_java_stack_trace(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_detects_java_stack_trace(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         with patch("requests.get", return_value=make_response(body=_JAVA_TRACE)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
         assert "Java stack trace" in results[0].evidence
 
-    def test_detects_mysql_error(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["q"])
+    def test_detects_mysql_error(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/", status_code=200, parameters=["q"])
         with patch("requests.get", return_value=make_response(body=_MYSQL_ERROR)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
         assert "MySQL error" in results[0].evidence
 
-    def test_detects_oracle_error(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_detects_oracle_error(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         with patch("requests.get", return_value=make_response(body=_ORACLE_ERROR)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
         assert "Oracle SQL error" in results[0].evidence
 
-    def test_detects_postgresql_error(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_detects_postgresql_error(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         with patch("requests.get", return_value=make_response(body=_PG_ERROR)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
         assert "PostgreSQL error" in results[0].evidence
 
-    def test_detects_aspnet_error(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_detects_aspnet_error(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         with patch("requests.get", return_value=make_response(body=_ASPNET_ERROR)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
         assert "ASP.NET" in results[0].evidence
 
-    def test_no_finding_for_clean_response(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_no_finding_for_clean_response(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         with patch(
             "requests.get", return_value=make_response(body="<html><body>Not Found</body></html>")
         ):
             results = check_error_disclosure([ep])
         assert results == []
 
-    def test_skips_server_error_endpoints(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=500)
+    def test_skips_server_error_endpoints(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=500)
         with patch("requests.get") as mock_get:
             results = check_error_disclosure([ep])
         mock_get.assert_not_called()
         assert results == []
 
-    def test_network_exception_is_swallowed(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_network_exception_is_swallowed(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         with patch("requests.get", side_effect=Exception("timeout")):
             results = check_error_disclosure([ep])
         assert results == []
 
     def test_deduplicates_multiple_probe_hits(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         """Only one finding per endpoint even if both probe URLs trigger errors."""
-        ep = Endpoint(url="https://app.example.com/api", status_code=200, parameters=["id"])
+        ep = Endpoint(url=f"{victim_url}/api", status_code=200, parameters=["id"])
         with patch("requests.get", return_value=make_response(body=_PYTHON_TRACEBACK)):
             results = check_error_disclosure([ep])
         assert len(results) == 1
 
     def test_probes_404_path_even_without_parameters(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         seen_urls: list[str] = []
 
         def recording_get(url, **kwargs) -> MagicMock:

--- a/tests/test_header_xss.py
+++ b/tests/test_header_xss.py
@@ -32,8 +32,10 @@ def _make_reflecting_fake(
 
 
 class TestCheckHeaderXss:
-    def test_detects_user_agent_reflection(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/error", status_code=200)
+    def test_detects_user_agent_reflection(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/error", status_code=200)
 
         with patch("requests.get", side_effect=_make_reflecting_fake(make_response, "User-Agent")):
             results = check_header_xss([ep])
@@ -43,8 +45,10 @@ class TestCheckHeaderXss:
         assert results[0].severity_hint == Severity.HIGH
         assert "User-Agent" in results[0].evidence
 
-    def test_detects_referer_reflection(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+    def test_detects_referer_reflection(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/page", status_code=200)
 
         with patch("requests.get", side_effect=_make_reflecting_fake(make_response, "Referer")):
             results = check_header_xss([ep])
@@ -53,9 +57,9 @@ class TestCheckHeaderXss:
         assert "Referer" in results[0].evidence
 
     def test_detects_x_forwarded_for_reflection(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/page", status_code=200)
 
         with patch(
             "requests.get",
@@ -67,9 +71,9 @@ class TestCheckHeaderXss:
         assert "X-Forwarded-For" in results[0].evidence
 
     def test_no_finding_when_canary_is_html_encoded(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/page", status_code=200)
 
         with patch(
             "requests.get",
@@ -79,16 +83,18 @@ class TestCheckHeaderXss:
 
         assert results == []
 
-    def test_no_finding_when_canary_absent(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+    def test_no_finding_when_canary_absent(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/page", status_code=200)
 
         with patch("requests.get", return_value=make_response(body="<html>Normal</html>")):
             results = check_header_xss([ep])
 
         assert results == []
 
-    def test_skips_server_error_endpoints(self) -> None:
-        ep = Endpoint(url="https://app.example.com/", status_code=500)
+    def test_skips_server_error_endpoints(self, victim_url: str) -> None:
+        ep = Endpoint(url=f"{victim_url}/", status_code=500)
 
         with patch("requests.get") as mock_get:
             results = check_header_xss([ep])
@@ -97,9 +103,9 @@ class TestCheckHeaderXss:
         assert results == []
 
     def test_one_finding_per_endpoint_even_when_multiple_headers_reflect(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/page", status_code=200)
 
         with patch("requests.get", side_effect=_make_reflecting_fake(make_response)):
             results = check_header_xss([ep])
@@ -107,9 +113,9 @@ class TestCheckHeaderXss:
         assert len(results) == 1
 
     def test_stops_after_first_reflecting_header(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/page", status_code=200)
         call_count = 0
 
         def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> MagicMock:
@@ -123,16 +129,18 @@ class TestCheckHeaderXss:
 
         assert call_count == 1
 
-    def test_network_exception_is_swallowed(self) -> None:
-        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+    def test_network_exception_is_swallowed(self, victim_url: str) -> None:
+        ep = Endpoint(url=f"{victim_url}/page", status_code=200)
 
         with patch("requests.get", side_effect=OSError("connection refused")):
             results = check_header_xss([ep])
 
         assert results == []
 
-    def test_canary_contains_angle_brackets(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+    def test_canary_contains_angle_brackets(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/page", status_code=200)
         seen_canaries: list[str] = []
 
         def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> MagicMock:
@@ -148,9 +156,9 @@ class TestCheckHeaderXss:
         assert all(c.startswith("<") and c.endswith(">") for c in seen_canaries)
 
     def test_all_five_headers_probed_when_no_reflection(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/page", status_code=200)
         probed: set[str] = set()
 
         def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> MagicMock:
@@ -165,11 +173,11 @@ class TestCheckHeaderXss:
         assert probed == set(XSSHeader)
 
     def test_deduplicates_same_url_across_endpoint_list(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         eps = [
-            Endpoint(url="https://app.example.com/page", status_code=200),
-            Endpoint(url="https://app.example.com/page", status_code=200),
+            Endpoint(url=f"{victim_url}/page", status_code=200),
+            Endpoint(url=f"{victim_url}/page", status_code=200),
         ]
 
         with patch("requests.get", side_effect=_make_reflecting_fake(make_response)):
@@ -178,9 +186,9 @@ class TestCheckHeaderXss:
         assert len(results) == 1
 
     def test_evidence_includes_header_payload_and_snippet(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/page", status_code=200)
 
         with patch("requests.get", side_effect=_make_reflecting_fake(make_response, "Referer")):
             results = check_header_xss([ep])
@@ -192,9 +200,9 @@ class TestCheckHeaderXss:
         assert "Response snippet" in ev
 
     def test_header_names_restricts_probed_headers(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/page", status_code=200)
         probed: set[str] = set()
 
         def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> MagicMock:
@@ -209,9 +217,9 @@ class TestCheckHeaderXss:
         assert probed == {"Referer", "X-Forwarded-For"}
 
     def test_header_names_none_probes_all_headers(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/page", status_code=200)
         probed: set[str] = set()
 
         def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> MagicMock:
@@ -226,9 +234,9 @@ class TestCheckHeaderXss:
         assert probed == set(XSSHeader)
 
     def test_header_names_single_header_finds_reflection(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/page", status_code=200)
 
         with patch(
             "requests.get",
@@ -239,8 +247,8 @@ class TestCheckHeaderXss:
         assert len(results) == 1
         assert "User-Agent" in results[0].evidence
 
-    def test_header_names_empty_list_makes_no_requests(self) -> None:
-        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+    def test_header_names_empty_list_makes_no_requests(self, victim_url: str) -> None:
+        ep = Endpoint(url=f"{victim_url}/page", status_code=200)
 
         with patch("requests.get") as mock_get:
             results = check_header_xss([ep], header_names=[])
@@ -248,8 +256,10 @@ class TestCheckHeaderXss:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_unique_canary_per_request(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/page", status_code=200)
+    def test_unique_canary_per_request(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/page", status_code=200)
         canaries: list[str] = []
 
         def fake_get(url: str, headers: dict | None = None, **kwargs: object) -> MagicMock:

--- a/tests/test_hpp.py
+++ b/tests/test_hpp.py
@@ -14,10 +14,12 @@ pytestmark = pytest.mark.unit
 
 
 class TestCheckHPP:
-    def test_detects_status_delta(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_detects_status_delta(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         # Baseline returns 200, polluted returns 302 - server picked one of
         # the duplicate values and triggered a redirect.
-        ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["id"])
+        ep = Endpoint(url=f"{victim_url}/", status_code=200, parameters=["id"])
 
         def fake_get(url, **kwargs) -> MagicMock:
             if "id=1&id=2" in url:
@@ -33,10 +35,12 @@ class TestCheckHPP:
         assert "id" in results[0].evidence
         assert "302" in results[0].evidence
 
-    def test_detects_length_delta(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_detects_length_delta(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         # Same status code, but the polluted response body is materially
         # longer because the server combined both values into the output.
-        ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["q"])
+        ep = Endpoint(url=f"{victim_url}/", status_code=200, parameters=["q"])
 
         def fake_get(url, **kwargs) -> MagicMock:
             if "q=1&q=2" in url:
@@ -50,34 +54,36 @@ class TestCheckHPP:
         assert "HPP behaviour confirmed" in results[0].evidence
 
     def test_no_finding_when_responses_identical(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Server collapses duplicates - baseline and polluted look the same.
-        ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["id"])
+        ep = Endpoint(url=f"{victim_url}/", status_code=200, parameters=["id"])
 
         with patch("requests.get", return_value=make_response(status=200, body="ok")):
             results = check_hpp([ep])
 
         assert results == []
 
-    def test_skips_endpoints_without_parameters(self):
-        ep = Endpoint(url="https://app.example.com/about", status_code=200)
+    def test_skips_endpoints_without_parameters(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/about", status_code=200)
         with patch("requests.get") as mock_get:
             results = check_hpp([ep])
         mock_get.assert_not_called()
         assert results == []
 
-    def test_skips_server_error_endpoints(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=503, parameters=["id"])
+    def test_skips_server_error_endpoints(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=503, parameters=["id"])
         with patch("requests.get") as mock_get:
             results = check_hpp([ep])
         mock_get.assert_not_called()
         assert results == []
 
-    def test_one_finding_per_endpoint(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_one_finding_per_endpoint(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         # First param triggers - subsequent params should not be probed.
         ep = Endpoint(
-            url="https://app.example.com/",
+            url=f"{victim_url}/",
             status_code=200,
             parameters=["a", "b", "c"],
         )
@@ -94,8 +100,10 @@ class TestCheckHPP:
         # Only param 'a' probed: baseline + polluted = 2 calls
         assert mock_get.call_count == 2
 
-    def test_baseline_and_polluted_both_sent(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["q"])
+    def test_baseline_and_polluted_both_sent(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/", status_code=200, parameters=["q"])
         urls_seen: list[str] = []
 
         def fake_get(url, **kwargs) -> MagicMock:
@@ -110,11 +118,11 @@ class TestCheckHPP:
         assert len(urls_seen) == 2
 
     def test_continues_to_next_param_when_first_does_not_trigger(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Param 'a' shows no delta; param 'b' does. Tool must keep probing.
         ep = Endpoint(
-            url="https://app.example.com/",
+            url=f"{victim_url}/",
             status_code=200,
             parameters=["a", "b"],
         )
@@ -130,16 +138,16 @@ class TestCheckHPP:
         assert len(results) == 1
         assert "b" in results[0].evidence
 
-    def test_network_exception_is_swallowed(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["id"])
+    def test_network_exception_is_swallowed(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=200, parameters=["id"])
         with patch("requests.get", side_effect=Exception("network error")):
             results = check_hpp([ep])
         assert results == []
 
     def test_evidence_records_both_signatures(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["id"])
+        ep = Endpoint(url=f"{victim_url}/", status_code=200, parameters=["id"])
 
         def fake_get(url, **kwargs) -> MagicMock:
             if "id=1&id=2" in url:

--- a/tests/test_idor.py
+++ b/tests/test_idor.py
@@ -1,0 +1,251 @@
+"""tests/test_idor.py - unit tests for tools/pentest/idor.py"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from models import Endpoint, Severity
+from tools.pentest.idor import _ID_PARAMS, _PII_RE, IDORAttack, check_idor
+
+pytestmark = pytest.mark.unit
+
+
+class TestCheckIDOR:
+    def test_detects_access_control_bypass(self, make_response: Callable[..., MagicMock]) -> None:
+        ep = Endpoint(url="https://app.example.com/api/users/12345", status_code=403)
+
+        with patch("requests.get", return_value=make_response(status=200, body='{"name":"Alice"}')):
+            results = check_idor([ep])
+
+        assert len(results) == 1
+        assert results[0].vuln_class == "IDOR"
+        assert results[0].severity_hint == Severity.HIGH
+        assert "403" in results[0].evidence
+        assert "200" in results[0].evidence
+
+    def test_detects_pii_in_response(self, make_response: Callable[..., MagicMock]) -> None:
+        ep = Endpoint(url="https://app.example.com/api/orders/99", status_code=200)
+        body = '{"id": 100, "email": "alice@example.com", "total": 49.99}'
+
+        with patch("requests.get", return_value=make_response(status=200, body=body)):
+            results = check_idor([ep])
+
+        assert len(results) == 1
+        assert results[0].vuln_class == "IDOR"
+        assert results[0].severity_hint == Severity.HIGH
+        assert "PII" in results[0].evidence
+
+    def test_detects_boundary_id_200_on_param(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
+        ep = Endpoint(
+            url="https://app.example.com/api/docs",
+            status_code=200,
+            parameters=["id"],
+        )
+
+        def respond(url: str, **_: object) -> MagicMock:
+            if "id=0" in url or "id=-1" in url:
+                return make_response(status=200, body='{"doc":"secret"}')
+            return make_response(status=404, body="not found")
+
+        with patch("requests.get", side_effect=respond):
+            results = check_idor([ep])
+
+        assert len(results) == 1
+        assert results[0].severity_hint == Severity.MEDIUM
+        assert "boundary" in results[0].evidence.lower()
+
+    def test_skips_500_endpoints(self) -> None:
+        ep = Endpoint(url="https://app.example.com/api/users/42", status_code=500)
+
+        with patch("requests.get") as mock_get:
+            results = check_idor([ep])
+
+        mock_get.assert_not_called()
+        assert results == []
+
+    def test_skips_non_id_params(self) -> None:
+        ep = Endpoint(
+            url="https://app.example.com/search",
+            status_code=200,
+            parameters=["q", "page"],
+        )
+
+        with patch("requests.get") as mock_get:
+            results = check_idor([ep])
+
+        mock_get.assert_not_called()
+        assert results == []
+
+    def test_skips_endpoint_with_no_numeric_segment_and_no_id_params(self) -> None:
+        ep = Endpoint(url="https://app.example.com/about", status_code=200)
+
+        with patch("requests.get") as mock_get:
+            results = check_idor([ep])
+
+        mock_get.assert_not_called()
+        assert results == []
+
+    def test_probes_numeric_path_segment_variants(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
+        ep = Endpoint(url="https://app.example.com/api/invoices/500", status_code=200)
+
+        seen_urls: list[str] = []
+
+        def record(url: str, **_: object) -> MagicMock:
+            seen_urls.append(url)
+            return make_response(status=404, body="not found")
+
+        with patch("requests.get", side_effect=record):
+            check_idor([ep])
+
+        probed_values = {u.rsplit("/", 1)[-1] for u in seen_urls}
+        assert "499" in probed_values
+        assert "501" in probed_values
+        assert "0" in probed_values
+        assert "500" not in probed_values  # original value not re-probed
+
+    def test_no_finding_for_clean_response(
+        self, make_response: Callable[..., MagicMock], clean_response_body: str
+    ) -> None:
+        ep = Endpoint(
+            url="https://app.example.com/api/items/10",
+            status_code=200,
+            parameters=["id"],
+        )
+
+        mock_resp = make_response(status=404, body=clean_response_body)
+        with patch("requests.get", return_value=mock_resp):
+            results = check_idor([ep])
+
+        assert results == []
+
+    def test_network_exception_is_swallowed(self) -> None:
+        ep = Endpoint(url="https://app.example.com/api/users/1001", status_code=200)
+
+        with patch("requests.get", side_effect=OSError("timeout")):
+            results = check_idor([ep])
+
+        assert results == []
+
+    def test_deduplicates_to_one_finding_per_endpoint(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
+        # Both the path segment (12345) and a query param would trigger, but
+        # the path-segment phase fires first - only one finding expected.
+        ep = Endpoint(
+            url="https://app.example.com/api/users/12345",
+            status_code=403,
+            parameters=["id"],
+        )
+
+        with patch("requests.get", return_value=make_response(status=200, body="data")):
+            results = check_idor([ep])
+
+        assert len(results) == 1
+
+    def test_pii_re_matches_email(self) -> None:
+        assert _PII_RE.search("contact: alice@example.com") is not None
+
+    def test_pii_re_matches_sensitive_json_key(self) -> None:
+        assert _PII_RE.search('"phone": "+1-555-0100"') is not None
+
+    def test_pii_re_matches_card_number_field(self) -> None:
+        assert _PII_RE.search("card_number: 4111111111111111") is not None
+
+    def test_pii_re_no_match_on_clean_body(self, clean_response_body: str) -> None:
+        assert _PII_RE.search(clean_response_body) is None
+
+    def test_id_params_covers_common_identifiers(self) -> None:
+        required = {"id", "user_id", "account_id", "order_id", "doc_id", "file_id"}
+        assert required <= _ID_PARAMS
+
+    def test_attack_filter_boundary_only_sends_two_probes(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
+        ep = Endpoint(
+            url="https://app.example.com/api/docs",
+            status_code=200,
+            parameters=["id"],
+        )
+        seen_urls: list[str] = []
+
+        def record(url: str, **_: object) -> MagicMock:
+            seen_urls.append(url)
+            return make_response(status=404, body="not found")
+
+        with patch("requests.get", side_effect=record):
+            check_idor([ep], attacks=[IDORAttack.boundary])
+
+        # Only "0" and "-1" should be probed.
+        assert len(seen_urls) == 2
+        joined = " ".join(seen_urls)
+        assert "id=0" in joined
+        assert "id=-1" in joined
+
+    def test_attack_filter_type_juggling_only(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
+        ep = Endpoint(
+            url="https://app.example.com/api/docs",
+            status_code=200,
+            parameters=["id"],
+        )
+        seen_urls: list[str] = []
+
+        def record(url: str, **_: object) -> MagicMock:
+            seen_urls.append(url)
+            return make_response(status=404, body="not found")
+
+        with patch("requests.get", side_effect=record):
+            check_idor([ep], attacks=[IDORAttack.type_juggling])
+
+        probed_values = {u.split("id=", 1)[1] for u in seen_urls}
+        assert "1.0" in probed_values
+        assert "1e1" in probed_values
+        # Boundary probes must be absent when only type_juggling is selected.
+        assert "0" not in probed_values
+        assert "-1" not in probed_values
+
+    def test_attack_filter_empty_list_is_noop(self) -> None:
+        ep = Endpoint(
+            url="https://app.example.com/api/users/42",
+            status_code=200,
+            parameters=["id"],
+        )
+        with patch("requests.get") as mock_get:
+            results = check_idor([ep], attacks=[])
+
+        mock_get.assert_not_called()
+        assert results == []
+
+    def test_attack_filter_none_runs_all_strategies(
+        self, make_response: Callable[..., MagicMock]
+    ) -> None:
+        ep = Endpoint(
+            url="https://app.example.com/api/users/500",
+            status_code=200,
+        )
+        seen_urls: list[str] = []
+
+        def record(url: str, **_: object) -> MagicMock:
+            seen_urls.append(url)
+            return make_response(status=404, body="not found")
+
+        with patch("requests.get", side_effect=record):
+            check_idor([ep], attacks=None)
+
+        probed_values = {u.rsplit("/", 1)[-1] for u in seen_urls}
+        # sequential
+        assert "499" in probed_values
+        assert "501" in probed_values
+        # boundary
+        assert "0" in probed_values
+        assert "-1" in probed_values
+        # type juggling
+        assert "500.0" in probed_values

--- a/tests/test_idor.py
+++ b/tests/test_idor.py
@@ -14,8 +14,10 @@ pytestmark = pytest.mark.unit
 
 
 class TestCheckIDOR:
-    def test_detects_access_control_bypass(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/api/users/12345", status_code=403)
+    def test_detects_access_control_bypass(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/api/users/12345", status_code=403)
 
         with patch("requests.get", return_value=make_response(status=200, body='{"name":"Alice"}')):
             results = check_idor([ep])
@@ -26,8 +28,10 @@ class TestCheckIDOR:
         assert "403" in results[0].evidence
         assert "200" in results[0].evidence
 
-    def test_detects_pii_in_response(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/api/orders/99", status_code=200)
+    def test_detects_pii_in_response(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/api/orders/99", status_code=200)
         body = '{"id": 100, "email": "alice@example.com", "total": 49.99}'
 
         with patch("requests.get", return_value=make_response(status=200, body=body)):
@@ -39,13 +43,9 @@ class TestCheckIDOR:
         assert "PII" in results[0].evidence
 
     def test_detects_boundary_id_200_on_param(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(
-            url="https://app.example.com/api/docs",
-            status_code=200,
-            parameters=["id"],
-        )
+        ep = Endpoint(url=f"{victim_url}/api/docs", status_code=200, parameters=["id"])
 
         def respond(url: str, **_: object) -> MagicMock:
             if "id=0" in url or "id=-1" in url:
@@ -59,8 +59,8 @@ class TestCheckIDOR:
         assert results[0].severity_hint == Severity.MEDIUM
         assert "boundary" in results[0].evidence.lower()
 
-    def test_skips_500_endpoints(self) -> None:
-        ep = Endpoint(url="https://app.example.com/api/users/42", status_code=500)
+    def test_skips_500_endpoints(self, victim_url: str) -> None:
+        ep = Endpoint(url=f"{victim_url}/api/users/42", status_code=500)
 
         with patch("requests.get") as mock_get:
             results = check_idor([ep])
@@ -68,9 +68,9 @@ class TestCheckIDOR:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_skips_non_id_params(self) -> None:
+    def test_skips_non_id_params(self, victim_url: str) -> None:
         ep = Endpoint(
-            url="https://app.example.com/search",
+            url=f"{victim_url}/search",
             status_code=200,
             parameters=["q", "page"],
         )
@@ -81,8 +81,8 @@ class TestCheckIDOR:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_skips_endpoint_with_no_numeric_segment_and_no_id_params(self) -> None:
-        ep = Endpoint(url="https://app.example.com/about", status_code=200)
+    def test_skips_endpoint_with_no_numeric_segment_and_no_id_params(self, victim_url: str) -> None:
+        ep = Endpoint(url=f"{victim_url}/about", status_code=200)
 
         with patch("requests.get") as mock_get:
             results = check_idor([ep])
@@ -91,9 +91,9 @@ class TestCheckIDOR:
         assert results == []
 
     def test_probes_numeric_path_segment_variants(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/api/invoices/500", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/api/invoices/500", status_code=200)
 
         seen_urls: list[str] = []
 
@@ -111,10 +111,13 @@ class TestCheckIDOR:
         assert "500" not in probed_values  # original value not re-probed
 
     def test_no_finding_for_clean_response(
-        self, make_response: Callable[..., MagicMock], clean_response_body: str
+        self,
+        make_response: Callable[..., MagicMock],
+        clean_response_body: str,
+        victim_url: str,
     ) -> None:
         ep = Endpoint(
-            url="https://app.example.com/api/items/10",
+            url=f"{victim_url}/api/items/10",
             status_code=200,
             parameters=["id"],
         )
@@ -125,8 +128,8 @@ class TestCheckIDOR:
 
         assert results == []
 
-    def test_network_exception_is_swallowed(self) -> None:
-        ep = Endpoint(url="https://app.example.com/api/users/1001", status_code=200)
+    def test_network_exception_is_swallowed(self, victim_url: str) -> None:
+        ep = Endpoint(url=f"{victim_url}/api/users/1001", status_code=200)
 
         with patch("requests.get", side_effect=OSError("timeout")):
             results = check_idor([ep])
@@ -134,12 +137,12 @@ class TestCheckIDOR:
         assert results == []
 
     def test_deduplicates_to_one_finding_per_endpoint(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Both the path segment (12345) and a query param would trigger, but
         # the path-segment phase fires first - only one finding expected.
         ep = Endpoint(
-            url="https://app.example.com/api/users/12345",
+            url=f"{victim_url}/api/users/12345",
             status_code=403,
             parameters=["id"],
         )
@@ -166,13 +169,9 @@ class TestCheckIDOR:
         assert required <= _ID_PARAMS
 
     def test_attack_filter_boundary_only_sends_two_probes(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(
-            url="https://app.example.com/api/docs",
-            status_code=200,
-            parameters=["id"],
-        )
+        ep = Endpoint(url=f"{victim_url}/api/docs", status_code=200, parameters=["id"])
         seen_urls: list[str] = []
 
         def record(url: str, **_: object) -> MagicMock:
@@ -189,13 +188,9 @@ class TestCheckIDOR:
         assert "id=-1" in joined
 
     def test_attack_filter_type_juggling_only(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(
-            url="https://app.example.com/api/docs",
-            status_code=200,
-            parameters=["id"],
-        )
+        ep = Endpoint(url=f"{victim_url}/api/docs", status_code=200, parameters=["id"])
         seen_urls: list[str] = []
 
         def record(url: str, **_: object) -> MagicMock:
@@ -212,9 +207,9 @@ class TestCheckIDOR:
         assert "0" not in probed_values
         assert "-1" not in probed_values
 
-    def test_attack_filter_empty_list_is_noop(self) -> None:
+    def test_attack_filter_empty_list_is_noop(self, victim_url: str) -> None:
         ep = Endpoint(
-            url="https://app.example.com/api/users/42",
+            url=f"{victim_url}/api/users/42",
             status_code=200,
             parameters=["id"],
         )
@@ -225,12 +220,9 @@ class TestCheckIDOR:
         assert results == []
 
     def test_attack_filter_none_runs_all_strategies(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(
-            url="https://app.example.com/api/users/500",
-            status_code=200,
-        )
+        ep = Endpoint(url=f"{victim_url}/api/users/500", status_code=200)
         seen_urls: list[str] = []
 
         def record(url: str, **_: object) -> MagicMock:

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -31,8 +31,6 @@ from tools.pentest.jwt import (
 
 pytestmark = pytest.mark.unit
 
-_ENDPOINT = "https://victim.example.com/api/profile"
-
 
 def _dict_to_base64url(d: dict) -> str:
     raw = json.dumps(d, separators=(",", ":")).encode()
@@ -91,28 +89,32 @@ class TestHelpers:
 
 
 class TestAlgNone:
-    def test_detects_alg_none_bypass(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_detects_alg_none_bypass(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1", "role": "user"})
         with patch("requests.get", return_value=make_response(status=200, body="{}")):
-            results = check_jwt(token, _ENDPOINT)
+            results = check_jwt(token, f"{victim_url}/api/profile")
         alg_none = [r for r in results if "alg:none" in r.title]
         assert len(alg_none) == 1
         assert alg_none[0].severity_hint == Severity.CRITICAL
 
-    def test_no_finding_when_none_rejected(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_no_finding_when_none_rejected(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1"})
         with patch("requests.get", return_value=make_response(status=401, body="{}")):
-            results = check_jwt(token, _ENDPOINT)
+            results = check_jwt(token, f"{victim_url}/api/profile")
         assert not any("alg:none" in r.title for r in results)
 
     def test_stops_after_first_accepted_variant(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Only one alg:none finding should be reported even though 4 variants exist.
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1"})
 
         with patch("requests.get", return_value=make_response(status=200, body="{}")):
-            results = check_jwt(token, _ENDPOINT)
+            results = check_jwt(token, f"{victim_url}/api/profile")
 
         alg_none = [r for r in results if "alg:none" in r.title]
         assert len(alg_none) == 1
@@ -126,31 +128,35 @@ class TestAlgNone:
 
 
 class TestWeakSecret:
-    def test_detects_weak_secret(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_detects_weak_secret(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         header = {"alg": "HS256", "typ": "JWT"}
         payload = {"sub": "1", "role": "user"}
         token = _make_hmac_signed_token(header, payload, b"secret")
 
         with patch("requests.get", return_value=make_response(status=401, body="{}")):
-            results = check_jwt(token, _ENDPOINT)
+            results = check_jwt(token, f"{victim_url}/api/profile")
 
         weak = [r for r in results if "weak HMAC" in r.title]
         assert len(weak) == 1
         assert weak[0].severity_hint == Severity.CRITICAL
         assert "secret" in weak[0].evidence
 
-    def test_no_finding_on_strong_secret(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_no_finding_on_strong_secret(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         header = {"alg": "HS256", "typ": "JWT"}
         payload = {"sub": "1"}
         token = _make_hmac_signed_token(header, payload, b"v3ryStr0ngS3cr3t!XYZ987")
 
         with patch("requests.get", return_value=make_response(status=401, body="{}")):
-            results = check_jwt(token, _ENDPOINT)
+            results = check_jwt(token, f"{victim_url}/api/profile")
 
         assert not any("weak HMAC" in r.title for r in results)
 
     def test_weak_secret_reported_even_without_2xx_replay(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Cracking the secret offline is proof enough - even if replay returns 403.
         header = {"alg": "HS256", "typ": "JWT"}
@@ -158,7 +164,7 @@ class TestWeakSecret:
         token = _make_hmac_signed_token(header, payload, b"secret")
 
         with patch("requests.get", return_value=make_response(status=403, body="{}")):
-            results = check_jwt(token, _ENDPOINT)
+            results = check_jwt(token, f"{victim_url}/api/profile")
 
         weak = [r for r in results if "weak HMAC" in r.title]
         assert len(weak) == 1
@@ -168,7 +174,9 @@ class TestWeakSecret:
         assert "password" in _WEAK_SECRETS
         assert "" in _WEAK_SECRETS
 
-    def test_non_hs_alg_skips_brute_force(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_non_hs_alg_skips_brute_force(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         token = _make_token({"alg": "RS256", "typ": "JWT"}, {"sub": "1"})
 
         def fake_get(url: str, **kw: Any) -> MagicMock:
@@ -177,13 +185,15 @@ class TestWeakSecret:
             return r
 
         with patch("requests.get", side_effect=fake_get):
-            results = check_jwt(token, _ENDPOINT)
+            results = check_jwt(token, f"{victim_url}/api/profile")
 
         assert not any("weak HMAC" in r.title for r in results)
 
 
 class TestKidInjection:
-    def test_detects_kid_path_traversal(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_detects_kid_path_traversal(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT", "kid": "key-1"}, {"sub": "1"})
 
         def fake_get(url: str, **kw: Any) -> MagicMock:
@@ -196,14 +206,16 @@ class TestKidInjection:
             return make_response(status=401, body="{}")
 
         with patch("requests.get", side_effect=fake_get):
-            results = check_jwt(token, _ENDPOINT)
+            results = check_jwt(token, f"{victim_url}/api/profile")
 
         trav = [r for r in results if "path traversal" in r.title]
         assert len(trav) == 1
         assert trav[0].severity_hint == Severity.CRITICAL
         assert _KID_PATH_TRAVERSAL in trav[0].evidence
 
-    def test_detects_kid_sql_injection(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_detects_kid_sql_injection(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT", "kid": "key-1"}, {"sub": "1"})
 
         def fake_get(url: str, **kw: Any) -> MagicMock:
@@ -215,13 +227,15 @@ class TestKidInjection:
             return make_response(status=401, body="{}")
 
         with patch("requests.get", side_effect=fake_get):
-            results = check_jwt(token, _ENDPOINT)
+            results = check_jwt(token, f"{victim_url}/api/profile")
 
         sqli = [r for r in results if "SQL injection" in r.title]
         assert len(sqli) == 1
         assert sqli[0].severity_hint == Severity.CRITICAL
 
-    def test_detects_kid_nosql_injection(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_detects_kid_nosql_injection(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT", "kid": "key-1"}, {"sub": "1"})
 
         def fake_get(url: str, **kw: Any) -> MagicMock:
@@ -233,7 +247,7 @@ class TestKidInjection:
             return make_response(status=401, body="{}")
 
         with patch("requests.get", side_effect=fake_get):
-            results = check_jwt(token, _ENDPOINT)
+            results = check_jwt(token, f"{victim_url}/api/profile")
 
         nosqli = [r for r in results if "NoSQL" in r.title]
         assert len(nosqli) == 1
@@ -244,17 +258,19 @@ class TestKidInjection:
         assert "$gt" in operators
         assert "$ne" in operators
 
-    def test_kid_attacks_skipped_when_no_kid(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_kid_attacks_skipped_when_no_kid(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1"})
         with patch("requests.get", return_value=make_response(status=401, body="{}")):
-            results = check_jwt(token, _ENDPOINT)
+            results = check_jwt(token, f"{victim_url}/api/profile")
         kid_findings = [r for r in results if "kid" in r.title]
         assert kid_findings == []
 
 
 class TestClaimsTampering:
     def test_detects_missing_signature_verification(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1", "role": "user"})
 
@@ -272,7 +288,7 @@ class TestClaimsTampering:
             return make_response(status=401, body="{}")
 
         with patch("requests.get", side_effect=fake_get):
-            results = check_jwt(token, _ENDPOINT)
+            results = check_jwt(token, f"{victim_url}/api/profile")
 
         tamper = [r for r in results if "signature not verified" in r.title]
         assert len(tamper) == 1
@@ -280,17 +296,19 @@ class TestClaimsTampering:
         assert "Original signature retained" in tamper[0].evidence
 
     def test_no_tamper_finding_when_signature_checked(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1", "role": "user"})
         with patch("requests.get", return_value=make_response(status=401, body="{}")):
-            results = check_jwt(token, _ENDPOINT)
+            results = check_jwt(token, f"{victim_url}/api/profile")
         tamper = [r for r in results if "signature not verified" in r.title]
         assert tamper == []
 
 
 class TestRS256Confusion:
-    def test_detects_rs256_hs256_confusion(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_detects_rs256_hs256_confusion(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         token = _make_token({"alg": "RS256", "typ": "JWT", "kid": "k1"}, {"sub": "1"})
 
         # Minimal self-signed RSA public key as a JWK (tiny key, test only).
@@ -339,34 +357,40 @@ class TestRS256Confusion:
             return make_response(status=401, body="{}")
 
         with patch("requests.get", side_effect=fake_get):
-            results = check_jwt(token, _ENDPOINT)
+            results = check_jwt(token, f"{victim_url}/api/profile")
 
         confusion = [r for r in results if "RS256->HS256" in r.title]
         assert len(confusion) == 1
         assert confusion[0].severity_hint == Severity.CRITICAL
 
-    def test_rs256_skipped_when_no_jwks(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_rs256_skipped_when_no_jwks(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         token = _make_token({"alg": "RS256", "typ": "JWT"}, {"sub": "1"})
         with patch("requests.get", return_value=make_response(status=404, body="{}")):
-            results = check_jwt(token, _ENDPOINT)
+            results = check_jwt(token, f"{victim_url}/api/profile")
         assert not any("RS256->HS256" in r.title for r in results)
 
 
 class TestEdgeCases:
-    def test_invalid_token_returns_empty(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_invalid_token_returns_empty(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         with patch("requests.get", return_value=make_response(status=200, body="{}")):
-            results = check_jwt("not.a.jwt", _ENDPOINT)
+            results = check_jwt("not.a.jwt", f"{victim_url}/api/profile")
         assert results == []
 
-    def test_network_exception_swallowed(self) -> None:
+    def test_network_exception_swallowed(self, victim_url: str) -> None:
         token = _make_token({"alg": "HS256", "typ": "JWT"}, {"sub": "1"})
         with patch("requests.get", side_effect=OSError("connection refused")):
-            results = check_jwt(token, _ENDPOINT)
+            results = check_jwt(token, f"{victim_url}/api/profile")
         assert isinstance(results, list)
 
-    def test_two_part_token_returns_empty(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_two_part_token_returns_empty(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         with patch("requests.get", return_value=make_response(status=200, body="{}")):
-            results = check_jwt("onlytwoparts.here", _ENDPOINT)
+            results = check_jwt("onlytwoparts.here", f"{victim_url}/api/profile")
         assert results == []
 
 
@@ -382,7 +406,7 @@ class TestAttackFilter:
         return _make_token({"alg": "HS256", "kid": "k1", "typ": "JWT"}, {"sub": "1"})
 
     def test_only_alg_none_runs_when_filtered(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # A token with kid set would normally trigger alg-none + kid-traversal
         # + kid-sqli + kid-nosqli + claims-escalation = 5 attack classes.
@@ -398,7 +422,7 @@ class TestAttackFilter:
             return make_response(status=401, body="{}")
 
         with patch("requests.get", side_effect=record):
-            check_jwt(token, _ENDPOINT, attack_names=[JwtAttack.alg_none])
+            check_jwt(token, f"{victim_url}/api/profile", attack_names=[JwtAttack.alg_none])
 
         # Exactly four replays: one per alg:none variant.
         assert len(replayed_tokens) == len(_ALG_NONE_VARIANTS)
@@ -407,7 +431,7 @@ class TestAttackFilter:
             assert replayed.endswith(".")
 
     def test_only_claims_escalation_runs_when_filtered(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         token = self._token_with_kid()
 
@@ -420,7 +444,9 @@ class TestAttackFilter:
             return make_response(status=401, body="{}")
 
         with patch("requests.get", side_effect=record):
-            check_jwt(token, _ENDPOINT, attack_names=[JwtAttack.claims_escalation])
+            check_jwt(
+                token, f"{victim_url}/api/profile", attack_names=[JwtAttack.claims_escalation]
+            )
 
         # Exactly one replay: the claims-tampered token with original sig.
         assert len(seen_tokens) == 1
@@ -429,7 +455,7 @@ class TestAttackFilter:
         assert seen_tokens[0].split(".")[2] == orig_sig
 
     def test_kid_attacks_only_runs_when_filtered(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # The agent wants to focus on kid-* attacks because the token has a
         # kid header. Passing the three kid-* attack names should run them
@@ -447,7 +473,7 @@ class TestAttackFilter:
         with patch("requests.get", side_effect=record):
             check_jwt(
                 token,
-                _ENDPOINT,
+                f"{victim_url}/api/profile",
                 attack_names=[
                     JwtAttack.kid_traversal,
                     JwtAttack.kid_sqli,
@@ -461,17 +487,17 @@ class TestAttackFilter:
         for t in replayed:
             assert not t.endswith(".")
 
-    def test_attack_filter_empty_list_runs_no_attacks(self) -> None:
+    def test_attack_filter_empty_list_runs_no_attacks(self, victim_url: str) -> None:
         token = self._token_with_kid()
 
         with patch("requests.get") as mock_get:
-            results = check_jwt(token, _ENDPOINT, attack_names=[])
+            results = check_jwt(token, f"{victim_url}/api/profile", attack_names=[])
 
         assert results == []
         mock_get.assert_not_called()
 
     def test_attack_filter_none_runs_every_attack(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Sanity check: default attack_names=None must run all seven attack
         # blocks (those whose preconditions hold for this token).
@@ -486,7 +512,7 @@ class TestAttackFilter:
             return make_response(status=401, body="{}")
 
         with patch("requests.get", side_effect=record):
-            check_jwt(token, _ENDPOINT, attack_names=None)
+            check_jwt(token, f"{victim_url}/api/profile", attack_names=None)
 
         # alg-none(4) + weak-secret(0, fakesig won't verify) + kid-trav(1) +
         # kid-sqli(1) + kid-nosqli(2) + claims-escalation(1) = 9 replays.
@@ -494,7 +520,7 @@ class TestAttackFilter:
         assert len(attempted) == 9
 
     def test_filtered_finding_evidence_names_the_attack(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # When alg-none succeeds, evidence must name the attack class so the
         # agent and report know what fired.
@@ -509,7 +535,9 @@ class TestAttackFilter:
             return make_response(status=401, body="{}")
 
         with patch("requests.get", side_effect=accept_unsigned):
-            results = check_jwt(token, _ENDPOINT, attack_names=[JwtAttack.alg_none])
+            results = check_jwt(
+                token, f"{victim_url}/api/profile", attack_names=[JwtAttack.alg_none]
+            )
 
         assert len(results) == 1
         assert "alg:none" in results[0].evidence

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -31,7 +31,7 @@ from tools.pentest.jwt import (
 
 pytestmark = pytest.mark.unit
 
-_ENDPOINT = "https://app.example.com/api/profile"
+_ENDPOINT = "https://victim.example.com/api/profile"
 
 
 def _dict_to_base64url(d: dict) -> str:

--- a/tests/test_ldap_injection.py
+++ b/tests/test_ldap_injection.py
@@ -27,8 +27,10 @@ def _baseline_or_probe(url: str, baseline_resp: MagicMock, probe_resp: MagicMock
 
 
 class TestCheckLDAPInjection:
-    def test_detects_auth_bypass_high(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
+    def test_detects_auth_bypass_high(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200, parameters=["username"])
 
         with patch(
             "requests.get",
@@ -47,9 +49,9 @@ class TestCheckLDAPInjection:
         assert "username" in results[0].evidence
 
     def test_detects_ldap_error_marker_medium(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/search", status_code=200, parameters=["q"])
+        ep = Endpoint(url=f"{victim_url}/search", status_code=200, parameters=["q"])
 
         with patch(
             "requests.get",
@@ -66,9 +68,9 @@ class TestCheckLDAPInjection:
         assert "javax.naming" in results[0].evidence
 
     def test_detects_server_error_on_payload_medium(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/auth", status_code=200, parameters=["user"])
+        ep = Endpoint(url=f"{victim_url}/auth", status_code=200, parameters=["user"])
 
         with patch(
             "requests.get",
@@ -84,8 +86,10 @@ class TestCheckLDAPInjection:
         assert results[0].severity_hint == Severity.MEDIUM
         assert "500" in results[0].evidence
 
-    def test_no_finding_on_clean_response(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
+    def test_no_finding_on_clean_response(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200, parameters=["username"])
 
         with patch(
             "requests.get", return_value=make_response(status=401, body="Invalid credentials")
@@ -94,8 +98,8 @@ class TestCheckLDAPInjection:
 
         assert results == []
 
-    def test_skips_endpoints_without_parameters(self) -> None:
-        ep = Endpoint(url="https://app.example.com/about", status_code=200)
+    def test_skips_endpoints_without_parameters(self, victim_url: str) -> None:
+        ep = Endpoint(url=f"{victim_url}/about", status_code=200)
 
         with patch("requests.get") as mock_get:
             results = check_ldap_injection([ep])
@@ -103,8 +107,8 @@ class TestCheckLDAPInjection:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_skips_server_error_endpoints(self) -> None:
-        ep = Endpoint(url="https://app.example.com/login", status_code=500, parameters=["username"])
+    def test_skips_server_error_endpoints(self, victim_url: str) -> None:
+        ep = Endpoint(url=f"{victim_url}/login", status_code=500, parameters=["username"])
 
         with patch("requests.get") as mock_get:
             results = check_ldap_injection([ep])
@@ -113,10 +117,10 @@ class TestCheckLDAPInjection:
         assert results == []
 
     def test_one_finding_per_endpoint_with_multiple_params(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         ep = Endpoint(
-            url="https://app.example.com/login",
+            url=f"{victim_url}/login",
             status_code=200,
             parameters=["username", "email"],
         )
@@ -133,9 +137,11 @@ class TestCheckLDAPInjection:
 
         assert len(results) == 1
 
-    def test_stops_probing_after_first_match(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_stops_probing_after_first_match(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         ep = Endpoint(
-            url="https://app.example.com/login",
+            url=f"{victim_url}/login",
             status_code=200,
             parameters=["username"],
         )
@@ -153,8 +159,10 @@ class TestCheckLDAPInjection:
         # One baseline + one payload before match - should stop immediately.
         assert mock_get.call_count == 2
 
-    def test_baseline_exception_skips_param(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
+    def test_baseline_exception_skips_param(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200, parameters=["username"])
 
         def raise_on_baseline(url: str, **kw: object) -> MagicMock:
             if _BASELINE_VALUE in url:
@@ -166,8 +174,10 @@ class TestCheckLDAPInjection:
 
         assert results == []
 
-    def test_probe_exception_is_swallowed(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
+    def test_probe_exception_is_swallowed(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200, parameters=["username"])
 
         def raise_on_probe(url: str, **kw: object) -> MagicMock:
             if _BASELINE_VALUE in url:
@@ -180,12 +190,10 @@ class TestCheckLDAPInjection:
         assert results == []
 
     def test_deduplicates_across_multiple_endpoints_same_url(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep1 = Endpoint(
-            url="https://app.example.com/login", status_code=200, parameters=["username"]
-        )
-        ep2 = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["email"])
+        ep1 = Endpoint(url=f"{victim_url}/login", status_code=200, parameters=["username"])
+        ep2 = Endpoint(url=f"{victim_url}/login", status_code=200, parameters=["email"])
 
         with patch(
             "requests.get",
@@ -199,10 +207,12 @@ class TestCheckLDAPInjection:
 
         assert len(results) == 1
 
-    def test_high_takes_priority_over_medium(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_high_takes_priority_over_medium(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         # Response triggers both a status-code bypass AND an error marker -
         # the finding should be HIGH, not MEDIUM.
-        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200, parameters=["username"])
 
         with patch(
             "requests.get",
@@ -231,11 +241,11 @@ class TestCheckLDAPInjection:
         assert "objectClass" in _LDAP_ERROR_MARKERS
 
     def test_payload_filter_restricts_to_named_variants(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Asking only for auth-bypass should send one baseline + one probe
         # per parameter - the other five payloads must not fire.
-        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200, parameters=["username"])
 
         seen_urls: list[str] = []
 
@@ -250,9 +260,9 @@ class TestCheckLDAPInjection:
         assert len(seen_urls) == 2
 
     def test_payload_filter_finding_evidence_names_the_variant(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200, parameters=["username"])
 
         with patch(
             "requests.get",
@@ -268,9 +278,9 @@ class TestCheckLDAPInjection:
         assert "boolean-blind-true" in results[0].evidence
 
     def test_payload_filter_empty_list_is_a_noop(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["username"])
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200, parameters=["username"])
 
         seen_urls: list[str] = []
 

--- a/tests/test_open_redirect.py
+++ b/tests/test_open_redirect.py
@@ -51,18 +51,20 @@ class TestRedirectsToCanary:
     def test_matches_subdomain_of_canary(self):
         assert _redirects_to_canary(f"https://sub.{_PAYLOAD_HOST}/")
 
-    def test_does_not_match_when_canary_is_only_in_path(self):
+    def test_does_not_match_when_canary_is_only_in_path(self, victim_url: str):
         # Server safely placed our payload inside the path of the legitimate
         # host - browser would stay on-origin, so this is NOT a finding.
-        assert not _redirects_to_canary(f"https://app.example.com/{_PAYLOAD_HOST}/")
+        assert not _redirects_to_canary(f"{victim_url}/{_PAYLOAD_HOST}/")
 
-    def test_does_not_match_unrelated_host(self):
-        assert not _redirects_to_canary("https://app.example.com/dashboard")
+    def test_does_not_match_unrelated_host(self, victim_url: str):
+        assert not _redirects_to_canary(f"{victim_url}/dashboard")
 
 
 class TestCheckOpenRedirect:
-    def test_detects_30x_to_canary(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
+    def test_detects_30x_to_canary(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200, parameters=["next"])
 
         def fake_get(url, **kwargs) -> MagicMock:
             payload = url.split("next=", 1)[1]
@@ -77,8 +79,10 @@ class TestCheckOpenRedirect:
         assert "next" in results[0].evidence
         assert _PAYLOAD_HOST in results[0].evidence
 
-    def test_detects_meta_refresh_redirect(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/go", status_code=200, parameters=["dest"])
+    def test_detects_meta_refresh_redirect(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/go", status_code=200, parameters=["dest"])
 
         def fake_get(url, **kwargs) -> MagicMock:
             payload = url.split("dest=", 1)[1]
@@ -94,10 +98,10 @@ class TestCheckOpenRedirect:
         assert "Redirect target" in results[0].evidence
 
     def test_no_finding_when_redirect_stays_on_origin(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Application sanitises by ignoring our payload and redirecting home
-        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200, parameters=["next"])
 
         def fake_get(url, **kwargs) -> MagicMock:
             return make_response(status=302, headers={"Location": "/dashboard"})
@@ -108,9 +112,9 @@ class TestCheckOpenRedirect:
         assert results == []
 
     def test_no_finding_when_no_redirect_at_all(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200, parameters=["next"])
 
         def fake_get(url, **kwargs) -> MagicMock:
             return make_response(status=200, body="<html>login form</html>")
@@ -120,25 +124,25 @@ class TestCheckOpenRedirect:
 
         assert results == []
 
-    def test_skips_endpoints_without_parameters(self):
-        ep = Endpoint(url="https://app.example.com/about", status_code=200)
+    def test_skips_endpoints_without_parameters(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/about", status_code=200)
         with patch("requests.get") as mock_get:
             results = check_open_redirect([ep])
         mock_get.assert_not_called()
         assert results == []
 
-    def test_skips_server_error_endpoints(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=500, parameters=["url"])
+    def test_skips_server_error_endpoints(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=500, parameters=["url"])
         with patch("requests.get") as mock_get:
             results = check_open_redirect([ep])
         mock_get.assert_not_called()
         assert results == []
 
     def test_one_finding_per_endpoint_even_with_multiple_vuln_params(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         ep = Endpoint(
-            url="https://app.example.com/login",
+            url=f"{victim_url}/login",
             status_code=200,
             parameters=["next", "return_to"],
         )
@@ -157,10 +161,10 @@ class TestCheckOpenRedirect:
         assert len(results) == 1
 
     def test_protocol_relative_payload_in_location(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Server normalises a backslash payload to protocol-relative
-        ep = Endpoint(url="https://app.example.com/r", status_code=200, parameters=["u"])
+        ep = Endpoint(url=f"{victim_url}/r", status_code=200, parameters=["u"])
 
         def fake_get(url, **kwargs) -> MagicMock:
             return make_response(status=302, headers={"Location": f"//{_PAYLOAD_HOST}/"})
@@ -170,8 +174,8 @@ class TestCheckOpenRedirect:
 
         assert len(results) == 1
 
-    def test_network_exception_is_swallowed(self):
-        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
+    def test_network_exception_is_swallowed(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200, parameters=["next"])
         with patch("requests.get", side_effect=Exception("network error")):
             results = check_open_redirect([ep])
         assert results == []
@@ -182,11 +186,11 @@ class TestCheckOpenRedirect:
         assert _PAYLOAD_HOST.endswith(".invalid")
 
     def test_payload_filter_restricts_to_named_variants(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Selecting only "https" should fire one request per parameter,
         # not four.
-        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200, parameters=["next"])
 
         seen_urls: list[str] = []
 
@@ -200,9 +204,9 @@ class TestCheckOpenRedirect:
         assert len(seen_urls) == 1
 
     def test_payload_filter_finding_evidence_names_the_variant(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200, parameters=["next"])
 
         with patch(
             "requests.get",
@@ -216,9 +220,9 @@ class TestCheckOpenRedirect:
         assert "https" in results[0].evidence
 
     def test_payload_filter_none_runs_all_variants(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200, parameters=["next"])
 
         seen_urls: list[str] = []
 
@@ -231,8 +235,8 @@ class TestCheckOpenRedirect:
 
         assert len(seen_urls) == len(_PAYLOADS)
 
-    def test_payload_filter_empty_list_is_a_noop(self):
-        ep = Endpoint(url="https://app.example.com/login", status_code=200, parameters=["next"])
+    def test_payload_filter_empty_list_is_a_noop(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/login", status_code=200, parameters=["next"])
 
         with patch("requests.get") as mock_get:
             results = check_open_redirect([ep], payload_names=[])

--- a/tests/test_path_traversal.py
+++ b/tests/test_path_traversal.py
@@ -21,8 +21,10 @@ _WIN_INI_BODY = "; for 16-bit app support\n[fonts]\n[extensions]\n"
 
 
 class TestCheckPathTraversal:
-    def test_detects_linux_passwd_marker(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/download", status_code=200, parameters=["file"])
+    def test_detects_linux_passwd_marker(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/download", status_code=200, parameters=["file"])
 
         with patch("requests.get", return_value=make_response(body=_PASSWD_BODY)):
             results = check_path_traversal([ep])
@@ -33,8 +35,10 @@ class TestCheckPathTraversal:
         assert "file" in results[0].evidence
         assert "root:x:0:0:" in results[0].evidence
 
-    def test_detects_windows_win_ini_marker(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/view", status_code=200, parameters=["page"])
+    def test_detects_windows_win_ini_marker(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/view", status_code=200, parameters=["page"])
 
         def fake_get(url, **kwargs) -> MagicMock:
             # Only respond with win.ini content when the Windows payload is sent
@@ -49,11 +53,11 @@ class TestCheckPathTraversal:
         assert "for 16-bit app support" in results[0].evidence
 
     def test_detects_url_encoded_payload_only(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Server sanitises plain "../" but not "%2f" - the encoded variant
         # must still be tried so this is detected.
-        ep = Endpoint(url="https://app.example.com/dl", status_code=200, parameters=["f"])
+        ep = Endpoint(url=f"{victim_url}/dl", status_code=200, parameters=["f"])
 
         def fake_get(url, **kwargs) -> MagicMock:
             # Plain "../" is stripped by the (fake) server's filter
@@ -69,8 +73,10 @@ class TestCheckPathTraversal:
         assert len(results) == 1
         assert "%2f" in results[0].evidence.lower()
 
-    def test_no_finding_when_marker_absent(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/download", status_code=200, parameters=["file"])
+    def test_no_finding_when_marker_absent(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/download", status_code=200, parameters=["file"])
 
         with patch("requests.get", return_value=make_response(body="<html>Not Found</html>")):
             results = check_path_traversal([ep])
@@ -78,36 +84,36 @@ class TestCheckPathTraversal:
         assert results == []
 
     def test_no_false_positive_when_only_word_root_present(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Body mentions "root" but not the unique "root:x:0:0:" prefix - the
         # marker check must be strict enough to skip this.
-        ep = Endpoint(url="https://app.example.com/download", status_code=200, parameters=["file"])
+        ep = Endpoint(url=f"{victim_url}/download", status_code=200, parameters=["file"])
 
         with patch("requests.get", return_value=make_response(body="Welcome, root admin user!")):
             results = check_path_traversal([ep])
 
         assert results == []
 
-    def test_skips_endpoints_without_parameters(self):
-        ep = Endpoint(url="https://app.example.com/about", status_code=200)
+    def test_skips_endpoints_without_parameters(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/about", status_code=200)
         with patch("requests.get") as mock_get:
             results = check_path_traversal([ep])
         mock_get.assert_not_called()
         assert results == []
 
-    def test_skips_server_error_endpoints(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=500, parameters=["file"])
+    def test_skips_server_error_endpoints(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=500, parameters=["file"])
         with patch("requests.get") as mock_get:
             results = check_path_traversal([ep])
         mock_get.assert_not_called()
         assert results == []
 
     def test_one_finding_per_endpoint_even_with_multiple_vuln_params(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         ep = Endpoint(
-            url="https://app.example.com/dl",
+            url=f"{victim_url}/dl",
             status_code=200,
             parameters=["file", "path"],
         )
@@ -117,11 +123,13 @@ class TestCheckPathTraversal:
 
         assert len(results) == 1
 
-    def test_stops_calling_after_first_match(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_stops_calling_after_first_match(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         # Once we have a finding for an endpoint we should not keep firing
         # additional payloads against later parameters.
         ep = Endpoint(
-            url="https://app.example.com/dl",
+            url=f"{victim_url}/dl",
             status_code=200,
             parameters=["file", "path", "page"],
         )
@@ -132,8 +140,8 @@ class TestCheckPathTraversal:
         # First param matches on the very first probe - only one request expected
         assert mock_get.call_count == 1
 
-    def test_network_exception_is_swallowed(self):
-        ep = Endpoint(url="https://app.example.com/dl", status_code=200, parameters=["file"])
+    def test_network_exception_is_swallowed(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/dl", status_code=200, parameters=["file"])
         with patch("requests.get", side_effect=Exception("network error")):
             results = check_path_traversal([ep])
         assert results == []
@@ -150,11 +158,11 @@ class TestCheckPathTraversal:
         assert "\\" in joined
 
     def test_payload_filter_restricts_to_named_variants(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Asking for just the Linux variants should skip both Windows probes
         # entirely - useful when recon already confirms the target OS.
-        ep = Endpoint(url="https://app.example.com/dl", status_code=200, parameters=["file"])
+        ep = Endpoint(url=f"{victim_url}/dl", status_code=200, parameters=["file"])
 
         seen_urls: list[str] = []
 
@@ -178,9 +186,9 @@ class TestCheckPathTraversal:
         assert "windows" not in joined.lower()
 
     def test_payload_filter_finding_evidence_names_the_variant(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/dl", status_code=200, parameters=["file"])
+        ep = Endpoint(url=f"{victim_url}/dl", status_code=200, parameters=["file"])
 
         with patch("requests.get", return_value=make_response(body=_PASSWD_BODY)):
             results = check_path_traversal(
@@ -191,9 +199,9 @@ class TestCheckPathTraversal:
         assert "unix-null-byte" in results[0].evidence
 
     def test_payload_filter_none_runs_all_variants(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/dl", status_code=200, parameters=["file"])
+        ep = Endpoint(url=f"{victim_url}/dl", status_code=200, parameters=["file"])
 
         seen_urls: list[str] = []
 
@@ -207,8 +215,8 @@ class TestCheckPathTraversal:
         # All six probes fire when no filter is applied.
         assert len(seen_urls) == len(_PROBES)
 
-    def test_payload_filter_empty_list_is_a_noop(self):
-        ep = Endpoint(url="https://app.example.com/dl", status_code=200, parameters=["file"])
+    def test_payload_filter_empty_list_is_a_noop(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/dl", status_code=200, parameters=["file"])
 
         with patch("requests.get") as mock_get:
             results = check_path_traversal([ep], payload_names=[])

--- a/tests/test_prototype_pollution.py
+++ b/tests/test_prototype_pollution.py
@@ -21,9 +21,9 @@ pytestmark = pytest.mark.unit
 
 class TestCheckPrototypePollution:
     def test_detects_canary_in_url_param_get_response(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/api", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/api", status_code=200)
 
         # Baseline GET returns clean body; second GET (URL param probe) reflects canary.
         responses = [
@@ -40,9 +40,9 @@ class TestCheckPrototypePollution:
         assert "URL parameter" in results[0].evidence
 
     def test_detects_canary_in_json_post_response(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/api", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/api", status_code=200)
 
         # All GETs return empty; first POST reflects canary.
         clean_get = make_response(body="")
@@ -66,9 +66,9 @@ class TestCheckPrototypePollution:
         assert "JSON body" in results[0].evidence
 
     def test_no_finding_when_canary_absent_and_no_500(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/api", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/api", status_code=200)
 
         with (
             patch("requests.get", return_value=make_response(body="nothing here")),
@@ -79,9 +79,9 @@ class TestCheckPrototypePollution:
         assert results == []
 
     def test_detects_server_error_after_injection_medium(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/api", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/api", status_code=200)
 
         baseline = make_response(status=200, body="ok")
         error_resp = make_response(status=500, body="Internal Server Error")
@@ -100,9 +100,9 @@ class TestCheckPrototypePollution:
         assert "500" in results[0].evidence
 
     def test_critical_takes_priority_over_medium(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/api", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/api", status_code=200)
 
         baseline = make_response(status=200, body="ok")
 
@@ -120,8 +120,8 @@ class TestCheckPrototypePollution:
         assert len(results) == 1
         assert results[0].severity_hint == Severity.CRITICAL
 
-    def test_skips_5xx_endpoints(self) -> None:
-        ep = Endpoint(url="https://app.example.com/broken", status_code=503)
+    def test_skips_5xx_endpoints(self, victim_url: str) -> None:
+        ep = Endpoint(url=f"{victim_url}/broken", status_code=503)
 
         with patch("requests.get") as mock_get, patch("requests.post") as mock_post:
             results = check_prototype_pollution([ep])
@@ -130,9 +130,11 @@ class TestCheckPrototypePollution:
         mock_post.assert_not_called()
         assert results == []
 
-    def test_deduplicates_same_url(self, make_response: Callable[..., MagicMock]) -> None:
-        ep1 = Endpoint(url="https://app.example.com/api", status_code=200)
-        ep2 = Endpoint(url="https://app.example.com/api", status_code=200)
+    def test_deduplicates_same_url(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep1 = Endpoint(url=f"{victim_url}/api", status_code=200)
+        ep2 = Endpoint(url=f"{victim_url}/api", status_code=200)
 
         responses_get = [
             make_response(body=""),  # baseline for ep1
@@ -148,10 +150,10 @@ class TestCheckPrototypePollution:
         assert len(results) == 1
 
     def test_multiple_distinct_endpoints_each_get_a_finding(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep1 = Endpoint(url="https://app.example.com/api/users", status_code=200)
-        ep2 = Endpoint(url="https://app.example.com/api/posts", status_code=200)
+        ep1 = Endpoint(url=f"{victim_url}/api/users", status_code=200)
+        ep2 = Endpoint(url=f"{victim_url}/api/posts", status_code=200)
 
         with (
             patch("requests.get", return_value=make_response(body=f"{_CANARY}")),
@@ -161,11 +163,11 @@ class TestCheckPrototypePollution:
 
         assert len(results) == 2
         targets = {r.target for r in results}
-        assert "https://app.example.com/api/users" in targets
-        assert "https://app.example.com/api/posts" in targets
+        assert f"{victim_url}/api/users" in targets
+        assert f"{victim_url}/api/posts" in targets
 
-    def test_network_exception_is_swallowed(self) -> None:
-        ep = Endpoint(url="https://app.example.com/api", status_code=200)
+    def test_network_exception_is_swallowed(self, victim_url: str) -> None:
+        ep = Endpoint(url=f"{victim_url}/api", status_code=200)
 
         with (
             patch("requests.get", side_effect=OSError("connection refused")),
@@ -287,10 +289,10 @@ class TestCheckPrototypePollution:
         mock_post.assert_not_called()
 
     def test_endpoint_with_none_status_code_is_probed(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # status_code=None means the endpoint was discovered but not yet probed.
-        ep = Endpoint(url="https://app.example.com/api", status_code=None)
+        ep = Endpoint(url=f"{victim_url}/api", status_code=None)
 
         with (
             patch("requests.get", return_value=make_response(body=f"{_CANARY}")),
@@ -302,10 +304,10 @@ class TestCheckPrototypePollution:
         assert results[0].severity_hint == Severity.CRITICAL
 
     def test_endpoint_with_400_status_is_probed(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Non-5xx error responses should still be probed.
-        ep = Endpoint(url="https://app.example.com/api", status_code=400)
+        ep = Endpoint(url=f"{victim_url}/api", status_code=400)
 
         with (
             patch("requests.get", return_value=make_response(body=f"{_CANARY}")),
@@ -316,10 +318,10 @@ class TestCheckPrototypePollution:
         assert len(results) == 1
 
     def test_medium_not_emitted_when_baseline_already_500(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # If the baseline itself is 500, a 500 on injection is not evidence.
-        ep = Endpoint(url="https://app.example.com/api", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/api", status_code=200)
 
         # Baseline returns 500 too, so server was already broken.
         with (

--- a/tests/test_sourcemaps.py
+++ b/tests/test_sourcemaps.py
@@ -15,7 +15,7 @@ from tools.pentest.sourcemaps import _scan_with_gitleaks, check_js_source_maps
 pytestmark = pytest.mark.unit
 
 
-def _html_with_script(js_url: str = "https://app.example.com/app.js") -> str:
+def _html_with_script(js_url: str = "https://victim.example.com/app.js") -> str:
     return f'<html><head><script src="{js_url}"></script></head></html>'
 
 
@@ -124,8 +124,8 @@ class TestCheckJsSourceMaps:
             patch("subprocess.run", side_effect=fake_run),
         )
 
-    def test_detects_exposed_map_with_internal_paths(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_detects_exposed_map_with_internal_paths(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
 
         map_data = _map_payload(
             sources=["/src/server/auth.ts", "/src/app/config.ts"],
@@ -154,8 +154,8 @@ class TestCheckJsSourceMaps:
         assert results[0].severity_hint == Severity.MEDIUM
         assert "/src/server/auth.ts" in results[0].evidence
 
-    def test_detects_critical_finding_when_gitleaks_finds_secrets(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_detects_critical_finding_when_gitleaks_finds_secrets(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
 
         map_data = _map_payload(
             sources=["/src/app.ts"],
@@ -185,8 +185,8 @@ class TestCheckJsSourceMaps:
         assert results[0].severity_hint == Severity.CRITICAL
         assert "generic-api-key" in results[0].evidence
 
-    def test_detects_aws_access_key_via_gitleaks(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_detects_aws_access_key_via_gitleaks(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
 
         map_data = _map_payload(
             sources=["/src/config.ts"],
@@ -215,15 +215,15 @@ class TestCheckJsSourceMaps:
         assert len(results) == 1
         assert results[0].severity_hint == Severity.CRITICAL
 
-    def test_skips_non_200_endpoints(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=404)
+    def test_skips_non_200_endpoints(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=404)
         with patch("requests.get") as mock_get:
             results = check_js_source_maps([ep])
         mock_get.assert_not_called()
         assert results == []
 
-    def test_skips_non_html_content_type(self):
-        ep = Endpoint(url="https://app.example.com/api/data", status_code=200)
+    def test_skips_non_html_content_type(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/api/data", status_code=200)
 
         mock_resp = MagicMock()
         mock_resp.status_code = 200
@@ -235,8 +235,8 @@ class TestCheckJsSourceMaps:
 
         assert results == []
 
-    def test_ignores_map_returning_non_200(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_ignores_map_returning_non_200(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
 
         def fake_get(url, **kwargs):
             resp = MagicMock()
@@ -257,16 +257,16 @@ class TestCheckJsSourceMaps:
 
         assert results == []
 
-    def test_request_exception_is_swallowed(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_request_exception_is_swallowed(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         with patch("requests.get", side_effect=Exception("network error")):
             results = check_js_source_maps([ep])
         assert results == []
 
-    def test_deduplicates_same_map_url(self):
+    def test_deduplicates_same_map_url(self, victim_url: str):
         endpoints = [
-            Endpoint(url="https://app.example.com/page1", status_code=200),
-            Endpoint(url="https://app.example.com/page2", status_code=200),
+            Endpoint(url=f"{victim_url}/page1", status_code=200),
+            Endpoint(url=f"{victim_url}/page2", status_code=200),
         ]
         map_data = _map_payload(
             sources=["/src/app.ts"],
@@ -296,8 +296,8 @@ class TestCheckJsSourceMaps:
 
         assert map_fetch_count == 1
 
-    def test_skips_map_when_gitleaks_missing_and_no_internal_paths(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_skips_map_when_gitleaks_missing_and_no_internal_paths(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
 
         # sources has only 1 entry and no internal path markers -> would be
         # filtered out anyway; this just confirms nothing crashes without gitleaks

--- a/tests/test_sourcemaps.py
+++ b/tests/test_sourcemaps.py
@@ -15,10 +15,6 @@ from tools.pentest.sourcemaps import _scan_with_gitleaks, check_js_source_maps
 pytestmark = pytest.mark.unit
 
 
-def _html_with_script(js_url: str = "https://victim.example.com/app.js") -> str:
-    return f'<html><head><script src="{js_url}"></script></head></html>'
-
-
 def _map_payload(sources: list[str], sources_content: list[str]) -> dict:
     return {
         "version": 3,
@@ -124,7 +120,7 @@ class TestCheckJsSourceMaps:
             patch("subprocess.run", side_effect=fake_run),
         )
 
-    def test_detects_exposed_map_with_internal_paths(self, victim_url: str):
+    def test_detects_exposed_map_with_internal_paths(self, victim_url: str, make_html_page):
         ep = Endpoint(url=f"{victim_url}/", status_code=200)
 
         map_data = _map_payload(
@@ -142,7 +138,7 @@ class TestCheckJsSourceMaps:
             elif url.endswith(".js"):
                 resp.text = "console.log('app')"
             else:
-                resp.text = _html_with_script()
+                resp.text = make_html_page()
             return resp
 
         which_patch, run_patch = self._patch_gitleaks_no_findings()
@@ -154,7 +150,9 @@ class TestCheckJsSourceMaps:
         assert results[0].severity_hint == Severity.MEDIUM
         assert "/src/server/auth.ts" in results[0].evidence
 
-    def test_detects_critical_finding_when_gitleaks_finds_secrets(self, victim_url: str):
+    def test_detects_critical_finding_when_gitleaks_finds_secrets(
+        self, victim_url: str, make_html_page
+    ):
         ep = Endpoint(url=f"{victim_url}/", status_code=200)
 
         map_data = _map_payload(
@@ -172,7 +170,7 @@ class TestCheckJsSourceMaps:
             elif url.endswith(".js"):
                 resp.text = "//# sourceMappingURL=app.js.map"
             else:
-                resp.text = _html_with_script()
+                resp.text = make_html_page()
             return resp
 
         which_patch, run_patch = self._patch_gitleaks_with_findings(
@@ -185,7 +183,7 @@ class TestCheckJsSourceMaps:
         assert results[0].severity_hint == Severity.CRITICAL
         assert "generic-api-key" in results[0].evidence
 
-    def test_detects_aws_access_key_via_gitleaks(self, victim_url: str):
+    def test_detects_aws_access_key_via_gitleaks(self, victim_url: str, make_html_page):
         ep = Endpoint(url=f"{victim_url}/", status_code=200)
 
         map_data = _map_payload(
@@ -203,7 +201,7 @@ class TestCheckJsSourceMaps:
             elif url.endswith(".js"):
                 resp.text = ""
             else:
-                resp.text = _html_with_script()
+                resp.text = make_html_page()
             return resp
 
         which_patch, run_patch = self._patch_gitleaks_with_findings(
@@ -235,7 +233,7 @@ class TestCheckJsSourceMaps:
 
         assert results == []
 
-    def test_ignores_map_returning_non_200(self, victim_url: str):
+    def test_ignores_map_returning_non_200(self, victim_url: str, make_html_page):
         ep = Endpoint(url=f"{victim_url}/", status_code=200)
 
         def fake_get(url, **kwargs):
@@ -249,7 +247,7 @@ class TestCheckJsSourceMaps:
             else:
                 resp.status_code = 200
                 resp.headers = {"Content-Type": "text/html"}
-                resp.text = _html_with_script()
+                resp.text = make_html_page()
             return resp
 
         with patch("requests.get", side_effect=fake_get):
@@ -263,7 +261,7 @@ class TestCheckJsSourceMaps:
             results = check_js_source_maps([ep])
         assert results == []
 
-    def test_deduplicates_same_map_url(self, victim_url: str):
+    def test_deduplicates_same_map_url(self, victim_url: str, make_html_page):
         endpoints = [
             Endpoint(url=f"{victim_url}/page1", status_code=200),
             Endpoint(url=f"{victim_url}/page2", status_code=200),
@@ -287,7 +285,7 @@ class TestCheckJsSourceMaps:
             elif url.endswith(".js"):
                 resp.text = ""
             else:
-                resp.text = _html_with_script()
+                resp.text = make_html_page()
             return resp
 
         which_patch, run_patch = self._patch_gitleaks_no_findings()
@@ -296,7 +294,9 @@ class TestCheckJsSourceMaps:
 
         assert map_fetch_count == 1
 
-    def test_skips_map_when_gitleaks_missing_and_no_internal_paths(self, victim_url: str):
+    def test_skips_map_when_gitleaks_missing_and_no_internal_paths(
+        self, victim_url: str, make_html_page
+    ):
         ep = Endpoint(url=f"{victim_url}/", status_code=200)
 
         # sources has only 1 entry and no internal path markers -> would be
@@ -316,7 +316,7 @@ class TestCheckJsSourceMaps:
             elif url.endswith(".js"):
                 resp.text = ""
             else:
-                resp.text = _html_with_script()
+                resp.text = make_html_page()
             return resp
 
         with patch("requests.get", side_effect=fake_get):

--- a/tests/test_sri.py
+++ b/tests/test_sri.py
@@ -15,9 +15,9 @@ pytestmark = pytest.mark.unit
 
 class TestCheckSri:
     def test_flags_cross_origin_script_without_integrity(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         html = '<script src="https://cdn.example.net/lib.js"></script>'
 
         with patch(
@@ -32,9 +32,9 @@ class TestCheckSri:
         assert "cdn.example.net" in results[0].evidence
 
     def test_no_finding_when_integrity_present(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         html = (
             '<script src="https://cdn.example.net/lib.js" '
             'integrity="sha384-abc123" crossorigin="anonymous"></script>'
@@ -49,9 +49,9 @@ class TestCheckSri:
         assert results == []
 
     def test_no_finding_for_same_origin_script(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         html = '<script src="/static/app.js"></script>'
 
         with patch(
@@ -63,9 +63,9 @@ class TestCheckSri:
         assert results == []
 
     def test_flags_cross_origin_stylesheet_without_integrity(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         html = '<link rel="stylesheet" href="https://fonts.example.net/style.css">'
 
         with patch(
@@ -78,9 +78,9 @@ class TestCheckSri:
         assert "fonts.example.net" in results[0].evidence
 
     def test_no_finding_for_non_stylesheet_link(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         html = '<link rel="icon" href="https://cdn.example.net/favicon.ico">'
 
         with patch(
@@ -91,15 +91,17 @@ class TestCheckSri:
 
         assert results == []
 
-    def test_skips_non_200_endpoints(self) -> None:
-        ep = Endpoint(url="https://app.example.com/", status_code=404)
+    def test_skips_non_200_endpoints(self, victim_url: str) -> None:
+        ep = Endpoint(url=f"{victim_url}/", status_code=404)
         with patch("requests.get") as mock_get:
             results = check_sri([ep])
         mock_get.assert_not_called()
         assert results == []
 
-    def test_skips_non_html_content_type(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/api", status_code=200)
+    def test_skips_non_html_content_type(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/api", status_code=200)
 
         with patch(
             "requests.get",
@@ -109,16 +111,16 @@ class TestCheckSri:
 
         assert results == []
 
-    def test_network_exception_is_swallowed(self) -> None:
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_network_exception_is_swallowed(self, victim_url: str) -> None:
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         with patch("requests.get", side_effect=Exception("timeout")):
             results = check_sri([ep])
         assert results == []
 
     def test_multiple_missing_resources_in_one_finding(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         html = (
             '<script src="https://cdn1.example.net/a.js"></script>'
             '<script src="https://cdn2.example.net/b.js"></script>'
@@ -134,10 +136,12 @@ class TestCheckSri:
         assert "cdn1.example.net" in results[0].evidence
         assert "cdn2.example.net" in results[0].evidence
 
-    def test_deduplicates_same_endpoint(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_deduplicates_same_endpoint(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         endpoints = [
-            Endpoint(url="https://app.example.com/page1", status_code=200),
-            Endpoint(url="https://app.example.com/page1", status_code=200),
+            Endpoint(url=f"{victim_url}/page1", status_code=200),
+            Endpoint(url=f"{victim_url}/page1", status_code=200),
         ]
         html = '<script src="https://cdn.example.net/lib.js"></script>'
 

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -14,8 +14,10 @@ pytestmark = pytest.mark.unit
 
 
 class TestCheckSSRF:
-    def test_detects_aws_imds_response(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/fetch", status_code=200, parameters=["url"])
+    def test_detects_aws_imds_response(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/fetch", status_code=200, parameters=["url"])
 
         body = "ami-id\nami-launch-index\nhostname\n"
         with patch("requests.get", return_value=make_response(body=body)):
@@ -27,17 +29,17 @@ class TestCheckSSRF:
         assert "url" in results[0].evidence
 
     def test_no_finding_when_no_marker_in_response(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/fetch", status_code=200, parameters=["url"])
+        ep = Endpoint(url=f"{victim_url}/fetch", status_code=200, parameters=["url"])
 
         with patch("requests.get", return_value=make_response(body="<html>nothing here</html>")):
             results = check_ssrf([ep])
 
         assert results == []
 
-    def test_skips_endpoints_without_parameters(self) -> None:
-        ep = Endpoint(url="https://app.example.com/about", status_code=200)
+    def test_skips_endpoints_without_parameters(self, victim_url: str) -> None:
+        ep = Endpoint(url=f"{victim_url}/about", status_code=200)
 
         with patch("requests.get") as mock_get:
             results = check_ssrf([ep])
@@ -45,8 +47,8 @@ class TestCheckSSRF:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_network_exception_is_swallowed(self) -> None:
-        ep = Endpoint(url="https://app.example.com/fetch", status_code=200, parameters=["url"])
+    def test_network_exception_is_swallowed(self, victim_url: str) -> None:
+        ep = Endpoint(url=f"{victim_url}/fetch", status_code=200, parameters=["url"])
 
         with patch("requests.get", side_effect=OSError("connection refused")):
             results = check_ssrf([ep])
@@ -63,11 +65,11 @@ class TestCheckSSRF:
         assert "[::1]" in joined
 
     def test_payload_filter_restricts_to_named_variants(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # An agent on a known AWS target should be able to fire only the
         # AWS IMDS payload and skip the two loopback probes.
-        ep = Endpoint(url="https://app.example.com/fetch", status_code=200, parameters=["url"])
+        ep = Endpoint(url=f"{victim_url}/fetch", status_code=200, parameters=["url"])
 
         seen_urls: list[str] = []
 
@@ -86,9 +88,9 @@ class TestCheckSSRF:
         assert "%5B%3A%3A1%5D" not in joined  # urlencoded [::1]
 
     def test_payload_filter_finding_evidence_names_the_variant(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/fetch", status_code=200, parameters=["url"])
+        ep = Endpoint(url=f"{victim_url}/fetch", status_code=200, parameters=["url"])
 
         with patch("requests.get", return_value=make_response(body="ami-id")):
             results = check_ssrf([ep], payload_names=[SsrfPayload.aws_imds])
@@ -97,9 +99,9 @@ class TestCheckSSRF:
         assert "aws-imds" in results[0].evidence
 
     def test_payload_filter_none_runs_all_variants(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/fetch", status_code=200, parameters=["url"])
+        ep = Endpoint(url=f"{victim_url}/fetch", status_code=200, parameters=["url"])
 
         seen_urls: list[str] = []
 
@@ -112,8 +114,8 @@ class TestCheckSSRF:
 
         assert len(seen_urls) == len(_SSRF_PAYLOADS)
 
-    def test_payload_filter_empty_list_is_a_noop(self) -> None:
-        ep = Endpoint(url="https://app.example.com/fetch", status_code=200, parameters=["url"])
+    def test_payload_filter_empty_list_is_a_noop(self, victim_url: str) -> None:
+        ep = Endpoint(url=f"{victim_url}/fetch", status_code=200, parameters=["url"])
 
         with patch("requests.get") as mock_get:
             results = check_ssrf([ep], payload_names=[])

--- a/tests/test_ssti.py
+++ b/tests/test_ssti.py
@@ -14,8 +14,10 @@ pytestmark = pytest.mark.unit
 
 
 class TestCheckSSTI:
-    def test_detects_jinja_style_evaluation(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
+    def test_detects_jinja_style_evaluation(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/preview", status_code=200, parameters=["name"])
 
         def echo(url: str) -> MagicMock:
             payload = url.split("=", 1)[1] if "=" in url else ""
@@ -38,8 +40,10 @@ class TestCheckSSTI:
         assert _EXPECTED in results[0].evidence
         assert "Jinja2" in results[0].evidence
 
-    def test_detects_dollar_brace_engine(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/render", status_code=200, parameters=["tpl"])
+    def test_detects_dollar_brace_engine(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/render", status_code=200, parameters=["tpl"])
 
         def echo(url: str) -> MagicMock:
             payload = url.split("=", 1)[1] if "=" in url else ""
@@ -57,11 +61,13 @@ class TestCheckSSTI:
         assert len(results) == 1
         assert "Mako" in results[0].evidence or "FreeMarker" in results[0].evidence
 
-    def test_detects_liquid_plus_filter(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_detects_liquid_plus_filter(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         # Liquid has no infix arithmetic - it can only do `{{ x | plus: y }}`.
         # The probe must fire on that signature specifically (not the Jinja2/
         # Twig {{x+y}} form which Liquid would render literally).
-        ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
+        ep = Endpoint(url=f"{victim_url}/preview", status_code=200, parameters=["name"])
 
         def echo(url: str) -> MagicMock:
             payload = url.split("=", 1)[1] if "=" in url else ""
@@ -79,11 +85,13 @@ class TestCheckSSTI:
         assert "Liquid" in results[0].evidence
         assert _EXPECTED in results[0].evidence
 
-    def test_detects_django_add_filter(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_detects_django_add_filter(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         # Django does not evaluate raw arithmetic in {{ }} but it does
         # evaluate its built-in filter chain - the |add: filter does integer
         # addition. Only fire when the Django payload signature shows up.
-        ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
+        ep = Endpoint(url=f"{victim_url}/preview", status_code=200, parameters=["name"])
 
         def echo(url: str) -> MagicMock:
             payload = url.split("=", 1)[1] if "=" in url else ""
@@ -102,12 +110,12 @@ class TestCheckSSTI:
         assert _EXPECTED in results[0].evidence
 
     def test_no_finding_when_input_is_echoed_literally(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Page reflects the raw payload (input echo) but does not evaluate it.
         # The literal-absence guard must suppress detection even when the
         # expected sum happens to appear somewhere unrelated on the page.
-        ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
+        ep = Endpoint(url=f"{victim_url}/preview", status_code=200, parameters=["name"])
 
         def fake_get(url, **kwargs) -> MagicMock:
             payload = url.split("name=", 1)[1]
@@ -118,8 +126,10 @@ class TestCheckSSTI:
 
         assert results == []
 
-    def test_no_finding_when_expected_absent(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
+    def test_no_finding_when_expected_absent(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/preview", status_code=200, parameters=["name"])
 
         def fake_get(url, **kwargs) -> MagicMock:
             return make_response(body="<html>Hello world</html>")
@@ -129,23 +139,25 @@ class TestCheckSSTI:
 
         assert results == []
 
-    def test_skips_endpoints_without_parameters(self):
-        ep = Endpoint(url="https://app.example.com/about", status_code=200)
+    def test_skips_endpoints_without_parameters(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/about", status_code=200)
         with patch("requests.get") as mock_get:
             results = check_ssti([ep])
         mock_get.assert_not_called()
         assert results == []
 
-    def test_skips_server_error_endpoints(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=500, parameters=["q"])
+    def test_skips_server_error_endpoints(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=500, parameters=["q"])
         with patch("requests.get") as mock_get:
             results = check_ssti([ep])
         mock_get.assert_not_called()
         assert results == []
 
-    def test_one_finding_per_endpoint(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_one_finding_per_endpoint(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         ep = Endpoint(
-            url="https://app.example.com/preview",
+            url=f"{victim_url}/preview",
             status_code=200,
             parameters=["name", "title"],
         )
@@ -160,8 +172,8 @@ class TestCheckSSTI:
         # First param, first payload should trigger - only one request fired
         assert mock_get.call_count == 1
 
-    def test_network_exception_is_swallowed(self):
-        ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
+    def test_network_exception_is_swallowed(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/preview", status_code=200, parameters=["name"])
         with patch("requests.get", side_effect=Exception("network error")):
             results = check_ssti([ep])
         assert results == []
@@ -195,11 +207,11 @@ class TestCheckSSTI:
         assert any("|add:" in p for p in payloads)
 
     def test_payload_filter_restricts_to_named_engines(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # When the agent knows the stack is Jinja2 it should only fire that
         # one probe - five other engine probes must be skipped.
-        ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
+        ep = Endpoint(url=f"{victim_url}/preview", status_code=200, parameters=["name"])
 
         seen_urls: list[str] = []
 
@@ -216,11 +228,11 @@ class TestCheckSSTI:
         assert "%7B%7B" in joined or "{{" in joined
 
     def test_payload_filter_finding_uses_engine_label_in_evidence(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # The agent picked "django" by name; the finding evidence must still
         # carry the verbose engine label so reports name what was probed.
-        ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
+        ep = Endpoint(url=f"{victim_url}/preview", status_code=200, parameters=["name"])
 
         def echo(url: str) -> MagicMock:
             payload = url.split("=", 1)[1] if "=" in url else ""
@@ -237,8 +249,8 @@ class TestCheckSSTI:
         assert len(results) == 1
         assert "Django" in results[0].evidence
 
-    def test_payload_filter_empty_list_is_a_noop(self):
-        ep = Endpoint(url="https://app.example.com/preview", status_code=200, parameters=["name"])
+    def test_payload_filter_empty_list_is_a_noop(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/preview", status_code=200, parameters=["name"])
 
         with patch("requests.get") as mock_get:
             results = check_ssti([ep], payload_names=[])

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -47,8 +47,8 @@ class TestCheckTls:
     def _testssl_item(self, test_id: str, severity: str, finding: str, cve: str = "") -> dict:
         return {"id": test_id, "severity": severity, "finding": finding, "cve": cve}
 
-    def test_returns_empty_when_testssl_missing(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_returns_empty_when_testssl_missing(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         with patch("shutil.which", return_value=None):
             results = check_tls([ep])
         assert results == []
@@ -59,8 +59,8 @@ class TestCheckTls:
             results = check_tls([ep])
         assert results == []
 
-    def test_parses_testssl_findings(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_parses_testssl_findings(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         report = [
             self._testssl_item("heartbleed", "CRITICAL", "VULNERABLE", "CVE-2014-0160"),
             self._testssl_item("SSLv2", "HIGH", "offered (deprecated)"),
@@ -86,8 +86,8 @@ class TestCheckTls:
         assert crit.severity_hint == Severity.CRITICAL
         assert "CVE-2014-0160" in crit.evidence
 
-    def test_skips_ok_and_info_severity(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_skips_ok_and_info_severity(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         report = [
             self._testssl_item("TLS1_3", "OK", "offered"),
             self._testssl_item("cert_chain_of_trust", "INFO", "chain ok"),
@@ -105,10 +105,10 @@ class TestCheckTls:
 
         assert results == []
 
-    def test_deduplicates_same_host(self):
+    def test_deduplicates_same_host(self, victim_url: str):
         endpoints = [
-            Endpoint(url="https://app.example.com/page1", status_code=200),
-            Endpoint(url="https://app.example.com/page2", status_code=200),
+            Endpoint(url=f"{victim_url}/page1", status_code=200),
+            Endpoint(url=f"{victim_url}/page2", status_code=200),
         ]
         call_count = 0
 
@@ -126,23 +126,23 @@ class TestCheckTls:
 
         assert call_count == 1
 
-    def test_skips_non_200_endpoints(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=500)
+    def test_skips_non_200_endpoints(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=500)
         with patch("shutil.which", return_value="/usr/bin/testssl.sh"):
             with patch("tools.recon.tls._run") as mock_run:
                 results = check_tls([ep])
         mock_run.assert_not_called()
         assert results == []
 
-    def test_handles_run_exception(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_handles_run_exception(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
         with patch("shutil.which", return_value="/usr/bin/testssl.sh"):
             with patch("tools.recon.tls._run", side_effect=Exception("timeout")):
                 results = check_tls([ep])
         assert results == []
 
-    def test_handles_missing_output_file(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_handles_missing_output_file(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=200)
 
         def fake_run(cmd, timeout: int = 120, input: str | None = None) -> CompletedProcess:
             # Do not write the JSON file

--- a/tests/test_webapp_headers.py
+++ b/tests/test_webapp_headers.py
@@ -18,8 +18,8 @@ pytestmark = pytest.mark.unit
 
 # check_host_headers - reflection
 class TestCheckHostHeadersReflection:
-    def test_detects_canary_host_in_response_body(self):
-        endpoint = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_detects_canary_host_in_response_body(self, victim_url: str):
+        endpoint = Endpoint(url=f"{victim_url}/", status_code=200)
         mock_resp = MagicMock()
         mock_resp.text = "href=https://bountysquad-canary.invalid/reset"
         mock_resp.headers = {}
@@ -31,8 +31,8 @@ class TestCheckHostHeadersReflection:
         assert len(host_findings) >= 1
         assert host_findings[0].severity_hint == Severity.MEDIUM
 
-    def test_detects_canary_host_in_location_header(self):
-        endpoint = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_detects_canary_host_in_location_header(self, victim_url: str):
+        endpoint = Endpoint(url=f"{victim_url}/", status_code=200)
         mock_resp = MagicMock()
         mock_resp.text = "redirecting..."
         mock_resp.headers = {"Location": "https://bountysquad-canary.invalid/login"}
@@ -43,8 +43,8 @@ class TestCheckHostHeadersReflection:
         host_findings = [r for r in results if r.vuln_class == "HostHeaderInjection"]
         assert len(host_findings) >= 1
 
-    def test_clean_response_produces_no_reflection_finding(self):
-        endpoint = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_clean_response_produces_no_reflection_finding(self, victim_url: str):
+        endpoint = Endpoint(url=f"{victim_url}/", status_code=200)
         mock_resp = MagicMock()
         mock_resp.text = "<html>Normal page</html>"
         mock_resp.headers = {"Content-Type": "text/html"}
@@ -55,16 +55,16 @@ class TestCheckHostHeadersReflection:
         reflection = [r for r in results if r.vuln_class == "HostHeaderInjection"]
         assert reflection == []
 
-    def test_request_exception_is_swallowed(self):
-        endpoint = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_request_exception_is_swallowed(self, victim_url: str):
+        endpoint = Endpoint(url=f"{victim_url}/", status_code=200)
         with patch("requests.get", side_effect=Exception("timeout")):
             results = check_host_headers([endpoint])
         assert results == []
 
-    def test_deduplicates_by_origin(self):
+    def test_deduplicates_by_origin(self, victim_url: str):
         endpoints = [
-            Endpoint(url="https://app.example.com/page1", status_code=200),
-            Endpoint(url="https://app.example.com/page2", status_code=200),
+            Endpoint(url=f"{victim_url}/page1", status_code=200),
+            Endpoint(url=f"{victim_url}/page2", status_code=200),
         ]
         mock_resp = MagicMock()
         mock_resp.text = "bountysquad-canary.invalid in body"
@@ -86,8 +86,8 @@ class TestCheckHostHeadersReflection:
 
 # check_host_headers - URL override bypass
 class TestCheckHostHeadersPathOverride:
-    def test_detects_bypass_when_direct_is_403_and_override_is_200(self):
-        endpoint = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_detects_bypass_when_direct_is_403_and_override_is_200(self, victim_url: str):
+        endpoint = Endpoint(url=f"{victim_url}/", status_code=200)
 
         def mock_get(url, **kwargs):
             resp = MagicMock()
@@ -110,8 +110,8 @@ class TestCheckHostHeadersPathOverride:
         assert len(bypass) >= 1
         assert bypass[0].severity_hint == Severity.HIGH
 
-    def test_no_bypass_when_direct_returns_200(self):
-        endpoint = Endpoint(url="https://app.example.com/", status_code=200)
+    def test_no_bypass_when_direct_returns_200(self, victim_url: str):
+        endpoint = Endpoint(url=f"{victim_url}/", status_code=200)
 
         mock_resp = MagicMock()
         mock_resp.status_code = 200

--- a/tests/test_xss.py
+++ b/tests/test_xss.py
@@ -13,8 +13,8 @@ pytestmark = pytest.mark.unit
 
 
 class TestCheckReflectedXss:
-    def test_detects_unescaped_reflection(self):
-        ep = Endpoint(url="https://app.example.com/search", status_code=200, parameters=["q"])
+    def test_detects_unescaped_reflection(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/search", status_code=200, parameters=["q"])
 
         def fake_get(url, **kwargs):
             canary = url.split("q=")[1]
@@ -30,8 +30,8 @@ class TestCheckReflectedXss:
         assert results[0].severity_hint == Severity.HIGH
         assert "q" in results[0].evidence
 
-    def test_no_finding_when_canary_is_html_encoded(self):
-        ep = Endpoint(url="https://app.example.com/search", status_code=200, parameters=["q"])
+    def test_no_finding_when_canary_is_html_encoded(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/search", status_code=200, parameters=["q"])
 
         def fake_get(url, **kwargs):
             resp = MagicMock()
@@ -44,8 +44,8 @@ class TestCheckReflectedXss:
 
         assert results == []
 
-    def test_no_finding_when_canary_absent_from_response(self):
-        ep = Endpoint(url="https://app.example.com/search", status_code=200, parameters=["q"])
+    def test_no_finding_when_canary_absent_from_response(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/search", status_code=200, parameters=["q"])
 
         def fake_get(url, **kwargs):
             resp = MagicMock()
@@ -57,23 +57,23 @@ class TestCheckReflectedXss:
 
         assert results == []
 
-    def test_skips_endpoints_without_parameters(self):
-        ep = Endpoint(url="https://app.example.com/about", status_code=200)
+    def test_skips_endpoints_without_parameters(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/about", status_code=200)
         with patch("requests.get") as mock_get:
             results = check_reflected_xss([ep])
         mock_get.assert_not_called()
         assert results == []
 
-    def test_skips_server_error_endpoints(self):
-        ep = Endpoint(url="https://app.example.com/", status_code=500, parameters=["id"])
+    def test_skips_server_error_endpoints(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/", status_code=500, parameters=["id"])
         with patch("requests.get") as mock_get:
             results = check_reflected_xss([ep])
         mock_get.assert_not_called()
         assert results == []
 
-    def test_deduplicates_multiple_reflecting_params(self):
+    def test_deduplicates_multiple_reflecting_params(self, victim_url: str):
         ep = Endpoint(
-            url="https://app.example.com/search",
+            url=f"{victim_url}/search",
             status_code=200,
             parameters=["q", "category"],
         )
@@ -96,15 +96,15 @@ class TestCheckReflectedXss:
         # Only one finding per endpoint despite two reflecting params
         assert len(results) == 1
 
-    def test_network_exception_is_swallowed(self):
-        ep = Endpoint(url="https://app.example.com/search", status_code=200, parameters=["q"])
+    def test_network_exception_is_swallowed(self, victim_url: str):
+        ep = Endpoint(url=f"{victim_url}/search", status_code=200, parameters=["q"])
         with patch("requests.get", side_effect=Exception("network error")):
             results = check_reflected_xss([ep])
         assert results == []
 
-    def test_canary_includes_angle_brackets(self):
+    def test_canary_includes_angle_brackets(self, victim_url: str):
         """The canary must be a real tag to test for XSS, not just text."""
-        ep = Endpoint(url="https://app.example.com/", status_code=200, parameters=["x"])
+        ep = Endpoint(url=f"{victim_url}/", status_code=200, parameters=["x"])
 
         seen_urls: list[str] = []
 

--- a/tests/test_xxe.py
+++ b/tests/test_xxe.py
@@ -23,9 +23,9 @@ pytestmark = pytest.mark.unit
 
 class TestCheckXXE:
     def test_detects_linux_file_read_critical(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/soap", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/soap", status_code=200)
 
         with patch("requests.post", return_value=make_response(body=f"data: {_LINUX_MARKER} more")):
             results = check_xxe([ep])
@@ -36,9 +36,9 @@ class TestCheckXXE:
         assert _LINUX_MARKER in results[0].evidence
 
     def test_detects_windows_file_read_critical(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/xml", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/xml", status_code=200)
 
         def fake_post(url: str, **kw: object) -> MagicMock:
             body = kw.get("data", "")
@@ -53,8 +53,10 @@ class TestCheckXXE:
         assert results[0].severity_hint == Severity.CRITICAL
         assert _WIN_MARKER in results[0].evidence
 
-    def test_detects_xml_parser_error_medium(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/api", status_code=200)
+    def test_detects_xml_parser_error_medium(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/api", status_code=200)
 
         def fake_post(url: str, **kw: object) -> MagicMock:
             body = str(kw.get("data", ""))
@@ -71,11 +73,11 @@ class TestCheckXXE:
         assert "SAXParseException" in results[0].evidence
 
     def test_file_read_takes_priority_over_error(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Both file marker and XML error present - CRITICAL should win because
         # file-read probes are tried first and stop before error probes run.
-        ep = Endpoint(url="https://app.example.com/soap", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/soap", status_code=200)
         body = f"{_LINUX_MARKER}\nSAXParseException: something"
 
         with patch("requests.post", return_value=make_response(body=body)):
@@ -84,16 +86,18 @@ class TestCheckXXE:
         assert len(results) == 1
         assert results[0].severity_hint == Severity.CRITICAL
 
-    def test_no_finding_on_clean_response(self, make_response: Callable[..., MagicMock]) -> None:
-        ep = Endpoint(url="https://app.example.com/api", status_code=200)
+    def test_no_finding_on_clean_response(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep = Endpoint(url=f"{victim_url}/api", status_code=200)
 
         with patch("requests.post", return_value=make_response(body="<response>ok</response>")):
             results = check_xxe([ep])
 
         assert results == []
 
-    def test_skips_server_error_endpoints(self) -> None:
-        ep = Endpoint(url="https://app.example.com/soap", status_code=500)
+    def test_skips_server_error_endpoints(self, victim_url: str) -> None:
+        ep = Endpoint(url=f"{victim_url}/soap", status_code=500)
 
         with patch("requests.post") as mock_post:
             results = check_xxe([ep])
@@ -102,28 +106,32 @@ class TestCheckXXE:
         assert results == []
 
     def test_endpoint_without_status_code_is_probed(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # status_code=None means recon didn't record it - still worth trying.
-        ep = Endpoint(url="https://app.example.com/soap")
+        ep = Endpoint(url=f"{victim_url}/soap")
 
         with patch("requests.post", return_value=make_response(body=_LINUX_MARKER)):
             results = check_xxe([ep])
 
         assert len(results) == 1
 
-    def test_one_finding_per_endpoint(self, make_response: Callable[..., MagicMock]) -> None:
+    def test_one_finding_per_endpoint(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
         # Even though multiple probes would match, we stop at the first.
-        ep = Endpoint(url="https://app.example.com/soap", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/soap", status_code=200)
 
         with patch("requests.post", return_value=make_response(body=_LINUX_MARKER)):
             results = check_xxe([ep])
 
         assert len(results) == 1
 
-    def test_deduplicates_same_url(self, make_response: Callable[..., MagicMock]) -> None:
-        ep1 = Endpoint(url="https://app.example.com/soap", status_code=200)
-        ep2 = Endpoint(url="https://app.example.com/soap", status_code=200)
+    def test_deduplicates_same_url(
+        self, make_response: Callable[..., MagicMock], victim_url: str
+    ) -> None:
+        ep1 = Endpoint(url=f"{victim_url}/soap", status_code=200)
+        ep2 = Endpoint(url=f"{victim_url}/soap", status_code=200)
 
         with patch("requests.post", return_value=make_response(body=_LINUX_MARKER)):
             results = check_xxe([ep1, ep2])
@@ -131,18 +139,18 @@ class TestCheckXXE:
         assert len(results) == 1
 
     def test_multiple_distinct_endpoints_each_get_a_finding(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep1 = Endpoint(url="https://app.example.com/soap", status_code=200)
-        ep2 = Endpoint(url="https://app.example.com/xml-api", status_code=200)
+        ep1 = Endpoint(url=f"{victim_url}/soap", status_code=200)
+        ep2 = Endpoint(url=f"{victim_url}/xml-api", status_code=200)
 
         with patch("requests.post", return_value=make_response(body=_LINUX_MARKER)):
             results = check_xxe([ep1, ep2])
 
         assert len(results) == 2
 
-    def test_network_exception_is_swallowed(self) -> None:
-        ep = Endpoint(url="https://app.example.com/soap", status_code=200)
+    def test_network_exception_is_swallowed(self, victim_url: str) -> None:
+        ep = Endpoint(url=f"{victim_url}/soap", status_code=200)
 
         with patch("requests.post", side_effect=OSError("connection refused")):
             results = check_xxe([ep])
@@ -177,11 +185,11 @@ class TestCheckXXE:
         assert "expat" in joined
 
     def test_payload_filter_restricts_to_named_probes(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # Restricting to only linux-* probes must skip every windows-* probe
         # and every error-* probe.
-        ep = Endpoint(url="https://app.example.com/api", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/api", status_code=200)
 
         seen_bodies: list[str] = []
 
@@ -206,13 +214,13 @@ class TestCheckXXE:
         assert "cybersquad_xxe_probe" not in joined
 
     def test_payload_filter_only_error_probes_runs_just_error_tier(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
         # The Tier 1 file-read loop only fires if any active file-read probe
         # exists. Restricting to error-* names should skip Tier 1 entirely
         # and go straight to the parser-error probes - exactly what an agent
         # wants for a low-noise "is this XML-backed?" reconnaissance pass.
-        ep = Endpoint(url="https://app.example.com/api", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/api", status_code=200)
 
         seen_bodies: list[str] = []
 
@@ -230,9 +238,9 @@ class TestCheckXXE:
         assert results[0].severity_hint == Severity.MEDIUM
 
     def test_payload_filter_finding_evidence_names_the_probe(
-        self, make_response: Callable[..., MagicMock]
+        self, make_response: Callable[..., MagicMock], victim_url: str
     ) -> None:
-        ep = Endpoint(url="https://app.example.com/api", status_code=200)
+        ep = Endpoint(url=f"{victim_url}/api", status_code=200)
 
         with patch("requests.post", return_value=make_response(body=_LINUX_MARKER)):
             results = check_xxe([ep], payload_names=[XxePayload.linux_soap])
@@ -240,8 +248,8 @@ class TestCheckXXE:
         assert len(results) == 1
         assert "linux-soap" in results[0].evidence
 
-    def test_payload_filter_empty_list_is_a_noop(self) -> None:
-        ep = Endpoint(url="https://app.example.com/api", status_code=200)
+    def test_payload_filter_empty_list_is_a_noop(self, victim_url: str) -> None:
+        ep = Endpoint(url=f"{victim_url}/api", status_code=200)
 
         with patch("requests.post") as mock_post:
             results = check_xxe([ep], payload_names=[])

--- a/tools/pentest/idor.py
+++ b/tools/pentest/idor.py
@@ -1,0 +1,267 @@
+"""IDOR (Insecure Direct Object Reference) detection - probe numeric ID
+path segments and ID-shaped parameters with heuristic variants to detect
+access-control bypass and personal data exposure."""
+
+from __future__ import annotations
+
+import logging
+import re
+from enum import StrEnum
+from urllib.parse import urlparse, urlunparse
+
+import requests
+
+from config import config
+from models import Endpoint, RawFinding, Severity
+from tools import http
+from tools._helpers import adaptive_sleep
+
+logger = logging.getLogger(__name__)
+
+
+class IDORAttack(StrEnum):
+    """Named IDOR attack strategy variants.
+
+    sequential    - neighbour IDs: value-1, value+1, value-100. Only meaningful
+                    for numeric path segments where the current value is known.
+                    For query parameters (no known value) this probes 1 and 2.
+    boundary      - boundary IDs: 0 and -1. Catches missing lower-bound checks.
+    type_juggling - type-confusion probes: 1.0, 1e1, 01. Targets backends that
+                    accept loose numeric input and may resolve these to the same
+                    object while bypassing strict access-control comparisons.
+    """
+
+    sequential = "sequential"
+    boundary = "boundary"
+    type_juggling = "type-juggling"
+
+
+# Parameter names that commonly represent object identifiers.
+_ID_PARAMS = frozenset(
+    {
+        "id",
+        "user_id",
+        "account_id",
+        "order_id",
+        "doc_id",
+        "file_id",
+        "invoice_id",
+        "record_id",
+        "item_id",
+        "object_id",
+        "resource_id",
+        "customer_id",
+        "product_id",
+        "report_id",
+        "ticket_id",
+        "message_id",
+        "uuid",
+        "uid",
+        "pid",
+        "oid",
+    }
+)
+
+# Patterns that suggest a response body contains personal data.
+_PII_RE = re.compile(
+    r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}"  # email address
+    r'|"(?:email|phone|address|payment|ssn|dob|passport)"'  # sensitive JSON keys
+    r"|card_number|credit_card|account_number",
+    re.I,
+)
+
+# A numeric path segment: at least 2 digits as a whole path component.
+_NUMERIC_SEG_RE = re.compile(r"^\d{2,}$")
+
+
+def _path_variants(value: int, active: frozenset[IDORAttack]) -> list[str]:
+    """Probe values for a numeric path segment whose current value is known."""
+    candidates: set[str] = set()
+    if IDORAttack.sequential in active:
+        for delta in (-1, 1, -100):
+            neighbour = value + delta
+            if neighbour > 0:
+                candidates.add(str(neighbour))
+    if IDORAttack.boundary in active:
+        candidates |= {"0", "-1"}
+    if IDORAttack.type_juggling in active:
+        candidates |= {f"{value}.0", f"{value}e1", f"0{value}"}
+    candidates.discard(str(value))
+    return list(candidates)
+
+
+def _param_variants(active: frozenset[IDORAttack]) -> list[str]:
+    """Probe values for an ID-shaped query parameter (current value unknown)."""
+    candidates: set[str] = set()
+    if IDORAttack.sequential in active:
+        candidates |= {"1", "2"}
+    if IDORAttack.boundary in active:
+        candidates |= {"0", "-1"}
+    if IDORAttack.type_juggling in active:
+        candidates |= {"1.0", "1e1", "01"}
+    return list(candidates)
+
+
+def _replace_path_segment(url: str, index: int, replacement: str) -> str:
+    parsed = urlparse(url)
+    parts = parsed.path.split("/")
+    parts[index] = replacement
+    return urlunparse(parsed._replace(path="/".join(parts)))
+
+
+def check_idor(
+    endpoints: list[Endpoint],
+    attacks: list[IDORAttack] | None = None,
+) -> list[RawFinding]:
+    """Probe numeric path segments and ID-shaped parameters for IDOR.
+
+    For each endpoint:
+    - Numeric URL path segments (>= 2 digits): probed with variants selected
+      by the active attack set (see IDORAttack).
+    - ID-shaped query parameters (id, user_id, order_id, ...): same attack set,
+      but without a known current value sequential probes use 1 and 2.
+
+    Detection heuristics:
+      HIGH   - status changes from 401/403 to 200 (access-control bypass)
+      HIGH   - 200 response body contains a PII pattern (email, sensitive key)
+      MEDIUM - unexpected 200 for a boundary ID (value 0 or -1)
+
+    When attacks is None, all three strategies run. Pass a subset for targeted
+    probing: e.g. just IDORAttack.boundary for a quiet reconnaissance pass (2
+    requests per candidate instead of many).
+
+    One finding per endpoint; stops after the first confirming probe. Scope
+    enforcement is upstream. No ID-range brute-forcing.
+    """
+    active = frozenset(attacks) if attacks is not None else frozenset(IDORAttack)
+    findings: list[RawFinding] = []
+    seen: set[str] = set()
+    _delay = config.scan.request_delay
+
+    for ep in endpoints:
+        if ep.url in seen:
+            continue
+        if ep.status_code and ep.status_code >= 500:
+            continue
+
+        # Phase 1: numeric path segments embedded in the URL.
+        parsed = urlparse(ep.url)
+        for i, seg in enumerate(parsed.path.split("/")):
+            if ep.url in seen:
+                break
+            if not _NUMERIC_SEG_RE.match(seg):
+                continue
+            value = int(seg)
+            for variant in _path_variants(value, active):
+                probe_url = _replace_path_segment(ep.url, i, variant)
+                try:
+                    resp = http.get(  # nosemgrep
+                        probe_url,
+                        timeout=config.recon.http_timeout,
+                        allow_redirects=False,
+                    )
+                    finding = _evaluate(
+                        ep.url, f"path segment {seg!r}", variant, ep.status_code, resp
+                    )
+                    if finding:
+                        findings.append(finding)
+                        seen.add(ep.url)
+                        break
+                    _delay = adaptive_sleep(_delay, resp.status_code)
+                except Exception as exc:
+                    logger.debug("IDOR path probe failed for %s: %s", probe_url, exc)
+
+        if ep.url in seen:
+            continue
+
+        # Phase 2: ID-shaped query parameters.
+        id_params = [p for p in ep.parameters if p.lower() in _ID_PARAMS]
+        for param in id_params:
+            if ep.url in seen:
+                break
+            for variant in _param_variants(active):
+                probe_url = f"{ep.url}?{param}={variant}"
+                try:
+                    resp = http.get(  # nosemgrep
+                        probe_url,
+                        timeout=config.recon.http_timeout,
+                        allow_redirects=False,
+                    )
+                    finding = _evaluate(
+                        ep.url, f"parameter {param!r}", variant, ep.status_code, resp
+                    )
+                    if finding:
+                        findings.append(finding)
+                        seen.add(ep.url)
+                        break
+                    _delay = adaptive_sleep(_delay, resp.status_code)
+                except Exception as exc:
+                    logger.debug(
+                        "IDOR param probe failed for %s?%s=%s: %s",
+                        ep.url,
+                        param,
+                        variant,
+                        exc,
+                    )
+
+    logger.info("IDOR probe found %d findings", len(findings))
+    return findings
+
+
+def _evaluate(
+    original_url: str,
+    location: str,
+    variant: str,
+    baseline_status: int | None,
+    resp: requests.Response,
+) -> RawFinding | None:
+    """Map a probe response to a RawFinding, or return None if clean."""
+    status = resp.status_code
+    body = resp.text[:500]
+
+    if baseline_status in (401, 403) and status == 200:
+        return RawFinding(
+            title=f"IDOR - {original_url}",
+            vuln_class="IDOR",
+            target=original_url,
+            evidence=(
+                f"Location: {location}\n"
+                f"Probe value: {variant!r}\n"
+                f"Baseline status: {baseline_status} -> Probe: {status}\n"
+                f"Response: {body}"
+            ),
+            tool="idor_probe",
+            severity_hint=Severity.HIGH,
+        )
+
+    if status == 200 and _PII_RE.search(body):
+        return RawFinding(
+            title=f"IDOR - {original_url}",
+            vuln_class="IDOR",
+            target=original_url,
+            evidence=(
+                f"Location: {location}\n"
+                f"Probe value: {variant!r}\n"
+                f"PII pattern matched in 200 response.\n"
+                f"Response: {body}"
+            ),
+            tool="idor_probe",
+            severity_hint=Severity.HIGH,
+        )
+
+    if status == 200 and variant in ("0", "-1"):
+        return RawFinding(
+            title=f"IDOR - {original_url}",
+            vuln_class="IDOR",
+            target=original_url,
+            evidence=(
+                f"Location: {location}\n"
+                f"Probe value: {variant!r}\n"
+                f"Unexpected 200 for boundary ID; warrants manual review.\n"
+                f"Response: {body}"
+            ),
+            tool="idor_probe",
+            severity_hint=Severity.MEDIUM,
+        )
+
+    return None

--- a/tools/pentest/idor.py
+++ b/tools/pentest/idor.py
@@ -36,7 +36,8 @@ class IDORAttack(StrEnum):
     type_juggling = "type-juggling"
 
 
-# Parameter names that commonly represent object identifiers.
+# TODO: move to a shared parameter-classification module once the framework-
+# specific probe infrastructure proposed in #83 provides a natural home for it.
 _ID_PARAMS = frozenset(
     {
         "id",
@@ -62,7 +63,8 @@ _ID_PARAMS = frozenset(
     }
 )
 
-# Patterns that suggest a response body contains personal data.
+# TODO: for HTML responses, delegate to tools/html.py (BeautifulSoup) for
+# cleaner structured field detection rather than raw regex - tracked in #91.
 _PII_RE = re.compile(
     r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}"  # email address
     r'|"(?:email|phone|address|payment|ssn|dob|passport)"'  # sensitive JSON keys


### PR DESCRIPTION
## Summary

- Implements `tools/pentest/idor.py` - IDOR probe tool for OWASP A01 / HackerOne's most-rewarded class (closes #63)
- Adds `cybersquad-pentest-tool` skill to enforce the attack-classification pattern on all future pentest tool work

## What the tool does

Probes numeric path segments (`/api/users/12345`) and ID-shaped query parameters (`id`, `user_id`, `order_id`, ...) using three named attack strategies via `IDORAttack` StrEnum:

- `sequential` - neighbour IDs (value+/-1, value-100); for path segments where the current value is visible in the URL
- `boundary` - zero and negative IDs (0, -1); catches missing lower-bound checks on any ID-shaped param
- `type-juggling` - loose-numeric probes (1.0, 1e1, 01); targets backends that may bypass strict access-control comparisons

Detection signals: 401/403 -> 200 transition (HIGH), PII pattern in 200 response (HIGH), unexpected 200 for boundary ID (MEDIUM). One finding per endpoint; stops on first confirming probe. No ID-range brute-forcing.

Wired into the PT squad as `idor_probe_tool` with `IDORAttack` exposed so the agent can select a targeted subset (e.g. `attacks=["boundary"]` for a quiet recon pass, 2 requests per candidate instead of many).

## What the skill enforces

`cybersquad-pentest-tool` fires on edits to `tools/pentest/` and `squad/penetration_tester/__init__.py`. It codifies three checkpoints that must hold for any multi-variant active probe tool:

1. A `StrEnum` (`ToolNameAttack` or `ToolNamePayload`) with per-member docstrings explaining when an agent picks each variant
2. `check_*` function accepts `list[XxxAttack] | None = None`; `None` = all via `frozenset(XxxAttack)`, `[]` = no-op
3. Squad `@tool` wrapper imports the StrEnum, exposes it in the typed signature, and documents each variant

Explicit exemptions (single-vector tools, binary wrappers, structural checkers) are stated with reasoning.

## Test plan

- [x] 19 unit tests in `tests/test_idor.py` - all network calls mocked, `@pytest.mark.unit`
- [x] Covers all three detection signals, all three attack strategies, filter semantics (boundary-only, type-juggling-only, empty list no-op, None runs all), skip conditions (500 endpoints, non-ID params, no numeric segment), deduplication, and exception swallowing
- [x] Full CI stack passes locally: ruff, mypy, pytest (91.27% coverage, above 90% floor), bandit
