### PR TITLE
refactor: centralise probe canary strings in tools/pentest/canary.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,8 @@ name: CI
 
 on:
   push:
-    branches: ["main", "fix/**", "feat/**", "chore/**"]
+    branches: ["main", "fix/**", "feat/**", "chore/**", "claude/**"]
   pull_request:
-    branches: ["main"]
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["main", "fix/**", "feat/**", "chore/**", "claude/**"]
+    branches: ["main", "feat/**", "fix/**", "refactor/**", "chore/**", "ci/**", "build/**", "test/**", "docs/**", "perf/**", "style/**", "revert/**"]
   pull_request:
 
 permissions:

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -142,4 +142,4 @@ class TestCheckErrorDisclosure:
         with patch("requests.get", side_effect=recording_get):
             check_error_disclosure([ep])
 
-        assert any("bountysquad-404probe" in u for u in seen_urls)
+        assert any("cybersquad-404probe" in u for u in seen_urls)

--- a/tests/test_header_xss.py
+++ b/tests/test_header_xss.py
@@ -7,8 +7,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import tools.pentest.canary as canary
 from models import Endpoint, Severity
-from tools.pentest.header_xss import _CANARY_PREFIX, XSSHeader, check_header_xss
+from tools.pentest.header_xss import XSSHeader, check_header_xss
+
+_CANARY_PREFIX = canary.HXSS_PREFIX
 
 pytestmark = pytest.mark.unit
 
@@ -77,7 +80,7 @@ class TestCheckHeaderXss:
 
         with patch(
             "requests.get",
-            return_value=make_response(body="<html>&lt;bountysquad-hxss-test&gt;</html>"),
+            return_value=make_response(body="<html>&lt;cybersquad-hxss-test&gt;</html>"),
         ):
             results = check_header_xss([ep])
 

--- a/tests/test_open_redirect.py
+++ b/tests/test_open_redirect.py
@@ -8,14 +8,16 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from models import Endpoint, Severity
+from tools.pentest import canary
 from tools.pentest.open_redirect import (
-    _PAYLOAD_HOST,
     _PAYLOADS,
     OpenRedirectPayload,
     _redirect_target,
     _redirects_to_canary,
     check_open_redirect,
 )
+
+_PAYLOAD_HOST = canary.REDIRECT_HOST
 
 pytestmark = pytest.mark.unit
 

--- a/tests/test_vuln_tools.py
+++ b/tests/test_vuln_tools.py
@@ -289,7 +289,7 @@ class TestCheckHeaderInjection:
 
         endpoint = Endpoint(url="https://api.example.com/", status_code=200)
         mock_resp = MagicMock()
-        mock_resp.headers = {"BountySquadCanary": "yes"}
+        mock_resp.headers = {"CybersquadCanary": "yes"}
         mock_resp.text = ""
 
         with patch("requests.get", return_value=mock_resp):
@@ -304,7 +304,7 @@ class TestCheckHeaderInjection:
         endpoint = Endpoint(url="https://api.example.com/", status_code=200)
         mock_resp = MagicMock()
         mock_resp.headers = {}
-        mock_resp.text = "bountysquadcanary injected"
+        mock_resp.text = "cybersquadcanary injected"
 
         with patch("requests.get", return_value=mock_resp):
             results = check_header_injection([endpoint])

--- a/tests/test_webapp_headers.py
+++ b/tests/test_webapp_headers.py
@@ -21,7 +21,7 @@ class TestCheckHostHeadersReflection:
     def test_detects_canary_host_in_response_body(self, victim_url: str):
         endpoint = Endpoint(url=f"{victim_url}/", status_code=200)
         mock_resp = MagicMock()
-        mock_resp.text = "href=https://bountysquad-canary.invalid/reset"
+        mock_resp.text = "href=https://cybersquad-canary.invalid/reset"
         mock_resp.headers = {}
 
         with patch("requests.get", return_value=mock_resp):
@@ -35,7 +35,7 @@ class TestCheckHostHeadersReflection:
         endpoint = Endpoint(url=f"{victim_url}/", status_code=200)
         mock_resp = MagicMock()
         mock_resp.text = "redirecting..."
-        mock_resp.headers = {"Location": "https://bountysquad-canary.invalid/login"}
+        mock_resp.headers = {"Location": "https://cybersquad-canary.invalid/login"}
 
         with patch("requests.get", return_value=mock_resp):
             results = check_host_headers([endpoint])
@@ -67,7 +67,7 @@ class TestCheckHostHeadersReflection:
             Endpoint(url=f"{victim_url}/page2", status_code=200),
         ]
         mock_resp = MagicMock()
