### PR TITLE
refactor: replace seed_domain heuristic with type-filter in recon

### DIFF
--- a/tests/test_recon_tools.py
+++ b/tests/test_recon_tools.py
@@ -12,8 +12,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from models import Endpoint, Programme
+from models import Endpoint, Programme, ScopeType
 from tools.recon import (
+    _ACTIVE_RECON_TYPES,
+    _CODE_HOSTS,
     cert_transparency,
     discover_paths,
     enumerate_subdomains,
@@ -43,6 +45,29 @@ class TestExtractDomain:
 
     def test_url_with_port(self):
         assert extract_domain("https://example.com:8443") == "example.com"
+
+
+class TestSeedingConstants:
+    """
+    Regression: URL-type scope items pointing into third-party code hosting infra
+    (e.g. github.com/cloudflare) must not be used as subfinder seeds.
+    H1 returns URL for both bare domains and wildcard patterns; OTHER for products.
+    """
+
+    def test_url_type_is_active_recon(self):
+        assert ScopeType.URL in _ACTIVE_RECON_TYPES
+
+    def test_wildcard_type_is_active_recon(self):
+        assert ScopeType.WILDCARD in _ACTIVE_RECON_TYPES
+
+    def test_other_type_is_not_active_recon(self):
+        assert ScopeType.OTHER not in _ACTIVE_RECON_TYPES
+
+    def test_code_hosts_blocks_github(self):
+        assert "github.com" in _CODE_HOSTS
+
+    def test_code_hosts_blocks_gitlab(self):
+        assert "gitlab.com" in _CODE_HOSTS
 
 
 # filter_in_scope

--- a/tools/recon/__init__.py
+++ b/tools/recon/__init__.py
@@ -58,7 +58,22 @@ def _dirfuzz_targets(endpoints: list[Endpoint], seed_domains: list[str]) -> list
     return sorted(endpoints, key=_priority)
 
 
+# Third-party code hosting platforms that appear in H1 scope lists as URL-type
+# assets pointing to repos/orgs, but whose infrastructure must never be enumerated.
+_CODE_HOSTS: frozenset[str] = frozenset(
+    {"github.com", "gitlab.com", "bitbucket.org", "sourceforge.net"}
+)
+
+# Asset types that represent live web targets worth enumerating with subfinder.
+# H1 returns URL for bare domains (dash.cloudflare.com) and wildcards (*.teams.cloudflare.com).
+_ACTIVE_RECON_TYPES: frozenset[ScopeType] = frozenset(
+    {ScopeType.URL, ScopeType.WILDCARD, ScopeType.IP_ADDRESS}
+)
+
+
 __all__ = [
+    "_ACTIVE_RECON_TYPES",
+    "_CODE_HOSTS",
     "cert_transparency",
     "check_dns_email_security",
     "check_tls",
@@ -77,11 +92,19 @@ __all__ = [
 
 def run_recon(programme: Programme) -> ReconResult:
     """Full recon pipeline for a single programme."""
-    seed_domains: list[str] = [
-        extract_domain(item.asset_identifier)
-        for item in programme.in_scope
-        if item.asset_type in (ScopeType.URL, ScopeType.WILDCARD)
-    ]
+    seed_domains: list[str] = []
+    for item in programme.in_scope:
+        if item.asset_type not in _ACTIVE_RECON_TYPES:
+            continue
+        parsed = urlparse(
+            item.asset_identifier
+            if "://" in item.asset_identifier
+            else f"http://{item.asset_identifier}"
+        )
+        hostname = (parsed.hostname or "").lstrip("*.")
+        if not hostname or (parsed.path or "").strip("/") or hostname in _CODE_HOSTS:
+            continue
+        seed_domains.append(hostname)
     seed_domains = list(dict.fromkeys(seed_domains))
 
     all_subdomains: list[str] = []


### PR DESCRIPTION
Replaces the extract_domain() list-comprehension in run_recon() with an explicit loop that filters on _ACTIVE_RECON_TYPES (URL, WILDCARD, IP_ADDRESS) and skips code-hosting platforms in _CODE_HOSTS, preventing github.com/org-style scope items from being used as subfinder seeds.