### PR TITLE
test: fix issues from #116 test suite review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
   test:
     name: Unit tests
     runs-on: ubuntu-latest
+    needs: [lint]
     permissions:
       contents: read
       checks: write  # required by dorny/test-reporter to post check runs
@@ -54,7 +55,7 @@ jobs:
         run: pip install -e ".[dev]"
 
       - name: pytest (unit only)
-        run: pytest -m unit --cov --cov-report=term-missing --cov-report=xml:coverage.xml --cov-report=html --junit-xml=junit.xml
+        run: pytest -m unit --cov --cov-report=term-missing --cov-report=html --junit-xml=junit.xml
 
       - name: Publish test results
         uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5  # v1.9.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -244,6 +244,17 @@ def clean_response_body() -> str:
     return body
 
 
+@pytest.fixture()
+def reload_module():
+    """Reload a module so that monkeypatched env vars take effect on module-level singletons.
+
+    Usage: reload_module(my_module)
+    """
+    import importlib
+
+    return importlib.reload
+
+
 @pytest.fixture
 def make_response():
     """Factory for building MagicMock objects shaped like requests.Response.

--- a/tests/test_h1_api.py
+++ b/tests/test_h1_api.py
@@ -88,6 +88,18 @@ class TestParseProgramme:
         prog = h1_client.parse_programme(raw, self._raw_scope())
         assert prog.allows_automated_scanning is False
 
+    def test_allows_automated_scanning_false_when_scanning_prohibited_phrase(self, h1_client):
+        raw = self._raw_programme()
+        raw["attributes"]["policy"] = "Automated scanning prohibited on all assets."
+        prog = h1_client.parse_programme(raw, self._raw_scope())
+        assert prog.allows_automated_scanning is False
+
+    def test_allows_automated_scanning_false_when_no_scanners_phrase(self, h1_client):
+        raw = self._raw_programme()
+        raw["attributes"]["policy"] = "No scanners or automated tools may be used."
+        prog = h1_client.parse_programme(raw, self._raw_scope())
+        assert prog.allows_automated_scanning is False
+
     def test_in_scope_items_parsed(self, h1_client):
         prog = h1_client.parse_programme(self._raw_programme(), self._raw_scope(eligible=True))
         assert len(prog.in_scope) == 1

--- a/tests/test_recon_tools.py
+++ b/tests/test_recon_tools.py
@@ -283,10 +283,8 @@ class TestCertTransparency:
             {"name_value": "other.notexample.com"},
         ]
 
-    def test_returns_subdomains_ending_in_domain(self):
-        mock_resp = MagicMock()
-        mock_resp.raise_for_status = MagicMock()
-        mock_resp.json.return_value = self._crtsh_response()
+    def test_returns_subdomains_ending_in_domain(self, make_response):
+        mock_resp = make_response(json=self._crtsh_response())
 
         with patch("requests.get", return_value=mock_resp):
             result = cert_transparency("example.com")
@@ -294,33 +292,29 @@ class TestCertTransparency:
         assert "api.example.com" in result
         assert "stage.example.com" in result
 
-    def test_strips_wildcard_prefix(self):
-        mock_resp = MagicMock()
-        mock_resp.raise_for_status = MagicMock()
-        mock_resp.json.return_value = [{"name_value": "*.example.com"}]
+    def test_strips_wildcard_prefix(self, make_response):
+        mock_resp = make_response(json=[{"name_value": "*.example.com"}])
 
         with patch("requests.get", return_value=mock_resp):
             result = cert_transparency("example.com")
 
         assert all(not n.startswith("*.") for n in result)
 
-    def test_filters_off_domain_names(self):
-        mock_resp = MagicMock()
-        mock_resp.raise_for_status = MagicMock()
-        mock_resp.json.return_value = [{"name_value": "other.notexample.com"}]
+    def test_filters_off_domain_names(self, make_response):
+        mock_resp = make_response(json=[{"name_value": "other.notexample.com"}])
 
         with patch("requests.get", return_value=mock_resp):
             result = cert_transparency("example.com")
 
         assert result == []
 
-    def test_deduplicates_results(self):
-        mock_resp = MagicMock()
-        mock_resp.raise_for_status = MagicMock()
-        mock_resp.json.return_value = [
-            {"name_value": "api.example.com"},
-            {"name_value": "api.example.com"},
-        ]
+    def test_deduplicates_results(self, make_response):
+        mock_resp = make_response(
+            json=[
+                {"name_value": "api.example.com"},
+                {"name_value": "api.example.com"},
+            ]
+        )
 
         with patch("requests.get", return_value=mock_resp):
             result = cert_transparency("example.com")

--- a/tests/test_scan_mode.py
+++ b/tests/test_scan_mode.py
@@ -102,12 +102,10 @@ class TestScanMode:
 
 
 class TestAdaptiveSleep:
-    def test_sleeps_for_given_delay(self, monkeypatch):
-        import importlib
-
+    def test_sleeps_for_given_delay(self, monkeypatch, reload_module):
         import config as cfg_module
 
-        importlib.reload(cfg_module)
+        reload_module(cfg_module)
         from tools._helpers import adaptive_sleep
 
         with patch("time.sleep") as mock_sleep:
@@ -130,14 +128,12 @@ class TestAdaptiveSleep:
             new_delay = adaptive_sleep(50.0, 429)
         assert new_delay == 60.0
 
-    def test_200_recovers_elevated_delay(self, monkeypatch):
+    def test_200_recovers_elevated_delay(self, monkeypatch, reload_module):
         monkeypatch.delenv("SCAN_MODE", raising=False)
         monkeypatch.setenv("SCAN_DELAY", "0.5")
-        import importlib
-
         import config as cfg_module
 
-        importlib.reload(cfg_module)
+        reload_module(cfg_module)
         from tools._helpers import adaptive_sleep
 
         with patch("time.sleep"):
@@ -145,26 +141,22 @@ class TestAdaptiveSleep:
         # should recover towards base (0.5) by 10%
         assert new_delay == pytest.approx(9.0, rel=0.01)
 
-    def test_200_at_base_delay_stays_constant(self, monkeypatch):
+    def test_200_at_base_delay_stays_constant(self, monkeypatch, reload_module):
         monkeypatch.setenv("SCAN_DELAY", "0.5")
-        import importlib
-
         import config as cfg_module
 
-        importlib.reload(cfg_module)
+        reload_module(cfg_module)
         from tools._helpers import adaptive_sleep
 
         with patch("time.sleep"):
             new_delay = adaptive_sleep(0.5, 200)
         assert new_delay == 0.5
 
-    def test_recovery_does_not_go_below_base(self, monkeypatch):
+    def test_recovery_does_not_go_below_base(self, monkeypatch, reload_module):
         monkeypatch.setenv("SCAN_DELAY", "0.5")
-        import importlib
-
         import config as cfg_module
 
-        importlib.reload(cfg_module)
+        reload_module(cfg_module)
         from tools._helpers import adaptive_sleep
 
         # elevated by only a hair above base

--- a/tests/test_squad_tools.py
+++ b/tests/test_squad_tools.py
@@ -13,12 +13,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 # ----------------------------------------------------------------------------
 # Programme Manager
 # ----------------------------------------------------------------------------
 
 
-@pytest.mark.unit
 class TestProgrammeManagerTools:
     def test_list_programmes_tool(self) -> None:
         from squad.programme_manager import list_programmes_tool
@@ -68,7 +69,6 @@ class TestProgrammeManagerTools:
 # ----------------------------------------------------------------------------
 
 
-@pytest.mark.unit
 class TestOsintAnalystTools:
     def test_recon_tool(self, programme, recon_result) -> None:
         from squad.osint_analyst import recon_tool
@@ -134,7 +134,6 @@ class TestOsintAnalystTools:
 # ----------------------------------------------------------------------------
 
 
-@pytest.mark.unit
 class TestVulnerabilityResearcherTools:
     def test_triage_tool(self, raw_finding_high, programme, verified_vuln) -> None:
         from squad.vulnerability_researcher import triage_tool
@@ -224,7 +223,6 @@ class TestVulnerabilityResearcherTools:
 # ----------------------------------------------------------------------------
 
 
-@pytest.mark.unit
 class TestTechnicalAuthorTools:
     def test_create_report_tool(self, verified_vuln, disclosure_report) -> None:
         from squad.technical_author import create_report_tool
@@ -262,7 +260,6 @@ class TestTechnicalAuthorTools:
 # ----------------------------------------------------------------------------
 
 
-@pytest.mark.unit
 class TestDisclosureCoordinatorTools:
     def test_submit_report_tool(self, disclosure_report) -> None:
         from squad.disclosure_coordinator import submit_report_tool
@@ -318,7 +315,6 @@ class TestDisclosureCoordinatorTools:
 # ----------------------------------------------------------------------------
 
 
-@pytest.mark.unit
 class TestPenetrationTesterTools:
     def test_nuclei_scan_tool(self, endpoint, raw_finding_low) -> None:
         from squad.penetration_tester import nuclei_scan_tool

--- a/tests/test_xss.py
+++ b/tests/test_xss.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -13,14 +13,12 @@ pytestmark = pytest.mark.unit
 
 
 class TestCheckReflectedXss:
-    def test_detects_unescaped_reflection(self, victim_url: str):
+    def test_detects_unescaped_reflection(self, victim_url: str, make_response):
         ep = Endpoint(url=f"{victim_url}/search", status_code=200, parameters=["q"])
 
         def fake_get(url, **kwargs):
             canary = url.split("q=")[1]
-            resp = MagicMock()
-            resp.text = f"<html><body>Results for {canary}</body></html>"
-            return resp
+            return make_response(body=f"<html><body>Results for {canary}</body></html>")
 
         with patch("requests.get", side_effect=fake_get):
             results = check_reflected_xss([ep])
@@ -30,27 +28,24 @@ class TestCheckReflectedXss:
         assert results[0].severity_hint == Severity.HIGH
         assert "q" in results[0].evidence
 
-    def test_no_finding_when_canary_is_html_encoded(self, victim_url: str):
+    def test_no_finding_when_canary_is_html_encoded(self, victim_url: str, make_response):
         ep = Endpoint(url=f"{victim_url}/search", status_code=200, parameters=["q"])
 
         def fake_get(url, **kwargs):
-            resp = MagicMock()
             # Application HTML-encodes < and >
-            resp.text = "<html><body>Results for &lt;cybersquad-xss-test&gt;</body></html>"
-            return resp
+            encoded = "&lt;cybersquad-xss-test&gt;"
+            return make_response(body=f"<html><body>Results for {encoded}</body></html>")
 
         with patch("requests.get", side_effect=fake_get):
             results = check_reflected_xss([ep])
 
         assert results == []
 
-    def test_no_finding_when_canary_absent_from_response(self, victim_url: str):
+    def test_no_finding_when_canary_absent_from_response(self, victim_url: str, make_response):
         ep = Endpoint(url=f"{victim_url}/search", status_code=200, parameters=["q"])
 
         def fake_get(url, **kwargs):
-            resp = MagicMock()
-            resp.text = "<html><body>No results found</body></html>"
-            return resp
+            return make_response(body="<html><body>No results found</body></html>")
 
         with patch("requests.get", side_effect=fake_get):
             results = check_reflected_xss([ep])
@@ -71,7 +66,7 @@ class TestCheckReflectedXss:
         mock_get.assert_not_called()
         assert results == []
 
-    def test_deduplicates_multiple_reflecting_params(self, victim_url: str):
+    def test_deduplicates_multiple_reflecting_params(self, victim_url: str, make_response):
         ep = Endpoint(
             url=f"{victim_url}/search",
             status_code=200,
@@ -83,12 +78,8 @@ class TestCheckReflectedXss:
             for key in ("q=", "category="):
                 if key in url:
                     canary = url.split(key)[1]
-                    resp = MagicMock()
-                    resp.text = f"<html>{canary}</html>"
-                    return resp
-            resp = MagicMock()
-            resp.text = "<html></html>"
-            return resp
+                    return make_response(body=f"<html>{canary}</html>")
+            return make_response(body="<html></html>")
 
         with patch("requests.get", side_effect=fake_get):
             results = check_reflected_xss([ep])
@@ -102,7 +93,7 @@ class TestCheckReflectedXss:
             results = check_reflected_xss([ep])
         assert results == []
 
-    def test_canary_includes_angle_brackets(self, victim_url: str):
+    def test_canary_includes_angle_brackets(self, victim_url: str, make_response):
         """The canary must be a real tag to test for XSS, not just text."""
         ep = Endpoint(url=f"{victim_url}/", status_code=200, parameters=["x"])
 
@@ -110,9 +101,7 @@ class TestCheckReflectedXss:
 
         def fake_get(url, **kwargs):
             seen_urls.append(url)
-            resp = MagicMock()
-            resp.text = ""
-            return resp
+            return make_response(body="")
 
         with patch("requests.get", side_effect=fake_get):
             check_reflected_xss([ep])


### PR DESCRIPTION
Closes #116

Fixes all eight issues identified in the test suite review.

## Changes

### Safety (highest priority)
- **`test_h1_api.py`**: Add two missing safety-gate tests — `"automated scanning prohibited"` and `"no scanners"` were both untested. Removing either keyword from `parse_programme()` would have passed CI undetected.

### Correctness
- **`test_squad_tools.py`**: Move `pytestmark` from per-class decorators to module level. Per-class markers would silently exclude any top-level test function added in future from `pytest -m unit` runs.

### Consistency — use shared fixtures
- **`test_recon_tools.py`** (`TestCertTransparency`): Replace 4× hand-rolled `MagicMock()` HTTP responses with the `make_response` conftest factory.
- **`test_xss.py`**: Replace all bare `MagicMock()` closures with `make_response`; remove now-unused `MagicMock` import.

### Centralise `importlib.reload` pattern
- **`conftest.py`**: Add `reload_module` fixture (wraps `importlib.reload`) so tests don't each inline `import importlib; importlib.reload(...)`.
- **`test_scan_mode.py`**: Update `TestAdaptiveSleep` to use the new fixture.

### CI
- **`ci.yml`**: Add `needs: [lint]` to the `test` job — lint and tests were running in parallel, so a failing lint could show alongside green tests.
- **`ci.yml`**: Remove dead `--cov-report=xml:coverage.xml` flag; the file was generated but never uploaded or consumed.

## Test results
734 tests, 0 failures, 91.15% coverage (floor: 90%).