-        mock_resp.text = "bountysquad-canary.invalid in body"
+        mock_resp.text = "cybersquad-canary.invalid in body"
         mock_resp.headers = {}
 
         call_count = 0
@@ -131,7 +131,7 @@ class TestCheckHeaderInjectionCrlf:
     def test_detects_reflected_canary_in_response_headers(self):
         endpoint = Endpoint(url="https://api.example.com/", status_code=200)
         mock_resp = MagicMock()
-        mock_resp.headers = {"BountySquadCanary": "yes"}
+        mock_resp.headers = {"CybersquadCanary": "yes"}
         mock_resp.text = ""
 
         with patch("requests.get", return_value=mock_resp):

--- a/tests/test_xss.py
+++ b/tests/test_xss.py
@@ -36,7 +36,7 @@ class TestCheckReflectedXss:
         def fake_get(url, **kwargs):
             resp = MagicMock()
             # Application HTML-encodes < and >
-            resp.text = "<html><body>Results for &lt;bountysquad-xss-test&gt;</body></html>"
+            resp.text = "<html><body>Results for &lt;cybersquad-xss-test&gt;</body></html>"
             return resp
 
         with patch("requests.get", side_effect=fake_get):

--- a/tools/pentest/canary.py
+++ b/tools/pentest/canary.py
@@ -1,0 +1,14 @@
+"""Probe identifiers shared across active pentest tools.
+
+One source of truth prevents drift and allows future per-run or env-var
+configuration (e.g. replace PREFIX via config.py or generate a random one).
+"""
+
+PREFIX = "cybersquad"
+
+XSS_PREFIX = f"{PREFIX}-xss-"  # reflected XSS, random suffix appended per-request
+HXSS_PREFIX = f"{PREFIX}-hxss-"  # header XSS
+HEADER_INJECTION = f"{PREFIX.title()}Canary"  # -> "CybersquadCanary"
+HOST = f"{PREFIX}-canary.invalid"  # host-header injection (RFC 2606)
+REDIRECT_HOST = f"evil.{HOST}"  # open-redirect payload host
+PROBE_404_PATH = f"/{PREFIX}-404probe"  # error-disclosure probe path

--- a/tools/pentest/canary.py
+++ b/tools/pentest/canary.py
@@ -11,4 +11,6 @@ HXSS_PREFIX = f"{PREFIX}-hxss-"  # header XSS
 HEADER_INJECTION = f"{PREFIX.title()}Canary"  # -> "CybersquadCanary"
 HOST = f"{PREFIX}-canary.invalid"  # host-header injection (RFC 2606)
 REDIRECT_HOST = f"evil.{HOST}"  # open-redirect payload host
+# TODO: replace REDIRECT_HOST with a live callback server (interactsh or similar) for
+# blind open-redirect detection - tracked in #77
 PROBE_404_PATH = f"/{PREFIX}-404probe"  # error-disclosure probe path

--- a/tools/pentest/errors.py
+++ b/tools/pentest/errors.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import logging
 import re
 
+import tools.pentest.canary as canary
 from config import config
 from models import Endpoint, RawFinding, Severity
 from tools import http
@@ -21,8 +22,6 @@ logger = logging.getLogger(__name__)
 
 # Suffix appended to numeric/string parameters to provoke SQL and type errors
 _ERROR_SUFFIX = "1'--"
