### PR TITLE
feat: add runtime state module for pipeline run context

### DIFF
--- a/main.py
+++ b/main.py
@@ -117,14 +117,13 @@ def main() -> None:
         dry_run_summary(crew)
         return
 
-    run_id = datetime.now(UTC).strftime("%Y%m%d-%H%M%S") + "-" + uuid4().hex[:6]
-    runtime.run_id = run_id
+    runtime.run_id = datetime.now(UTC).strftime("%Y%m%d-%H%M%S") + "-" + uuid4().hex[:6]
     started_at = datetime.now(UTC)
 
     console.rule("[bold]Bounty Squad[/bold]")
     logger.info(
         "run=%s  model=%s  min_bounty=$%s  min_severity=%s",
-        run_id,
+        runtime.run_id,
         config.llm.model,
         config.h1.min_bounty_threshold,
         config.scan.min_severity,
@@ -146,7 +145,7 @@ def main() -> None:
         usage = getattr(result, "token_usage", None)
         if usage is not None:
             metrics = build_run_metrics(
-                run_id=run_id,
+                run_id=runtime.run_id,
                 started_at=started_at,
                 llm_model=config.llm.model,
                 input_tokens=getattr(usage, "prompt_tokens", 0),

--- a/main.py
+++ b/main.py
@@ -106,6 +106,7 @@ def main() -> None:
     check_env()
 
     # Import crew after env check
+    import runtime
     from config import config
     from crew import build_crew
     from tools.metrics import build_run_metrics, print_metrics, save_metrics
@@ -117,6 +118,7 @@ def main() -> None:
         return
 
     run_id = datetime.now(UTC).strftime("%Y%m%d-%H%M%S") + "-" + uuid4().hex[:6]
+    runtime.run_id = run_id
     started_at = datetime.now(UTC)
 
     console.rule("[bold]Bounty Squad[/bold]")

--- a/runtime.py
+++ b/runtime.py
@@ -1,0 +1,29 @@
+"""
+runtime.py - Mutable pipeline state set by main.py before crew.kickoff().
+
+Tools read run_id and programme_handle to locate the current run folder
+without needing those values passed as arguments through the agent layer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+run_id: str = ""
+programme_handle: str = ""
+
+
+def run_dir() -> Path:
+    """Return the run-specific folder: {reports_dir}/programs/{handle}/{run_id}/"""
+    from config import config
+
+    if not programme_handle or not run_id:
+        raise RuntimeError("runtime.programme_handle and run_id must be set before run_dir()")
+    return Path(config.reports_dir) / "programs" / programme_handle / run_id
+
+
+def programme_cache_path(handle: str) -> Path:
+    """Return {reports_dir}/programs/{handle}/programme.json"""
+    from config import config
+
+    return Path(config.reports_dir) / "programs" / handle / "programme.json"

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,66 @@
+"""tests/test_runtime.py - unit tests for runtime.py"""
+
+from __future__ import annotations
+
+import pytest
+
+import runtime
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def reset_runtime():
+    """Restore module globals after each test."""
+    yield
+    runtime.run_id = ""
+    runtime.programme_handle = ""
+
+
+class TestRunDir:
+    def test_returns_correct_path(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("config.config.reports_dir", str(tmp_path))
+        runtime.programme_handle = "acme"
+        runtime.run_id = "20260517-120000-abc123"
+
+        result = runtime.run_dir()
+
+        assert result == tmp_path / "programs" / "acme" / "20260517-120000-abc123"
+
+    def test_raises_when_handle_unset(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("config.config.reports_dir", str(tmp_path))
+        runtime.run_id = "20260517-120000-abc123"
+
+        with pytest.raises(RuntimeError, match="programme_handle"):
+            runtime.run_dir()
+
+    def test_raises_when_run_id_unset(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("config.config.reports_dir", str(tmp_path))
+        runtime.programme_handle = "acme"
+
+        with pytest.raises(RuntimeError, match="run_id"):
+            runtime.run_dir()
+
+    def test_raises_when_both_unset(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("config.config.reports_dir", str(tmp_path))
+
+        with pytest.raises(RuntimeError):
+            runtime.run_dir()
+
+
+class TestProgrammeCachePath:
+    def test_returns_correct_path(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("config.config.reports_dir", str(tmp_path))
+
+        result = runtime.programme_cache_path("acme")
+
+        assert result == tmp_path / "programs" / "acme" / "programme.json"
+
+    def test_uses_provided_handle_not_global(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("config.config.reports_dir", str(tmp_path))
+        runtime.programme_handle = "other"
+
+        result = runtime.programme_cache_path("acme")
+
+        assert "acme" in str(result)
+        assert "other" not in str(result)


### PR DESCRIPTION
## Summary

Adds `runtime.py` — a thin module-level state store set by `main.py` before `crew.kickoff()`.

- `run_id: str` — unique identifier for the current pipeline run
- `programme_handle: str` — H1 programme handle selected by the Programme Manager
- `run_dir() -> Path` — `{reports_dir}/programs/{handle}/{run_id}/`
- `programme_cache_path(handle) -> Path` — `{reports_dir}/programs/{handle}/programme.json`

Tools read these to locate the current run folder without needing the values threaded through the agent argument layer.

## Why a separate PR

`runtime.py` was originally part of #113 (TUI). It has no Textual dependency and is needed by both #114 (file-path artifacts) and #115 (H1 programme hydration). Landing it independently unblocks those two PRs without requiring the TUI to merge first.

## Test plan

- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `mypy . --ignore-missing-imports` — clean
- [x] `pytest -m unit --cov` — all passing