-# Path that should not exist on any real application
-_NONEXISTENT_PATH = "/bountysquad-404probe"
 
 # Pattern tuples: (compiled_regex, framework_label)
 _ERROR_PATTERNS: list[tuple[re.Pattern[str], str]] = [
@@ -88,7 +87,7 @@ def check_error_disclosure(endpoints: list[Endpoint]) -> list[RawFinding]:
 
         parsed = urlparse(ep.url)
         base = f"{parsed.scheme}://{parsed.netloc}"
-        probe_urls.append(f"{base}{_NONEXISTENT_PATH}")
+        probe_urls.append(f"{base}{canary.PROBE_404_PATH}")
 
         for url in probe_urls:
             try:

--- a/tools/pentest/header_xss.py
+++ b/tools/pentest/header_xss.py
@@ -7,7 +7,7 @@ import logging
 import uuid
 from enum import StrEnum
 
-import tools.pentest.canary as canary
+import tools.pentest.canary as _canary
 from config import config
 from models import Endpoint, RawFinding, Severity
 from tools import http
@@ -60,18 +60,18 @@ def check_header_xss(
             continue
 
         for header in headers_to_probe:
-            canary_val = f"<{canary.HXSS_PREFIX}{uuid.uuid4().hex[:8]}>"
+            canary = f"<{_canary.HXSS_PREFIX}{uuid.uuid4().hex[:8]}>"
             try:
                 resp = http.get(  # nosemgrep
                     ep.url,
-                    headers={header: canary_val},
+                    headers={header: canary},
                     timeout=config.recon.http_timeout,
                     allow_redirects=True,
                 )
                 body = resp.text
                 _delay = adaptive_sleep(_delay, resp.status_code)
 
-                if canary_val not in body:
+                if canary not in body:
                     continue
 
                 seen.add(ep.url)
@@ -82,7 +82,7 @@ def check_header_xss(
                         target=ep.url,
                         evidence=(
                             f"Header: {header}\n"
-                            f"Payload: {canary_val}\n"
+                            f"Payload: {canary}\n"
                             f"Status: {resp.status_code}\n"
                             f"Response snippet: {body[:300]}"
                         ),

--- a/tools/pentest/header_xss.py
+++ b/tools/pentest/header_xss.py
@@ -7,6 +7,7 @@ import logging
 import uuid
 from enum import StrEnum
 
+import tools.pentest.canary as canary
 from config import config
 from models import Endpoint, RawFinding, Severity
 from tools import http
@@ -23,9 +24,6 @@ class XSSHeader(StrEnum):
     X_FORWARDED_FOR = "X-Forwarded-For"
     X_CUSTOM_HEADER = "X-Custom-Header"
     ACCEPT_LANGUAGE = "Accept-Language"
-
-
-_CANARY_PREFIX = "bountysquad-hxss-"
 
 
 def check_header_xss(
@@ -62,18 +60,18 @@ def check_header_xss(
             continue
 
         for header in headers_to_probe:
-            canary = f"<{_CANARY_PREFIX}{uuid.uuid4().hex[:8]}>"
+            canary_val = f"<{canary.HXSS_PREFIX}{uuid.uuid4().hex[:8]}>"
             try:
                 resp = http.get(  # nosemgrep
                     ep.url,
-                    headers={header: canary},
+                    headers={header: canary_val},
                     timeout=config.recon.http_timeout,
                     allow_redirects=True,
                 )
                 body = resp.text
                 _delay = adaptive_sleep(_delay, resp.status_code)
 
-                if canary not in body:
+                if canary_val not in body:
                     continue
 
                 seen.add(ep.url)
@@ -84,7 +82,7 @@ def check_header_xss(
                         target=ep.url,
                         evidence=(
                             f"Header: {header}\n"
-                            f"Payload: {canary}\n"
+                            f"Payload: {canary_val}\n"
                             f"Status: {resp.status_code}\n"
                             f"Response snippet: {body[:300]}"
                         ),

--- a/tools/pentest/open_redirect.py
+++ b/tools/pentest/open_redirect.py
@@ -9,16 +9,13 @@ from urllib.parse import urlparse
 
 import requests
 
+import tools.pentest.canary as canary
 from config import config
 from models import Endpoint, RawFinding, Severity
 from tools import http
 from tools._helpers import adaptive_sleep
 
 logger = logging.getLogger(__name__)
-
-# Reserved-TLD canary host (RFC 2606) - guaranteed not to resolve, so even if
-# a victim browser followed the redirect there is no live host to receive it.
-_PAYLOAD_HOST = "evil.bountysquad-canary.invalid"
 
 
 class OpenRedirectPayload(StrEnum):
@@ -34,14 +31,14 @@ class OpenRedirectPayload(StrEnum):
 # Multiple encodings of the same canary so we catch apps that try to
 # allowlist-by-prefix or strip the scheme without parsing the rest.
 _PAYLOADS: dict[str, str] = {
-    OpenRedirectPayload.https: f"https://{_PAYLOAD_HOST}/",
-    OpenRedirectPayload.protocol_relative: f"//{_PAYLOAD_HOST}/",
+    OpenRedirectPayload.https: f"https://{canary.REDIRECT_HOST}/",
+    OpenRedirectPayload.protocol_relative: f"//{canary.REDIRECT_HOST}/",
     # Backslash trick: some servers normalise \ to / before placing the value
     # in a Location header, turning this into a protocol-relative redirect.
-    OpenRedirectPayload.backslash: f"/\\{_PAYLOAD_HOST}/",
+    OpenRedirectPayload.backslash: f"/\\{canary.REDIRECT_HOST}/",
     # Userinfo confusion: naive validators that look for a known prefix can
     # be fooled into letting the real host through as the "user" component.
-    OpenRedirectPayload.userinfo: f"https://example.com@{_PAYLOAD_HOST}/",
+    OpenRedirectPayload.userinfo: f"https://example.com@{canary.REDIRECT_HOST}/",
 }
 
 # Catch <meta http-equiv="refresh" content="0;url=..."> in the body when the
@@ -77,7 +74,7 @@ def _redirects_to_canary(target: str) -> bool:
     # normalise stay as paths (no host) and correctly fall through as False.
     parsed = urlparse(target if "://" in target else f"http:{target}")
     host = (parsed.hostname or "").lower()
-    return host == _PAYLOAD_HOST or host.endswith("." + _PAYLOAD_HOST)
+    return host == canary.REDIRECT_HOST or host.endswith("." + canary.REDIRECT_HOST)
 
 
 def check_open_redirect(

--- a/tools/pentest/webapp_headers.py
+++ b/tools/pentest/webapp_headers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 from urllib.parse import urlparse, urlunparse
 
+import tools.pentest.canary as canary
 from config import config
 from models import Endpoint, RawFinding, Severity
 from tools import http
@@ -20,8 +21,7 @@ logger = logging.getLogger(__name__)
 # --- CRLF / header injection ---
 
 _CRLF_HEADERS = ["X-Forwarded-For", "X-Real-IP", "Referer"]
-_CANARY = "BountySquadCanary"
-_CRLF_PAYLOAD = f"127.0.0.1\r\n{_CANARY}: yes"
+_CRLF_PAYLOAD = f"127.0.0.1\r\n{canary.HEADER_INJECTION}: yes"
 
 
 def check_header_injection(endpoints: list[Endpoint]) -> list[RawFinding]:
@@ -40,7 +40,9 @@ def check_header_injection(endpoints: list[Endpoint]) -> list[RawFinding]:
                     timeout=config.recon.http_timeout,
                     allow_redirects=False,
                 )
-                if _CANARY in resp.headers or _CANARY.lower() in resp.text.lower():
+                header_hit = canary.HEADER_INJECTION in resp.headers
+                body_hit = canary.HEADER_INJECTION.lower() in resp.text.lower()
+                if header_hit or body_hit:
                     findings.append(
                         RawFinding(
                             title=f"Header Injection - {ep.url}",
@@ -73,7 +75,6 @@ _HOST_FORWARD_HEADERS = [
     "X-HTTP-Host-Override",
 ]
 _PATH_OVERRIDE_HEADERS = ["X-Original-URL", "X-Rewrite-URL"]
-_CANARY_HOST = "bountysquad-canary.invalid"
 _OVERRIDE_PATHS = ["/admin", "/manager", "/_admin", "/administrator", "/dashboard"]
 
 
@@ -112,14 +113,14 @@ def check_host_headers(endpoints: list[Endpoint]) -> list[RawFinding]:
             try:
                 resp = http.get(  # nosemgrep
                     ep.url,
-                    headers={hdr: _CANARY_HOST},
+                    headers={hdr: canary.HOST},
                     timeout=config.recon.http_timeout,
                     allow_redirects=False,
                 )
                 reflected = (
-                    _CANARY_HOST in resp.text
-                    or _CANARY_HOST in resp.headers.get("Location", "")
-                    or _CANARY_HOST in resp.headers.get("Link", "")
+                    canary.HOST in resp.text
+                    or canary.HOST in resp.headers.get("Location", "")
+                    or canary.HOST in resp.headers.get("Link", "")
                 )
                 if reflected:
                     findings.append(
@@ -128,7 +129,7 @@ def check_host_headers(endpoints: list[Endpoint]) -> list[RawFinding]:
                             vuln_class="HostHeaderInjection",
                             target=ep.url,
                             evidence=(
-                                f"Header: {hdr}: {_CANARY_HOST}\n"
+                                f"Header: {hdr}: {canary.HOST}\n"
                                 f"Canary reflected in response - "
                                 f"potential cache poisoning or password-reset poisoning."
                             ),

--- a/tools/pentest/xss.py
+++ b/tools/pentest/xss.py
@@ -5,16 +5,13 @@ from __future__ import annotations
 import logging
 import uuid
 
+import tools.pentest.canary as canary
 from config import config
 from models import Endpoint, RawFinding, Severity
 from tools import http
 from tools._helpers import adaptive_sleep
 
 logger = logging.getLogger(__name__)
-
-# Tag-style canary so it stands out from normal values. We use a random suffix
-# per-run so WAF signatures can't simply allowlist the literal string.
-_CANARY_PREFIX = "bountysquad-xss-"
 
 
 def check_reflected_xss(endpoints: list[Endpoint]) -> list[RawFinding]:
@@ -37,9 +34,9 @@ def check_reflected_xss(endpoints: list[Endpoint]) -> list[RawFinding]:
             continue
 
         for param in ep.parameters:
-            canary = f"<{_CANARY_PREFIX}{uuid.uuid4().hex[:8]}>"
+            canary_val = f"<{canary.XSS_PREFIX}{uuid.uuid4().hex[:8]}>"
             try:
-                test_url = f"{ep.url}?{param}={canary}"
+                test_url = f"{ep.url}?{param}={canary_val}"
                 resp = http.get(  # nosemgrep
                     test_url,
                     timeout=config.recon.http_timeout,
@@ -47,7 +44,7 @@ def check_reflected_xss(endpoints: list[Endpoint]) -> list[RawFinding]:
                 )
                 body = resp.text
 
-                if canary not in body:
+                if canary_val not in body:
                     _delay = adaptive_sleep(_delay, resp.status_code)
                     continue
 
@@ -63,7 +60,8 @@ def check_reflected_xss(endpoints: list[Endpoint]) -> list[RawFinding]:
                         vuln_class="ReflectedXSS",
                         target=ep.url,
                         evidence=(
-                            f"Parameter: {param}\nPayload: {canary}\nResponse snippet: {body[:300]}"
+                            f"Parameter: {param}\nPayload: {canary_val}\n"
+                            f"Response snippet: {body[:300]}"
                         ),
                         tool="xss_probe",
                         severity_hint=Severity.HIGH,

--- a/tools/pentest/xss.py
+++ b/tools/pentest/xss.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import uuid
 
-import tools.pentest.canary as canary
+import tools.pentest.canary as _canary
 from config import config
 from models import Endpoint, RawFinding, Severity
 from tools import http
@@ -34,9 +34,9 @@ def check_reflected_xss(endpoints: list[Endpoint]) -> list[RawFinding]:
             continue
 
         for param in ep.parameters:
-            canary_val = f"<{canary.XSS_PREFIX}{uuid.uuid4().hex[:8]}>"
+            canary = f"<{_canary.XSS_PREFIX}{uuid.uuid4().hex[:8]}>"
             try:
-                test_url = f"{ep.url}?{param}={canary_val}"
+                test_url = f"{ep.url}?{param}={canary}"
                 resp = http.get(  # nosemgrep
                     test_url,
                     timeout=config.recon.http_timeout,
@@ -44,7 +44,7 @@ def check_reflected_xss(endpoints: list[Endpoint]) -> list[RawFinding]:
                 )
                 body = resp.text
 
-                if canary_val not in body:
+                if canary not in body:
                     _delay = adaptive_sleep(_delay, resp.status_code)
                     continue
 
@@ -60,8 +60,7 @@ def check_reflected_xss(endpoints: list[Endpoint]) -> list[RawFinding]:
                         vuln_class="ReflectedXSS",
                         target=ep.url,
                         evidence=(
-                            f"Parameter: {param}\nPayload: {canary_val}\n"
-                            f"Response snippet: {body[:300]}"
+                            f"Parameter: {param}\nPayload: {canary}\nResponse snippet: {body[:300]}"
                         ),
                         tool="xss_probe",
                         severity_hint=Severity.HIGH,


### PR DESCRIPTION
## Summary

- **`tools/pentest/canary.py`** (new) — single source of truth for all probe identifiers: `PREFIX`, `XSS_PREFIX`, `HXSS_PREFIX`, `HEADER_INJECTION`, `HOST`, `REDIRECT_HOST`, `PROBE_404_PATH`
- **`tools/pentest/xss.py`** — removes `_CANARY_PREFIX`; imports from `canary`
- **`tools/pentest/header_xss.py`** — same
- **`tools/pentest/webapp_headers.py`** — removes `_CANARY`, `_CANARY_HOST`
- **`tools/pentest/open_redirect.py`** — removes `_PAYLOAD_HOST`
- **`tools/pentest/errors.py`** — removes `_NONEXISTENT_PATH`
- **Tests** updated to import canary strings from `tools.pentest.canary` instead of private module globals

Also includes: `ci: cover all conventional prefixes; run on all pull requests` — the CI workflow now fires on all PR events (not just those targeting `main`) and on pushes to all conventional branch prefixes.

Replaces #106 (wrong branch name).

## Test plan

- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `mypy . --ignore-missing-imports` — clean
- [x] `pytest -m unit --cov` — 91%+ coverage
- [x] `bandit -c pyproject.toml -r . -q` — clean
