### PR TITLE
feat(ta): make the Technical Author actually author

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,4 +23,5 @@ cybersquad is a six-agent CrewAI pipeline that autonomously selects HackerOne bu
 | `tools/pentest/` | Pentest tools: nuclei, sqlmap, CORS, SSRF, XSS, SRI, header injection, source maps, error disclosure. |
 | `tools/cloud/` | Cloud/service checks: S3, Azure Blob, per-engine databases, admin panels, branded panels. |
 | `tools/cloud/databases/` | Per-engine unauthenticated database checks: one file per engine. |
-| `tools/report_tools.py` | Renders Markdown reports and writes them to disk. |
+| `tools/report_tools.py` | Authoring primitives for the Technical Author: evidence sanitisation, draft persistence, quality validation, and final consolidation into reports.json. |
+| `tools/cwe_data.py` / `tools/owasp_data.py` | Local CWE / OWASP cheat-sheet catalogues the Technical Author cites in disclosure reports. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,10 +18,12 @@ cybersquad is a six-agent CrewAI pipeline that autonomously selects HackerOne bu
 | `squad/<member>/{description,expected_output}.md` | Two single-purpose files driving the Task description and expected output. |
 | `squad/<member>/__init__.py` | Tool functions (`@tool`) + a module-level `MEMBER = SquadMember(...)` constant. |
 | `tools/h1_api.py` | HackerOne REST client. Singleton: `from tools.h1_api import h1`. |
-| `tools/recon/` | Recon tools: subfinder, httpx, nmap, TLS, DNS, dirfuzz, waybackurls, cert transparency, traceroute, scope guard. |
+| `tools/recon/` | Recon tools: subfinder, httpx, dnsx (subdomain-takeover detection), nmap, TLS, DNS, dirfuzz, waybackurls, cert transparency, traceroute, scope guard. |
 | `tools/recon/scope.py` | `filter_in_scope()` - hard scope enforcement boundary. Do not weaken. |
+| `tools/recon_insights.py` | Host-annotation authoring primitives for the OSINT Analyst: HostInsight persistence, quality validation, and final consolidation of sweep.json + insights into recon.json. |
 | `tools/pentest/` | Pentest tools: nuclei, sqlmap, CORS, SSRF, XSS, SRI, header injection, source maps, error disclosure. |
 | `tools/cloud/` | Cloud/service checks: S3, Azure Blob, per-engine databases, admin panels, branded panels. |
 | `tools/cloud/databases/` | Per-engine unauthenticated database checks: one file per engine. |
+| `tools/triage_tools.py` | Authoring primitives for the Vulnerability Researcher: per-finding assessment / discard, quality validation, and final consolidation into verified.json. |
 | `tools/report_tools.py` | Authoring primitives for the Technical Author: evidence sanitisation, draft persistence, quality validation, and final consolidation into reports.json. |
-| `tools/cwe_data.py` / `tools/owasp_data.py` | Local CWE / OWASP cheat-sheet catalogues the Technical Author cites in disclosure reports. |
+| `tools/cwe_data.py` / `tools/owasp_data.py` | Local CWE / OWASP cheat-sheet catalogues both the Vulnerability Researcher and Technical Author cite. |

--- a/install-tools.sh
+++ b/install-tools.sh
@@ -6,7 +6,7 @@
 #
 # Tools installed:
 #   Go (if absent or < 1.22): official tarball from go.dev
-#   go install: subfinder, httpx, nuclei, ffuf, waybackurls
+#   go install: subfinder, httpx, nuclei, ffuf, waybackurls, dnsx
 #   apt         : nmap, sqlmap
 #   git clone   : testssl.sh -> /usr/local/bin/testssl.sh
 
@@ -90,6 +90,7 @@ declare -A GO_TOOLS=(
   [nuclei]="github.com/projectdiscovery/nuclei/v3/cmd/nuclei"
   [ffuf]="github.com/ffuf/ffuf/v2@latest"
   [waybackurls]="github.com/tomnomnom/waybackurls"
+  [dnsx]="github.com/projectdiscovery/dnsx/cmd/dnsx"
 )
 
 for tool in "${!GO_TOOLS[@]}"; do
@@ -155,7 +156,7 @@ echo "==> PATH is updated. Run 'source ~/.bashrc' (or open a new terminal) to us
 
 echo ""
 echo "==> Tool check:"
-for tool in subfinder httpx nmap nuclei ffuf waybackurls sqlmap testssl.sh; do
+for tool in subfinder httpx dnsx nmap nuclei ffuf waybackurls sqlmap testssl.sh; do
   if need "${tool}"; then
     echo "  [ok]      ${tool} -> $(command -v ${tool})"
   else

--- a/models.py
+++ b/models.py
@@ -96,6 +96,57 @@ class EndpointPage(BaseModel):
     endpoints: list[Endpoint]
 
 
+class HostRole(StrEnum):
+    """The role a host plays in the programme's attack surface.
+
+    Drives priority decisions downstream: an ``ADMIN`` host with a known
+    framework is a higher-value pentest target than a ``CDN`` host that
+    serves static assets.
+    """
+
+    ADMIN = "admin"  # admin / control-plane UIs
+    API = "api"  # REST / GraphQL / SOAP endpoints
+    AUTH = "auth"  # SSO, OAuth, login, password reset
+    APP = "app"  # main user-facing application
+    CDN = "cdn"  # static asset delivery, edge caches
+    STATIC = "static"  # purely static content (marketing, blog, docs)
+    MAIL = "mail"  # SMTP / IMAP / MX hosts
+    INFRA = "infra"  # name servers, monitoring, IaaS
+    DEV = "dev"  # dev / staging / beta surfaces
+    UNKNOWN = "unknown"
+
+
+class HostPriority(StrEnum):
+    """The OSINT Analyst's curation signal for downstream agents.
+
+    The Penetration Tester biases probe budget toward ``HIGH`` hosts; the
+    Vulnerability Researcher prioritises CVE / report-history research for
+    them. ``SKIP`` is a hard signal not to probe (third-party-managed, known
+    decoy, etc.)."""
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    SKIP = "skip"
+
+
+class HostInsight(BaseModel):
+    """One OSINT Analyst-authored annotation for a single host.
+
+    The sweep produces ``subdomains`` / ``endpoints`` / ``open_ports`` /
+    ``technologies`` as raw inventory; ``HostInsight`` is the agent's
+    curation layer that tells downstream agents WHERE to look first and
+    WHY.
+    """
+
+    hostname: str
+    role: HostRole
+    priority: HostPriority
+    notes: str  # agent-authored, >= 30 chars
+    detected_tech: list[str] = Field(default_factory=list)  # ideally with versions
+    annotated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
 class ReconResult(BaseModel):
     """Everything the OSINT Analyst found about a programme's attack surface."""
 
@@ -111,6 +162,9 @@ class ReconResult(BaseModel):
     # hostname -> ordered list of public hop IPs from traceroute.
     # Useful for identifying origin IPs behind CDNs/WAFs (CDN bypass vector).
     network_hops: dict[str, list[str]] = Field(default_factory=dict)
+    # Per-host curation the OSINT Analyst authors via Annotate Host. Empty on
+    # the OA's internal sweep.json; populated on the final recon.json.
+    host_insights: list[HostInsight] = Field(default_factory=list)
     completed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
 

--- a/squad/osint_analyst/__init__.py
+++ b/squad/osint_analyst/__init__.py
@@ -2,43 +2,120 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from crewai.tools import tool
 
-from models import Endpoint
+import runtime
+from models import Endpoint, HostInsight, HostPriority, HostRole, Programme
 from squad import SquadMember, read_run_file_tool, read_run_filelist_tool
-from tools import http
+from tools import cwe_data, http, owasp_data
 from tools.h1_api import h1
-from tools.recon import cert_transparency, detect_llm_endpoints, historical_urls, run_recon
+from tools.recon import (
+    cert_transparency,
+    detect_llm_endpoints,
+    detect_takeover_candidates,
+    historical_urls,
+    run_recon,
+)
+from tools.recon import probe_endpoints as probe_endpoints_impl
+from tools.recon.query import recon_endpoints, recon_open_ports, recon_subdomains
+from tools.recon.scope import filter_in_scope as filter_in_scope_impl
+from tools.recon_insights import (
+    ReconFinalisationError,
+    finalise_recon,
+    save_insight,
+    uncovered_interesting_hosts,
+    validate_insight,
+)
+from tools.recon_insights import (
+    load_insights as load_insights_impl,
+)
+from tools.recon_insights import (
+    load_sweep as load_sweep_impl,
+)
 
 
-@tool("Run Recon")
-def recon_tool(programme_handle: str) -> str:
+@tool("Run Initial Sweep")
+def run_initial_sweep_tool(programme_handle: str) -> str:
     """
-    Run full OSINT recon (subdomain enumeration, HTTP probing, port scanning)
-    against the in-scope assets of the given programme handle. Writes the
-    serialised ReconResult to recon.json in the run directory and returns
-    the relative filename for downstream agents to read.
-    """
-    import runtime
+    Run the initial OSINT sweep against the in-scope assets of the given
+    programme: subfinder for subdomain enumeration, httpx for live HTTP/S
+    probing and tech detection, nmap for port scanning, ffuf for content
+    discovery, plus passive TLS and DNS email-security checks. Writes the
+    serialised inventory to ``sweep.json`` (the OA's internal draft) in the
+    run directory and returns the relative filename.
 
+    This is the inventory step. Annotate the interesting hosts with
+    Annotate Host and call Finalise Recon to produce the canonical
+    ``recon.json`` that downstream agents consume.
+    """
     http.set_programme(programme_handle)
     policy = h1.get_programme_policy(programme_handle)
     scope = h1.get_structured_scope(programme_handle)
     programme = h1.parse_programme(policy["data"], scope)
     result = run_recon(programme)
-    out_path = runtime.run_dir() / "recon.json"
+    out_path = runtime.run_dir() / "sweep.json"
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(result.model_dump_json(), encoding="utf-8")
-    return "recon.json"
+    return "sweep.json"
+
+
+@tool("Recon Subdomains")
+def recon_subdomains_tool(sweep_path: str = "sweep.json", host_filter: str | None = None) -> list:
+    """
+    Return the in-scope subdomains in the OA's draft sweep. ``host_filter`` is
+    a case-insensitive substring (e.g. "api" returns every subdomain
+    containing "api"). Use this to inspect the sweep before deciding which
+    hosts to annotate.
+    """
+    return recon_subdomains(sweep_path, host_filter=host_filter)
+
+
+@tool("Recon Endpoints")
+def recon_endpoints_tool(
+    sweep_path: str = "sweep.json",
+    status: int | None = None,
+    tech: str | None = None,
+    host_contains: str | None = None,
+    offset: int = 0,
+    limit: int = 50,
+) -> dict:
+    """
+    Return a paginated slice of endpoints from the sweep matching the given
+    filters (conjunctive). ``tech`` matches case-insensitively as a
+    substring against each endpoint's technologies; ``host_contains``
+    matches the URL. Use this to find which hostnames run a given stack
+    before annotating.
+    """
+    return recon_endpoints(
+        sweep_path,
+        status=status,
+        tech=tech,
+        host_contains=host_contains,
+        offset=offset,
+        limit=limit,
+    ).model_dump(mode="json")
+
+
+@tool("Recon Open Ports")
+def recon_open_ports_tool(sweep_path: str = "sweep.json", host: str | None = None) -> dict:
+    """
+    Return the open-port map per host from the sweep. Passing a ``host``
+    restricts the result to that single host. Use to surface non-HTTP
+    services (Redis 6379, Elasticsearch 9200, Mongo 27017, etc.) that an
+    annotation should call out.
+    """
+    return recon_open_ports(sweep_path, host=host)
 
 
 @tool("Certificate Transparency Lookup")
 def cert_transparency_tool(domain: str) -> list[str]:
     """
-    Query crt.sh certificate transparency logs to discover subdomains not found
-    by active enumeration. Returns deduplicated hostnames.
+    Query crt.sh certificate transparency logs to discover subdomains not
+    found by active enumeration. Returns deduplicated hostnames. Feed
+    newly discovered hosts to Probe Hostnames to determine which are live.
     """
     return cert_transparency(domain)
 
@@ -46,8 +123,9 @@ def cert_transparency_tool(domain: str) -> list[str]:
 @tool("Historical URL Discovery")
 def historical_urls_tool(domain: str) -> list[str]:
     """
-    Use waybackurls to find historical endpoints for a domain from the Wayback
-    Machine. Surfaces paths that may no longer be linked but still exist.
+    Use waybackurls to find historical endpoints for a domain from the
+    Wayback Machine. Surfaces paths that may no longer be linked but still
+    exist - candidates for Probe Hostnames.
     """
     return historical_urls(domain)
 
@@ -55,37 +133,229 @@ def historical_urls_tool(domain: str) -> list[str]:
 @tool("LLM Endpoint Detection")
 def llm_detection_tool(endpoints_json: str) -> list[dict]:
     """
-    Scan a set of live endpoints for signals that they are backed by an LLM or
-    AI assistant. Uses two methods:
-
-    1. URL path inspection - checks path segments against known LLM tokens
-       (chat, ask, ai, assistant, completions, generate, copilot, etc.)
-    2. Response probing - checks HTTP headers (OpenAI gateway headers), content
-       type (text/event-stream for streaming responses), JSON structure
-       (OpenAI-format choices/tokens keys), and body text (AI self-identification
-       phrases).
-
-    endpoints_json: JSON array of endpoint objects from ReconResult. Pass the
-      full endpoint list after run_recon completes - the tool filters internally.
-      Example: '[{"url": "https://example.com/chat", "status_code": 200}]'
-
-    Returns endpoint dicts tagged with 'LLM' in their technologies list. Pass
-    these to the Penetration Tester for prompt injection testing.
+    Scan a set of live endpoints for signals that they are backed by an LLM
+    or AI assistant (URL path heuristics, OpenAI-format response keys,
+    EventSource content-type, self-identification phrases). Pass the
+    sweep's endpoint list (or a filtered subset) as JSON. Returned hits
+    deserve a HIGH-priority annotation and a note pointing the Penetration
+    Tester at prompt-injection probes.
     """
-    import json
-
     endpoints = [Endpoint.model_validate(e) for e in json.loads(endpoints_json)]
     return [ep.model_dump() for ep in detect_llm_endpoints(endpoints)]
+
+
+@tool("Probe Hostnames")
+def probe_hostnames_tool(hostnames: list[str], programme_handle: str) -> list[dict]:
+    """
+    Re-probe a list of hostnames with httpx to confirm liveness, capture
+    status codes, and fingerprint technologies. Use this on hostnames
+    surfaced by Certificate Transparency or Historical URL Discovery that
+    were not in the initial sweep.
+
+    The hostnames are filtered against the programme's structured scope
+    before any HTTP traffic is generated; out-of-scope hostnames are
+    dropped silently (we never probe outside scope, even for fingerprinting).
+    Returns ``[{url, status_code, technologies, parameters}]``. Net-new
+    endpoints can then be annotated with Annotate Host.
+    """
+    if not hostnames:
+        return []
+    programme = _load_programme(programme_handle)
+    in_scope = filter_in_scope_impl([h.strip().lower() for h in hostnames if h.strip()], programme)
+    if not in_scope:
+        return []
+    eps = probe_endpoints_impl(in_scope)
+    return [ep.model_dump(mode="json") for ep in eps]
+
+
+@tool("Detect Takeover Candidates")
+def detect_takeover_candidates_tool(hostnames: list[str], programme_handle: str) -> list[dict]:
+    """
+    Resolve each hostname via dnsx and flag subdomain-takeover candidates.
+
+    A candidate is flagged when the host's CNAME points to a known-vulnerable
+    provider (AWS S3, Heroku, GitHub Pages, Azure, Vercel, Netlify, ...) or
+    when the CNAME chain dangles (CNAME exists but resolves to no A records).
+    Returns ``[{hostname, cname, reason, service}]`` where ``reason`` is one
+    of ``cname_to_vulnerable_provider`` or ``dangling_cname``.
+
+    Each candidate is exactly that - a candidate. Follow up by annotating
+    the host HIGH priority with a note pointing the Penetration Tester at
+    the service-specific confirmation step (probe the host and check for
+    the "no such bucket" / "no such app" / "there isn't a GitHub Pages
+    site here" body fingerprint).
+
+    Hostnames are scope-filtered before any DNS traffic is generated.
+    """
+    if not hostnames:
+        return []
+    programme = _load_programme(programme_handle)
+    in_scope = filter_in_scope_impl([h.strip().lower() for h in hostnames if h.strip()], programme)
+    if not in_scope:
+        return []
+    candidates = detect_takeover_candidates(in_scope)
+    return [c.model_dump(mode="json") for c in candidates]
+
+
+@tool("Lookup CWE")
+def lookup_cwe_tool(query: str) -> list[dict]:
+    """
+    Find Common Weakness Enumeration entries that match a query - useful
+    when annotating a host whose detected tech has a well-known weakness
+    class (e.g. "WordPress" -> XSS / SQLi; "Spring Boot" -> SSTI / RCE).
+    Returns each match's cwe_id, name, short description, and the matching
+    OWASP cheat-sheet topic.
+    """
+    entries = cwe_data.lookup(query)
+    return [
+        {
+            "cwe_id": e.cwe_id,
+            "name": e.name,
+            "description": e.description,
+            "url": e.url,
+            "owasp_topic": e.owasp_topic,
+        }
+        for e in entries
+    ]
+
+
+@tool("Lookup OWASP Guidance")
+def lookup_owasp_tool(query: str) -> list[dict]:
+    """
+    Find OWASP Cheat Sheet entries for a vuln class or topic - hint for
+    the downstream VR's attack-plan reasoning. Returns each match's title,
+    key_principles, and the canonical cheatsheetseries.owasp.org URL.
+    """
+    entries = owasp_data.lookup(query)
+    return [
+        {
+            "topic": e.topic,
+            "title": e.title,
+            "url": e.url,
+            "key_principles": e.key_principles,
+        }
+        for e in entries
+    ]
+
+
+@tool("Annotate Host")
+def annotate_host_tool(
+    hostname: str,
+    role: str,
+    priority: str,
+    notes: str,
+    detected_tech: list[str] | None = None,
+    sweep_path: str = "sweep.json",
+    programme_handle: str | None = None,
+) -> dict:
+    """
+    Author one HostInsight for a single hostname and run the quality gate.
+
+    Inputs:
+      - hostname: a hostname from the sweep, or one newly discovered via
+        Certificate Transparency / Historical URL Discovery / Probe Hostnames
+      - role: one of admin, api, auth, app, cdn, static, mail, infra, dev,
+        unknown
+      - priority: one of high, medium, low, skip - the curation signal the
+        Penetration Tester uses to allocate probe budget
+      - notes: >= 30 chars (>= 60 for high-priority), explaining what the
+        host is, what tech runs on it, and why it matters (or does not)
+      - detected_tech: ideally with versions ("Spring Boot 2.6.3" beats
+        "Spring Boot"); the warning fires when the sweep saw tech that the
+        annotation drops
+
+    Returns ``{"path": "host_insights/HOST.json", "validation": {ok, issues}}``.
+    Re-run with the issues addressed when validation.ok is false.
+    """
+    sweep = load_sweep_impl(sweep_path)
+    programme = _load_programme(programme_handle)
+
+    insight = HostInsight(
+        hostname=hostname.strip().lower(),
+        role=HostRole(role),
+        priority=HostPriority(priority),
+        notes=notes.strip(),
+        detected_tech=[t.strip() for t in (detected_tech or []) if t.strip()],
+    )
+    path = save_insight(insight)
+    report = validate_insight(insight, sweep, programme)
+    return {
+        "path": str(path.relative_to(path.parents[1])),
+        "validation": report.model_dump(),
+    }
+
+
+@tool("Uncovered Hosts")
+def uncovered_hosts_tool(sweep_path: str = "sweep.json") -> list[str]:
+    """
+    Return interesting-status hostnames in the sweep (200, 301, 302, 401,
+    403, ...) that have no insight yet. Use as a checklist before calling
+    Finalise Recon - hosts you choose to leave uncovered should at least be
+    a deliberate decision.
+    """
+    sweep = load_sweep_impl(sweep_path)
+    insights = load_insights_impl()
+    return uncovered_interesting_hosts(sweep, insights)
+
+
+@tool("Finalise Recon")
+def finalise_recon_tool(
+    programme_handle: str,
+    sweep_path: str = "sweep.json",
+) -> str:
+    """
+    Consolidate the sweep + every authored HostInsight into recon.json for
+    the Vulnerability Researcher and Penetration Tester. Refuses if no
+    insights have been authored, if any insight has unresolved validation
+    errors, or if the surface is non-empty but no host has been marked
+    HIGH priority. Returns the bare filename ``recon.json`` on success.
+    """
+    programme = _load_programme(programme_handle)
+    try:
+        path = finalise_recon(programme, sweep_filename=sweep_path)
+    except ReconFinalisationError as exc:
+        raise ValueError(str(exc)) from exc
+    return path.name
+
+
+# Helpers
+
+
+def _load_programme(programme_handle: str | None) -> Programme:
+    """Fetch and parse the Programme - the scope guard in validate_insight
+    needs a real Programme to check against."""
+    if not programme_handle:
+        raise ValueError("programme_handle is required")
+    http.set_programme(programme_handle)
+    policy = h1.get_programme_policy(programme_handle)
+    scope = h1.get_structured_scope(programme_handle)
+    return h1.parse_programme(policy["data"], scope)
 
 
 MEMBER = SquadMember(
     slug="osint_analyst",
     dir=Path(__file__).parent,
     tools=[
-        recon_tool,
+        # Sweep
+        run_initial_sweep_tool,
+        # Inspect the sweep
+        recon_subdomains_tool,
+        recon_endpoints_tool,
+        recon_open_ports_tool,
+        # Supplementary discovery
         cert_transparency_tool,
         historical_urls_tool,
+        probe_hostnames_tool,
+        detect_takeover_candidates_tool,
         llm_detection_tool,
+        # Citation hints
+        lookup_cwe_tool,
+        lookup_owasp_tool,
+        # Authoring + finalisation
+        annotate_host_tool,
+        uncovered_hosts_tool,
+        finalise_recon_tool,
+        # Workspace
         read_run_filelist_tool,
         read_run_file_tool,
     ],

--- a/squad/osint_analyst/recon/description.md
+++ b/squad/osint_analyst/recon/description.md
@@ -1,27 +1,69 @@
-Using the programme selected in the previous task, run full OSINT
-reconnaissance against all in-scope assets:
-  - Enumerate subdomains using subfinder
-  - Probe live HTTP/S endpoints with httpx
-  - Perform lightweight port scanning on live hosts
-  - Identify technology stacks
+Map the in-scope attack surface for the programme selected in the previous
+task. The Vulnerability Researcher reads your output to plan an attack; the
+Penetration Tester allocates probe budget against your priorities. A flat
+list of subdomains is not useful - the curation is the deliverable.
 
-Strictly enforce scope - do not interact with any asset not listed
-as in-scope.
+Your workflow:
 
-When recon is complete, use Recon Subdomains, Recon Endpoints (filtered
-by status and tech), and Recon Open Ports to query the data you just
-wrote. Derive the briefing from what those tools return - do not write
-it from memory. The briefing is the headline; recon.json is the
-reference. Cover:
+  1. Call Run Initial Sweep with the programme handle. The sweep runs
+     subfinder, httpx, nmap, ffuf, plus passive TLS and DNS email-security
+     checks and writes the inventory to ``sweep.json``. Returns the bare
+     filename so you can pass it to the query tools.
 
-  - Top detected technologies and the hostnames they appear on
-    (especially WordPress / Spring / Apache / Joomla / Drupal versions
-    if known - any version is a starting point for CVE research)
-  - Subdomains worth a closer look (admin.*, api.*, internal.*, dev.*,
-    staging.*, *.s3.amazonaws.com, *.blob.core.windows.net)
-  - Open ports that hint at running services (6379 Redis, 9200 Elastic-
-    search, 5984 CouchDB, 27017 MongoDB, 3306/5432 DB, 2082/2083 cPanel,
-    10000 Webmin, etc.)
-  - Passive findings already collected (TLS issues, DNS misconfigs) -
-    flag the high-signal ones, do not enumerate them all
-  - Anything else that looks unusual or high-value
+  2. Inspect the sweep using Recon Subdomains, Recon Endpoints (filtered
+     by status, tech, host), and Recon Open Ports. Do not load the whole
+     file - the typed queries return focused slices.
+
+  3. Optionally widen the surface:
+     - Certificate Transparency Lookup on each seed domain (subdomains that
+       hold a valid cert but did not respond to subfinder).
+     - Historical URL Discovery on each seed (paths that may no longer be
+       linked).
+     - Probe Hostnames on net-new hostnames from those discoveries -
+       returns live status + tech.
+     - Detect Takeover Candidates on the full sweep's subdomains (CNAMEs
+       pointing at S3 / Heroku / GitHub Pages / Azure / Vercel / Netlify /
+       Fastly, or dangling CNAMEs). Hits warrant a HIGH-priority annotation
+       and a note pointing the Penetration Tester at the service-specific
+       confirmation fingerprint.
+     - LLM Endpoint Detection on the sweep's endpoints - any hit is a
+       high-priority annotation candidate for prompt-injection testing.
+
+  4. Annotate the interesting hosts. For each, call Annotate Host with:
+
+     - **role**: ``admin``, ``api``, ``auth``, ``app``, ``cdn``, ``static``,
+       ``mail``, ``infra``, ``dev``, or ``unknown``. Pick the closest fit.
+     - **priority**: ``high`` (PT spends budget here), ``medium`` (worth a
+       probe pass), ``low`` (likely boring), or ``skip`` (do not probe -
+       third-party-managed, decoy, sensitive).
+     - **notes**: >= 30 chars (>= 60 for high-priority). What the host is,
+       what tech runs on it, what makes it interesting - one to three
+       sentences. Specific beats vague: "Spring Boot 2.6.3 API gateway
+       with /actuator visible; CVE-2022-22965 applies" is good. "API
+       host" is not.
+     - **detected_tech**: ideally with versions. The gate warns when you
+       drop tech the sweep detected.
+
+     Use Lookup CWE / Lookup OWASP Guidance to ground a note in known
+     weakness classes for the tech you saw - "WordPress 5.8 -> CWE-79
+     stored XSS via plugin admin paths" is the kind of pointer the
+     downstream VR consumes directly.
+
+  5. Use Uncovered Hosts to list interesting-status hostnames in the sweep
+     that you have not annotated yet. Leaving hosts uncovered is allowed
+     but should be deliberate - go back and annotate anything you missed.
+
+  6. Call Finalise Recon with the programme handle. The tool refuses if
+     any insight has unresolved errors or if no host has been marked HIGH
+     priority on a non-empty surface (the PT needs at least one focus
+     target). On success it consolidates the sweep + every insight into
+     ``recon.json`` and returns the bare filename.
+
+Scope is non-negotiable. Annotated hosts are scope-checked again at the
+gate; out-of-scope hosts must not be annotated. The sweep is already scope-
+filtered, but Certificate Transparency / Historical URL Discovery / Probe
+Hostnames may surface candidates that fall outside the programme's
+structured scope - drop those before annotating.
+
+The briefing you return below is the headline; ``recon.json`` is the
+reference the downstream agents read directly via their own query tools.

--- a/squad/osint_analyst/recon/expected_output.md
+++ b/squad/osint_analyst/recon/expected_output.md
@@ -1,19 +1,28 @@
 A short Markdown briefing (roughly 8-15 lines) for the Vulnerability
-Researcher, followed by the relative filename of the recon artefact
-written to the run directory (e.g. `recon.json`).
+Researcher, followed by the relative filename of the canonical recon
+artefact written to the run directory (i.e. ``recon.json``).
 
-The briefing should call out:
-  - Top detected technologies with the hostnames they appear on
-  - Subdomains worth a closer look (admin/api/internal/staging/dev,
-    cloud-storage hostnames)
-  - Open ports that hint at running services
-  - High-signal passive findings already collected
-  - Anything else unusual or high-value
+The briefing must call out:
 
-The full inventory lives in recon.json - the Vulnerability Researcher
-uses the recon query tools (Recon Subdomains, Recon Endpoints, Recon
-Open Ports) and Read Run File to drill into it on demand. The briefing
-is what tells them where to look first.
+  - The HIGH-priority hosts with one-line rationale each (role + tech +
+    why the budget goes here)
+  - Top detected technologies and the hostnames they appear on -
+    especially WordPress / Spring / Apache / Joomla / Drupal versions,
+    since any version unlocks CVE research downstream
+  - Subdomains worth a closer look that ended up MEDIUM but not HIGH
+    (e.g. staging, dev, internal) and why they did not earn HIGH
+  - Open ports that hint at running services (6379 Redis, 9200
+    Elasticsearch, 5984 CouchDB, 27017 MongoDB, 3306/5432 DB, 2082/2083
+    cPanel, 10000 Webmin, ...) - which annotated host they belong to
+  - High-signal passive findings already collected (TLS issues, DNS
+    misconfigurations) - flag the high-signal ones, do not enumerate
+    them all
+  - Any hosts you deliberately marked SKIP and the reason
+
+The full inventory and every authored insight live in ``recon.json`` -
+downstream agents use Recon Subdomains / Recon Endpoints / Recon Open
+Ports and Read Run File to drill into it on demand. The briefing tells
+them where to look first.
 
 Return the briefing followed on a separate line by the filename string
-(no prefix, no surrounding path - just `recon.json`).
+(no prefix, no surrounding path - just ``recon.json``).

--- a/squad/technical_author/__init__.py
+++ b/squad/technical_author/__init__.py
@@ -2,47 +2,81 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 from crewai.tools import tool
 
-import runtime
 from squad import SquadMember, read_run_file_tool, read_run_filelist_tool
+from tools import cwe_data, http, owasp_data
+from tools.h1_api import h1
 from tools.report_tools import (
+    FinalisationError,
+    ReportDraft,
     calculate_cvss_score,
-    create_disclosure_report,
-    save_report,
+    finalise_drafts,
+    load_verified,
+    sanitise_evidence,
+    save_draft,
+    validate_draft,
 )
 from tools.workspace import resolve_run_path
 
 
-@tool("Create Disclosure Reports")
-def create_reports_tool(verified_path: str, programme_handle: str, summary: str) -> str:
+@tool("Sanitise Evidence")
+def sanitise_evidence_tool(text: str) -> dict:
     """
-    Create a DisclosureReport for every VerifiedVulnerability in verified.json
-    and write them all to reports.json in the run directory. Returns the bare
-    filename "reports.json". The Disclosure Coordinator reads this file to
-    submit each finding independently.
-
-    ``summary`` is a 2-3 sentence executive summary covering the overall
-    session; it is included in each report alongside the finding detail.
+    Redact credentials, cookies, bearer tokens, JWTs, AWS keys and secret-shaped
+    key=value pairs from a chunk of evidence so it is safe to inline in a
+    public-by-default report. Returns {sanitised, redactions, warnings}.
+    Payloads (XSS strings, SQL injection vectors, SSRF URLs) are deliberately
+    NOT redacted - the disclosure is private and the triager needs the literal
+    request that proves the issue. Run this on the Penetration Tester's raw
+    evidence before pasting it into Draft Vulnerability Report.
     """
-    from models import VerifiedVulnerability
+    return sanitise_evidence(text).model_dump()
 
-    raw = json.loads(resolve_run_path(verified_path).read_text(encoding="utf-8"))
-    if not raw:
-        raise ValueError(f"No verified findings in {verified_path}")
-    verified = [VerifiedVulnerability.model_validate(v) for v in raw]
-    reports = []
-    for vuln in verified:
-        report = create_disclosure_report(programme_handle, vuln, summary)
-        save_report(report)
-        reports.append(report.model_dump(mode="json"))
-    out_path = runtime.run_dir() / "reports.json"
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(json.dumps(reports), encoding="utf-8")
-    return "reports.json"
+
+@tool("Lookup CWE")
+def lookup_cwe_tool(query: str) -> list[dict]:
+    """
+    Find Common Weakness Enumeration entries that match a query. Pass a
+    vuln_class string ("SQLi", "ReflectedXSS"), a CWE name ("Cross-Site
+    Scripting"), or a free-text keyword. Returns each match's cwe_id, name,
+    short description, MITRE URL, and the matching OWASP cheat-sheet topic so
+    you can chain to Lookup OWASP Guidance.
+    """
+    entries = cwe_data.lookup(query)
+    return [
+        {
+            "cwe_id": e.cwe_id,
+            "name": e.name,
+            "description": e.description,
+            "url": e.url,
+            "owasp_topic": e.owasp_topic,
+        }
+        for e in entries
+    ]
+
+
+@tool("Lookup OWASP Guidance")
+def lookup_owasp_tool(query: str) -> list[dict]:
+    """
+    Find OWASP Cheat Sheet entries that match a query (topic slug or title
+    keyword such as "sql injection", "ssrf", "authorization"). Returns each
+    match's title, key_principles (short, paste-friendly statements), and the
+    canonical cheatsheetseries.owasp.org URL to cite in the Remediation
+    section.
+    """
+    entries = owasp_data.lookup(query)
+    return [
+        {
+            "topic": e.topic,
+            "title": e.title,
+            "url": e.url,
+            "key_principles": e.key_principles,
+        }
+        for e in entries
+    ]
 
 
 @tool("Calculate CVSS Score")
@@ -50,17 +84,137 @@ def calculate_cvss_tool(vector: str) -> float:
     """
     Compute the CVSS 3.1 base score from a vector string such as
     CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H. Returns a value in 0.0-10.0.
-    Use this instead of guessing the score.
+    Use this instead of guessing the score; Draft Vulnerability Report verifies
+    that cvss_score matches the computed value before accepting the draft.
     """
     return calculate_cvss_score(vector)
+
+
+@tool("List Programme Reports")
+def list_programme_reports_tool(programme_handle: str, page_size: int = 25) -> list[dict]:
+    """
+    List recent public reports on this programme so you can write a title that
+    is distinct from existing submissions. Returns each report's id, title,
+    severity, and state. Use this BEFORE drafting if you suspect collision -
+    the Disclosure Coordinator will reject duplicates at submission time and a
+    well-differentiated title speeds up triage.
+    """
+    http.set_programme(programme_handle)
+    reports = h1.list_reports(programme_handle, page_size=page_size)
+    return [
+        {
+            "report_id": r.get("id"),
+            "title": r.get("attributes", {}).get("title"),
+            "severity": r.get("attributes", {}).get("severity_rating"),
+            "state": r.get("attributes", {}).get("state"),
+        }
+        for r in reports
+    ]
+
+
+@tool("Draft Vulnerability Report")
+def draft_report_tool(
+    finding_index: int,
+    title: str,
+    summary: str,
+    description: str,
+    steps_to_reproduce: list[str],
+    evidence: str,
+    impact: str,
+    remediation: str,
+    cvss_vector: str,
+    cwe_id: int,
+    verified_path: str = "verified.json",
+) -> dict:
+    """
+    Draft a single H1-format report for one verified finding and run quality
+    validation against it. The carried fields (target, vuln_class, severity)
+    are pulled from verified.json at ``finding_index`` so you cannot
+    accidentally contradict the Vulnerability Researcher.
+
+    Inputs are the prose the triager will read:
+      - title: `[Type] in [Component/Endpoint] allows [Outcome]`
+      - summary: 2-3 sentences (root cause + location + concrete impact)
+      - description: developer-focused explanation of WHY the code is vulnerable
+      - steps_to_reproduce: numbered list, each step at least 10 chars
+      - evidence: PRE-SANITISED tool output / HTTP excerpt; run Sanitise
+        Evidence first to strip credentials and cookies
+      - impact: specific, named data/system and worst realistic outcome
+      - remediation: actionable fix with an OWASP or CWE URL citation
+      - cvss_vector + cwe_id: must match the computed CVSS score and an entry
+        in the CWE catalogue
+
+    Returns {"path": "drafts/NNN.json", "validation": {ok, issues}}. When
+    ok is false, re-run with the issues addressed - Finalise Reports refuses
+    to consolidate drafts with unresolved errors.
+    """
+    verified = load_verified(resolve_run_path(verified_path))
+    if finding_index < 0 or finding_index >= len(verified):
+        raise ValueError(
+            f"finding_index {finding_index} out of range "
+            f"(verified.json has {len(verified)} findings)"
+        )
+    finding = verified[finding_index]
+
+    draft = ReportDraft(
+        finding_index=finding_index,
+        target=finding.target,
+        vuln_class=finding.vuln_class,
+        severity=finding.severity,
+        cvss_vector=cvss_vector,
+        cvss_score=calculate_cvss_score(cvss_vector),
+        cwe_id=cwe_id,
+        title=title.strip(),
+        summary=summary.strip(),
+        description=description.strip(),
+        steps_to_reproduce=[s.strip() for s in steps_to_reproduce],
+        evidence=evidence,
+        impact=impact.strip(),
+        remediation=remediation.strip(),
+    )
+    path = save_draft(draft)
+    report = validate_draft(draft)
+    return {
+        "path": str(path.relative_to(path.parents[1])),
+        "validation": report.model_dump(),
+    }
+
+
+@tool("Finalise Reports")
+def finalise_reports_tool(
+    programme_handle: str,
+    summary: str,
+    verified_path: str = "verified.json",
+) -> str:
+    """
+    Roll up every draft in the current run into reports.json for the Disclosure
+    Coordinator. Refuses if any draft is missing or has unresolved validation
+    errors; the error message lists exactly which draft / section needs work.
+
+    ``summary`` is a 2-3 sentence executive summary covering the overall
+    session; it is attached to every report.
+
+    Returns the bare filename "reports.json" on success.
+    """
+    verified = load_verified(resolve_run_path(verified_path))
+    try:
+        path = finalise_drafts(programme_handle, summary, expected_count=len(verified))
+    except FinalisationError as exc:
+        raise ValueError(str(exc)) from exc
+    return path.name
 
 
 MEMBER = SquadMember(
     slug="technical_author",
     dir=Path(__file__).parent,
     tools=[
-        create_reports_tool,
+        draft_report_tool,
+        finalise_reports_tool,
+        sanitise_evidence_tool,
+        lookup_cwe_tool,
+        lookup_owasp_tool,
         calculate_cvss_tool,
+        list_programme_reports_tool,
         read_run_filelist_tool,
         read_run_file_tool,
     ],

--- a/squad/technical_author/write/description.md
+++ b/squad/technical_author/write/description.md
@@ -2,52 +2,76 @@ Read the Vulnerability Researcher's triage briefing from your task context
 to understand what was accepted and why. The verified findings live in
 verified.json in the run directory.
 
-For each verified vulnerability, produce a complete HackerOne-format
-disclosure report. Quality is the bar: a triager must be able to reproduce
-the issue from your report alone, without asking a single clarifying question.
+You write one report per verified finding. Quality is the bar: a triager
+must be able to reproduce the issue from your report alone, without asking
+a single clarifying question.
 
-**Title** - Use the formula:
-  `[Vulnerability Type] in [Component/Endpoint] allows [Outcome]`
+Your workflow per finding:
+
+  1. Use Read Run File to load `verified.json` and read the entry at your
+     current finding_index. The Vulnerability Researcher has assigned the
+     CVSS vector, target, vuln_class, and severity - keep them.
+
+  2. Use Lookup CWE on the finding's vuln_class to pick the most precise
+     CWE identifier. Note the suggested OWASP topic in the result.
+
+  3. Use Lookup OWASP Guidance with the topic from step 2 to fetch the
+     canonical cheat-sheet URL and key principles for the Remediation
+     section.
+
+  4. Use Sanitise Evidence on the finding's raw evidence to strip
+     credentials, cookies, bearer tokens, and JWT material. Payloads (XSS
+     vectors, SQL injection strings, SSRF URLs) are kept intact - this is a
+     private disclosure and the triager needs the literal exploit.
+
+  5. Call Draft Vulnerability Report with the finding_index and the prose
+     you have composed. The tool runs a quality gate and returns an issue
+     list. Fix every error and call again. When `validation.ok` is true,
+     move to the next finding.
+
+  6. Once every finding has a draft with `validation.ok == true`, call
+     Finalise Reports with the programme handle and your 2-3 sentence
+     executive summary. The tool consolidates the drafts into reports.json
+     and refuses if any draft is missing or unresolved.
+
+Authoring guidance for each section:
+
+**Title** - `[Vulnerability Type] in [Component/Endpoint] allows [Outcome]`
   Specific beats vague. "Stored XSS via `bio` parameter allows session
-  hijacking of any authenticated user" is good. "XSS" is not.
+  hijacking of any authenticated user" is good. "XSS" is not. If you suspect
+  a recent submission may collide, call List Programme Reports first.
 
-**Summary** - 2-3 sentences. Root cause, location, concrete impact.
+**Summary** - 2-3 sentences. Root cause + location + concrete impact.
 
-**Vulnerability details** - vuln_class, target, CVSS 3.1 vector and score
-  (use Calculate CVSS Score on the vector from verified.json - never guess
-  the number), and the most precise CWE identifier.
+**Description** - Explain the root cause to a developer. WHY is the code
+  vulnerable, not just what happens. Include a code-level snippet where the
+  flaw is visible. Write for the engineer who will fix it.
 
-**Technical description** - Explain the root cause to a developer. Why is
-  the code vulnerable, not just what happens. Write for someone who will
-  fix it.
+**Steps to reproduce** - Numbered, reproducible from a clean state. Include
+  exact HTTP requests (raw HTTP or curl with full headers), unredacted
+  payloads, what to observe as proof (HTTP status, response body, cookie
+  change, out-of-band callback, DNS lookup), and any prerequisites
+  (account type, tool version, browser).
 
-**Steps to reproduce** - Numbered steps from a clean state:
-  - Include exact HTTP requests (raw HTTP or curl commands with full headers)
-  - Unredacted payloads - this is a private disclosure, not a public post
-  - State what to observe as proof (HTTP status, response body, cookie
-    change, out-of-band callback, DNS lookup, etc.)
-  - Specify prerequisites: account type, tool version, browser if relevant
+**Evidence** - Pass the Penetration Tester's captured evidence through
+  Sanitise Evidence and inline the result. The validator refuses any draft
+  whose evidence still contains credentials or session tokens.
 
-**Evidence** - Reproduce the evidence captured by the Penetration Tester
-  (the `evidence` field of each VerifiedVulnerability). Include HTTP
-  request/response excerpts, tool output (sqlmap, nuclei, curl), and any
-  other artefacts exactly as captured.
+**Impact** - Concrete and specific. Name the data or system at risk, who is
+  affected (unauthenticated / any authenticated user / admin only), and the
+  worst realistic outcome. Avoid generic phrases - write:
+    "An unauthenticated attacker can read every user record, including
+     hashed passwords and email addresses"
+  not:
+    "An attacker could compromise user data."
 
-**Impact** - Concrete and specific. Name what data or system is at risk,
-  who is affected (unauthenticated / any authenticated user / admin only),
-  and the worst realistic outcome for the programme's users or business.
-  Avoid generic phrases. Write: "An unauthenticated attacker can read every
-  user record, including hashed passwords and email addresses" not "an
-  attacker could compromise user data".
+**Remediation** - Actionable. Give the developer a concrete fix. Quote one
+  of the key_principles returned by Lookup OWASP Guidance and cite the
+  cheat-sheet URL. Include a code-level example where possible.
 
-**Remediation** - Actionable. Give the developer a concrete fix. Reference
-  the specific OWASP guidance (https://owasp.org) or CWE entry
-  (https://cwe.mitre.org) for the weakness. Include a code-level example
-  where possible.
+**CVSS** - The vector lives on the verified finding. If you disagree with
+  the score, call Calculate CVSS Score on the (corrected) vector and pass
+  the new vector to Draft Vulnerability Report - the validator refuses any
+  draft whose cvss_score does not match its vector.
 
-Cover ALL verified findings. Call create_reports_tool with the verified.json
-path, the programme handle, and a 2-3 sentence executive summary of the
-overall session. The tool writes one report per finding to reports.json.
-
-After writing, use Read Run File to confirm all reports were written, then
-produce a briefing for the Disclosure Coordinator (see expected output).
+Do not edit verified.json. Do not skip findings. Cover every entry.

--- a/squad/technical_author/write/expected_output.md
+++ b/squad/technical_author/write/expected_output.md
@@ -3,9 +3,12 @@ Coordinator.
 
 The briefing must cover:
   - N reports written, one per verified finding
-  - For each report: title, severity (CVSS score), target
-  - Any findings that raised concerns during write-up (e.g. evidence too
-    thin to reproduce, severity borderline, potential scope ambiguity)
+  - For each report: title, severity (CVSS score), target, CWE-N
+  - Any findings that raised concerns during write-up (evidence thin
+    despite sanitisation, severity borderline, potential scope ambiguity)
+  - Any findings where you ran List Programme Reports and found a close
+    title match worth flagging to the Disclosure Coordinator before
+    submission
 
 Return the filename on its own line first, then the briefing. The Disclosure
 Coordinator reads reports.json directly; the briefing is a human-readable

--- a/squad/vulnerability_researcher/__init__.py
+++ b/squad/vulnerability_researcher/__init__.py
@@ -2,17 +2,35 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 from crewai.tools import tool
 
-import runtime
+from models import Programme, Severity
 from squad import SquadMember, read_run_file_tool, read_run_filelist_tool
-from tools import http
+from tools import cwe_data, http, owasp_data
 from tools.h1_api import h1
-from tools.pentest import lookup_cve, triage_findings
+from tools.pentest import lookup_cve
+from tools.report_tools import calculate_cvss_score
+from tools.triage_tools import (
+    DiscardEntry,
+    DiscardReason,
+    SeverityDecision,
+    TriageAssessment,
+    TriageFinalisationError,
+    load_raw_findings,
+    save_assessment,
+    save_discard,
+)
+from tools.triage_tools import (
+    finalise_triage as finalise_triage_impl,
+)
+from tools.triage_tools import (
+    validate_assessment as validate_assessment_impl,
+)
 from tools.workspace import resolve_run_path
+
+# Research-task tools (run before the Penetration Tester)
 
 
 @tool("NVD CVE Lookup")
@@ -49,39 +67,260 @@ def list_programme_reports_tool(programme_handle: str, page_size: int = 25) -> l
     ]
 
 
-@tool("Triage Findings")
-def triage_findings_tool(findings_path: str, programme_handle: str) -> str:
-    """
-    Load raw pentest findings from the run directory, scope-check and
-    severity-verify each against the programme policy, assign CVSS scores,
-    and write the accepted findings to verified.json in the run directory.
-    Returns the bare filename "verified.json". Pass this to the Technical
-    Author as the verified findings path.
-    """
-    from models import RawFinding
+# Triage-task tools (run after the Penetration Tester)
 
-    raw_data = json.loads(resolve_run_path(findings_path).read_text(encoding="utf-8"))
-    raw = [RawFinding.model_validate(f) for f in raw_data]
+
+@tool("List Raw Findings")
+def list_raw_findings_tool(findings_path: str = "findings.json") -> list[dict]:
+    """
+    Compact summary of every raw finding in findings.json: returns
+    {index, title, vuln_class, target, severity_hint, evidence_bytes} per
+    finding, without dumping the verbose evidence payload. Use this as the
+    inventory step before deciding which findings to Assess and which to
+    Discard.
+    """
+    raw = load_raw_findings(resolve_run_path(findings_path))
+    return [
+        {
+            "index": i,
+            "title": f.title,
+            "vuln_class": f.vuln_class,
+            "target": f.target,
+            "severity_hint": f.severity_hint.value,
+            "evidence_bytes": len(f.evidence),
+        }
+        for i, f in enumerate(raw)
+    ]
+
+
+@tool("Read Raw Finding")
+def read_raw_finding_tool(index: int, findings_path: str = "findings.json") -> dict:
+    """
+    Return the full raw finding at ``index`` from findings.json including its
+    evidence payload (which can be large). Pair with List Raw Findings to
+    pull one finding at a time rather than loading the whole file.
+    """
+    raw = load_raw_findings(resolve_run_path(findings_path))
+    if index < 0 or index >= len(raw):
+        raise ValueError(f"index {index} out of range (findings.json has {len(raw)} entries)")
+    return raw[index].model_dump(mode="json")
+
+
+@tool("Calculate CVSS Score")
+def calculate_cvss_tool(vector: str) -> float:
+    """
+    Compute the CVSS 3.1 base score from a vector string such as
+    CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H. Returns a value in 0.0-10.0.
+    Use this instead of guessing the score; Assess Finding verifies that
+    cvss_score matches the computed value before accepting.
+    """
+    return calculate_cvss_score(vector)
+
+
+@tool("Lookup CWE")
+def lookup_cwe_tool(query: str) -> list[dict]:
+    """
+    Find Common Weakness Enumeration entries that match a query. Useful when
+    writing the remediation section to cite the canonical MITRE definition
+    and chain to the matching OWASP cheat-sheet via Lookup OWASP Guidance.
+    """
+    entries = cwe_data.lookup(query)
+    return [
+        {
+            "cwe_id": e.cwe_id,
+            "name": e.name,
+            "description": e.description,
+            "url": e.url,
+            "owasp_topic": e.owasp_topic,
+        }
+        for e in entries
+    ]
+
+
+@tool("Lookup OWASP Guidance")
+def lookup_owasp_tool(query: str) -> list[dict]:
+    """
+    Find OWASP Cheat Sheet entries that match a query (topic slug, title, or
+    short alias such as "ssrf", "csrf", "sqli"). Returns title, paste-friendly
+    key_principles, and the canonical cheatsheetseries.owasp.org URL to cite
+    in the remediation section.
+    """
+    entries = owasp_data.lookup(query)
+    return [
+        {
+            "topic": e.topic,
+            "title": e.title,
+            "url": e.url,
+            "key_principles": e.key_principles,
+        }
+        for e in entries
+    ]
+
+
+@tool("Assess Raw Finding")
+def assess_finding_tool(
+    finding_index: int,
+    severity_decision: str,
+    severity: str,
+    severity_rationale: str,
+    cvss_vector: str,
+    title: str,
+    description: str,
+    steps_to_reproduce: list[str],
+    impact: str,
+    remediation: str,
+    findings_path: str = "findings.json",
+    programme_handle: str | None = None,
+) -> dict:
+    """
+    Author one triage assessment for the raw finding at ``finding_index`` and
+    run the quality gate. The carried fields (target, vuln_class,
+    severity_hint) are pulled from findings.json so you cannot contradict the
+    Penetration Tester.
+
+    Inputs you author:
+      - severity_decision: "keep" | "raise" | "lower" relative to the PT hint
+      - severity: the final severity after your decision
+      - severity_rationale: 1-2 sentences justifying the call
+      - cvss_vector: full CVSS 3.1 vector; cvss_score is recomputed and
+        verified against your declared severity band
+      - title: TA may rewrite, but keep it descriptive
+      - description: root-cause explanation aimed at a developer audience
+      - steps_to_reproduce: numbered steps the TA can refine into the report
+      - impact: specific - name the data/system at risk and worst outcome.
+        Hand-wavy language ("could compromise", "potential") is rejected.
+      - remediation: actionable fix with an OWASP or CWE URL citation
+
+    Out-of-scope or below-floor findings are rejected: use Discard Finding
+    instead. Returns {"path": "assessments/NNN.json", "validation": {...}};
+    when validation.ok is false, re-run with the issues addressed.
+    """
+    raw = load_raw_findings(resolve_run_path(findings_path))
+    if finding_index < 0 or finding_index >= len(raw):
+        raise ValueError(f"finding_index {finding_index} out of range")
+    finding = raw[finding_index]
+
+    programme = _load_programme(programme_handle)
+
+    assessment = TriageAssessment(
+        finding_index=finding_index,
+        target=finding.target,
+        vuln_class=finding.vuln_class,
+        severity_hint=finding.severity_hint,
+        severity_decision=SeverityDecision(severity_decision),
+        severity=_parse_severity(severity),
+        severity_rationale=severity_rationale.strip(),
+        cvss_vector=cvss_vector.strip(),
+        cvss_score=calculate_cvss_score(cvss_vector.strip()),
+        title=title.strip(),
+        description=description.strip(),
+        steps_to_reproduce=[s.strip() for s in steps_to_reproduce],
+        impact=impact.strip(),
+        remediation=remediation.strip(),
+    )
+    path = save_assessment(assessment)
+    report = validate_assessment_impl(assessment, finding, programme)
+    return {
+        "path": str(path.relative_to(path.parents[1])),
+        "validation": report.model_dump(),
+    }
+
+
+@tool("Discard Finding")
+def discard_finding_tool(
+    finding_index: int,
+    reason: str,
+    rationale: str,
+    findings_path: str = "findings.json",
+) -> dict:
+    """
+    Mark a raw finding as not eligible for verified.json. ``reason`` must be
+    one of: out_of_scope, below_floor, false_positive, duplicate,
+    non_exploitable. ``rationale`` is a one-sentence justification recorded
+    on the discard entry and surfaced in the briefing to the Technical
+    Author. Returns {"path": "discards/NNN.json"}.
+    """
+    raw = load_raw_findings(resolve_run_path(findings_path))
+    if finding_index < 0 or finding_index >= len(raw):
+        raise ValueError(f"finding_index {finding_index} out of range")
+    finding = raw[finding_index]
+    if len(rationale.strip()) < 10:
+        raise ValueError("rationale must be at least 10 chars - explain why this is discarded")
+    entry = DiscardEntry(
+        finding_index=finding_index,
+        target=finding.target,
+        vuln_class=finding.vuln_class,
+        severity_hint=finding.severity_hint,
+        reason=DiscardReason(reason),
+        rationale=rationale.strip(),
+    )
+    path = save_discard(entry)
+    return {"path": str(path.relative_to(path.parents[1]))}
+
+
+@tool("Finalise Triage")
+def finalise_triage_tool(
+    programme_handle: str,
+    findings_path: str = "findings.json",
+) -> str:
+    """
+    Consolidate every assessment into verified.json for the Technical Author.
+    Refuses if any raw finding has neither an assessment nor a discard, or
+    if any assessment has unresolved validation errors. The error message
+    lists exactly which finding / section needs work.
+
+    Returns the bare filename "verified.json" on success.
+    """
+    raw = load_raw_findings(resolve_run_path(findings_path))
+    programme = _load_programme(programme_handle)
+    try:
+        path = finalise_triage_impl(programme, raw)
+    except TriageFinalisationError as exc:
+        raise ValueError(str(exc)) from exc
+    return path.name
+
+
+# Helpers
+
+
+def _parse_severity(severity: str) -> Severity:
+    try:
+        return Severity(severity.lower())
+    except ValueError as exc:
+        raise ValueError(
+            f"severity must be one of {[s.value for s in Severity]}, got {severity!r}"
+        ) from exc
+
+
+def _load_programme(programme_handle: str | None) -> Programme:
+    """Fetch and parse the Programme. The scope/floor gates need a real
+    Programme to check against, so the triage tools call this on every
+    invocation."""
+    if not programme_handle:
+        raise ValueError("programme_handle is required")
+    http.set_programme(programme_handle)
     policy = h1.get_programme_policy(programme_handle)
     scope = h1.get_structured_scope(programme_handle)
-    programme = h1.parse_programme(policy["data"], scope)
-    verified = triage_findings(raw, programme)
-    out_path = runtime.run_dir() / "verified.json"
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(
-        json.dumps([v.model_dump(mode="json") for v in verified]),
-        encoding="utf-8",
-    )
-    return "verified.json"
+    return h1.parse_programme(policy["data"], scope)
 
 
 MEMBER = SquadMember(
     slug="vulnerability_researcher",
     dir=Path(__file__).parent,
     tools=[
+        # Research task
         lookup_cve_tool,
         list_programme_reports_tool,
-        triage_findings_tool,
+        # Triage task
+        list_raw_findings_tool,
+        read_raw_finding_tool,
+        calculate_cvss_tool,
+        lookup_cwe_tool,
+        lookup_owasp_tool,
+        assess_finding_tool,
+        discard_finding_tool,
+        finalise_triage_tool,
+        # Workspace
         read_run_filelist_tool,
         read_run_file_tool,
     ],

--- a/squad/vulnerability_researcher/triage/description.md
+++ b/squad/vulnerability_researcher/triage/description.md
@@ -1,21 +1,63 @@
-Read the Penetration Tester's briefing from your task context to understand
-what was found and the severity hints. The raw findings live in findings.json
-in the run directory.
+Read the Penetration Tester's briefing from your task context. The raw
+findings live in `findings.json` in the run directory.
 
-Call Triage Findings with `findings.json` and the programme handle. The tool:
-  - Scope-checks each finding against the programme's structured scope
-  - Verifies each severity hint (up or down based on exploitability and
-    business impact)
-  - Computes a CVSS 3.1 vector and score for each accepted finding
-  - Discards findings below LOW or clearly out of scope
-  - Writes the accepted findings to verified.json
+You assess one finding at a time. Each assessment must be specific enough
+that the Technical Author can write a triage-ready report from it without
+asking a single follow-up question.
 
-After triage completes, use Read Run File to read `verified.json`. You need
-this to brief the Technical Author accurately:
-  - How many findings were accepted versus discarded, and why
-  - For each accepted finding: title, target, final severity, CVSS score
-  - Any findings whose severity was adjusted from the PT's hint, and why
-  - Any findings discarded (was it out of scope, or below the severity floor?)
+Your workflow per finding:
 
-Do not summarise or merge findings - each distinct issue must remain a
-separate entry. The Technical Author writes one report per entry.
+  1. Use List Raw Findings for the inventory: index, title, vuln_class,
+     target, severity_hint, evidence size. Decide which findings warrant
+     full assessment and which to discard.
+
+  2. For each finding, use Read Raw Finding(index) to load the full
+     content including evidence.
+
+  3. Decide: Assess or Discard.
+
+     **Discard** (call Discard Finding with one of:
+       - `out_of_scope` - target hostname falls outside the structured scope
+       - `below_floor` - severity below the configured min-severity
+       - `false_positive` - tool fired but the evidence does not actually
+         demonstrate the issue
+       - `duplicate` - same root cause as another finding in this run
+       - `non_exploitable` - real but no realistic exploitation path
+
+     **Assess** (call Assess Raw Finding) for everything else.
+
+  4. When assessing:
+     - Decide severity. Hold or raise from the PT hint based on
+       exploitability (auth required?, user interaction?, blast radius)
+       and business impact. Lowering is allowed but justify it.
+     - Use Calculate CVSS Score on your candidate vector; the gate
+       refuses an assessment whose cvss_score does not match its vector,
+       and warns when the score's severity band differs from your call.
+     - Use Lookup CWE / Lookup OWASP Guidance to find the canonical
+       citations you reference in remediation.
+     - The gate also enforces:
+         * description >= 100 chars, root-cause focused, no
+           "Automated detection of..." boilerplate
+         * impact >= 40 chars, concrete (no "could compromise" /
+           "potential" / "pending manual review"); name the data or
+           system at risk and the worst realistic outcome
+         * remediation >= 60 chars and contains a URL (OWASP cheat-sheet
+           or CWE)
+         * steps_to_reproduce >= 2 steps, each >= 10 chars; no
+           "Observe the following evidence:" placeholder
+
+     Fix every error the validator reports and call again. Move on when
+     `validation.ok` is true.
+
+  5. Once every raw finding has either an assessment or a discard, call
+     Finalise Triage with the programme handle. The tool consolidates the
+     assessments into `verified.json` and refuses if any finding is
+     unprocessed or any assessment has unresolved errors.
+
+You may use List Programme Reports to calibrate severity against what the
+programme has historically accepted - a class that always lands as Medium
+may signal you should temper a borderline High call (or, conversely, that
+you have a genuine escalation worth flagging).
+
+Do not summarise or merge findings - each distinct issue stays a separate
+assessment. The Technical Author writes one report per accepted finding.

--- a/squad/vulnerability_researcher/triage/expected_output.md
+++ b/squad/vulnerability_researcher/triage/expected_output.md
@@ -2,12 +2,17 @@ The bare filename `verified.json` followed by a briefing for the
 Technical Author.
 
 The briefing must cover:
-  - N findings accepted, M discarded (with reason: out of scope / below LOW)
-  - For each accepted finding: title, target, severity, CVSS score, and a
-    one-line description of the issue
-  - Any severity adjustments made during triage: original PT hint and the
-    revised score, with a sentence explaining why
-  - For discarded findings: title and the discard reason
+  - N findings accepted, M discarded
+  - For each accepted finding: title, target, final severity, CVSS score,
+    severity_decision (keep/raise/lower vs PT hint) and a one-line
+    description of the issue
+  - For each severity adjustment: the PT hint, the revised severity, and
+    your rationale in one sentence
+  - For each discard: title, target, discard reason, and rationale in one
+    sentence
+  - Any assessments where the CVSS-implied severity band differed from
+    your final call (the gate surfaces these as warnings) - flag them so
+    the TA knows to double-check before drafting
 
 Return the filename on its own line first, then the briefing. The Technical
-Author uses this to understand what to write up before opening verified.json.
+Author uses this to decide what to write up before opening verified.json.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,12 +31,21 @@ from models import (  # noqa: E402
 # Domain fixtures
 #
 # Use these instead of ad-hoc hostnames so test intent is readable at a glance.
-# victim_url  - the scanning target (an app we are testing)
-# callback_url - OOB receiver (a server we control, used for blind injection);
-#                placeholder until #77 lands real interactsh infrastructure.
+# victim_url    - the scanning target (an app we are testing); in-scope per
+#                 the ``programme`` fixture's ``*.example.com`` wildcard rule.
+# bystander_url - an out-of-scope host on a different TLD. Use it whenever a
+#                 test exercises the scope guard - the name makes the intent
+#                 ("bystander, hands off") obvious at the call site.
+# callback_url  - OOB receiver (a server we control, used for blind injection);
+#                 placeholder until #77 lands real interactsh infrastructure.
 @pytest.fixture()
 def victim_url() -> str:
     return "https://victim.example.com"
+
+
+@pytest.fixture()
+def bystander_url() -> str:
+    return "https://bystander.example.org"
 
 
 @pytest.fixture()

--- a/tests/test_cwe_data.py
+++ b/tests/test_cwe_data.py
@@ -1,0 +1,66 @@
+"""tests/test_cwe_data.py - unit tests for tools/cwe_data.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.cwe_data import CWE_CATALOGUE, get_by_id, lookup
+
+pytestmark = pytest.mark.unit
+
+
+class TestLookup:
+    def test_exact_alias_match(self):
+        entries = lookup("SQLi")
+        assert entries
+        assert entries[0].cwe_id == 89
+
+    def test_case_insensitive(self):
+        entries = lookup("sqli")
+        assert entries
+        assert entries[0].cwe_id == 89
+
+    def test_substring_match(self):
+        entries = lookup("cross-site")
+        ids = [e.cwe_id for e in entries]
+        # CWE-79 (XSS) and CWE-352 (CSRF) both contain "cross-site"
+        assert 79 in ids
+        assert 352 in ids
+
+    def test_empty_query_returns_empty(self):
+        assert lookup("") == []
+
+    def test_unknown_returns_empty(self):
+        assert lookup("absolutely-not-a-vuln-class") == []
+
+    def test_limit_respected(self):
+        entries = lookup("injection", limit=2)
+        assert len(entries) <= 2
+
+    def test_exact_match_ordered_first(self):
+        entries = lookup("XXE")
+        assert entries[0].cwe_id == 611
+
+
+class TestGetById:
+    def test_returns_entry_for_known(self):
+        entry = get_by_id(79)
+        assert entry is not None
+        assert "Cross-site" in entry.name
+
+    def test_returns_none_for_unknown(self):
+        assert get_by_id(999999) is None
+
+
+class TestCatalogueIntegrity:
+    def test_ids_are_unique(self):
+        ids = [e.cwe_id for e in CWE_CATALOGUE]
+        assert len(ids) == len(set(ids)), "duplicate CWE id in catalogue"
+
+    def test_url_format(self):
+        for entry in CWE_CATALOGUE:
+            assert entry.url == f"https://cwe.mitre.org/data/definitions/{entry.cwe_id}.html"
+
+    def test_every_entry_has_description(self):
+        for entry in CWE_CATALOGUE:
+            assert entry.description.strip()

--- a/tests/test_dnsx.py
+++ b/tests/test_dnsx.py
@@ -1,0 +1,229 @@
+"""tests/test_dnsx.py - unit tests for tools/recon/dnsx.py."""
+
+from __future__ import annotations
+
+import json
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+import pytest
+
+from tools.recon.dnsx import (
+    _match_fingerprint,
+    detect_takeover_candidates,
+    resolve_records,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# Fingerprint matcher
+
+
+class TestMatchFingerprint:
+    def test_matches_s3(self):
+        assert _match_fingerprint("bucket.s3.amazonaws.com") == "AWS S3"
+
+    def test_matches_heroku(self):
+        assert _match_fingerprint("app.herokuapp.com") == "Heroku"
+
+    def test_matches_github_pages(self):
+        assert _match_fingerprint("user.github.io") == "GitHub Pages"
+
+    def test_matches_azure_blob(self):
+        assert _match_fingerprint("store.blob.core.windows.net") == "Azure Blob Storage"
+
+    def test_matches_case_insensitive(self):
+        assert _match_fingerprint("Bucket.S3.AmazonAWS.com") == "AWS S3"
+
+    def test_strips_trailing_dot(self):
+        assert _match_fingerprint("app.herokuapp.com.") == "Heroku"
+
+    def test_unknown_cname_returns_none(self):
+        assert _match_fingerprint("some.legitimate.host.example.com") is None
+
+    def test_empty_returns_none(self):
+        assert _match_fingerprint("") is None
+
+
+# resolve_records
+
+
+def _completed(stdout: str) -> CompletedProcess:
+    return CompletedProcess([], 0, stdout, "")
+
+
+class TestResolveRecords:
+    def test_empty_input_returns_empty(self):
+        # Should not require the binary or call _run
+        with patch("shutil.which", return_value=None):
+            assert resolve_records([]) == []
+
+    def test_parses_dnsx_json_output(self):
+        out = (
+            json.dumps({"host": "api.example.com", "a": ["1.2.3.4"], "cname": []})
+            + "\n"
+            + json.dumps(
+                {
+                    "host": "legacy.example.com",
+                    "a": [],
+                    "cname": ["legacy.example.com.s3.amazonaws.com"],
+                }
+            )
+            + "\n"
+        )
+        with (
+            patch("shutil.which", return_value="/usr/bin/dnsx"),
+            patch("tools.recon.dnsx._run", return_value=_completed(out)),
+        ):
+            records = resolve_records(["api.example.com", "legacy.example.com"])
+
+        assert {r.hostname for r in records} == {"api.example.com", "legacy.example.com"}
+        legacy = next(r for r in records if r.hostname == "legacy.example.com")
+        assert legacy.cname == ["legacy.example.com.s3.amazonaws.com"]
+        assert legacy.a_records == []
+
+    def test_skips_malformed_lines(self):
+        out = "not-json-at-all\n" + json.dumps({"host": "x.example.com", "a": ["1.1.1.1"]}) + "\n"
+        with (
+            patch("shutil.which", return_value="/usr/bin/dnsx"),
+            patch("tools.recon.dnsx._run", return_value=_completed(out)),
+        ):
+            records = resolve_records(["x.example.com"])
+
+        assert len(records) == 1
+        assert records[0].hostname == "x.example.com"
+
+    def test_skips_blank_lines(self):
+        out = "\n\n" + json.dumps({"host": "y.example.com", "a": ["1.1.1.1"]}) + "\n"
+        with (
+            patch("shutil.which", return_value="/usr/bin/dnsx"),
+            patch("tools.recon.dnsx._run", return_value=_completed(out)),
+        ):
+            assert len(resolve_records(["y.example.com"])) == 1
+
+    def test_drops_entries_with_no_host(self):
+        out = json.dumps({"a": ["1.1.1.1"]}) + "\n"
+        with (
+            patch("shutil.which", return_value="/usr/bin/dnsx"),
+            patch("tools.recon.dnsx._run", return_value=_completed(out)),
+        ):
+            assert resolve_records(["nohost.example.com"]) == []
+
+    def test_whitespace_only_input_returns_empty(self):
+        with patch("shutil.which", return_value="/usr/bin/dnsx") as mwhich:
+            assert resolve_records(["  ", ""]) == []
+            mwhich.assert_called_once()
+
+
+# detect_takeover_candidates
+
+
+class TestDetectTakeoverCandidates:
+    def test_flags_cname_to_vulnerable_provider(self):
+        out = json.dumps(
+            {
+                "host": "legacy.example.com",
+                "a": ["52.0.0.1"],
+                "cname": ["bucket.s3.amazonaws.com"],
+            }
+        )
+        with (
+            patch("shutil.which", return_value="/usr/bin/dnsx"),
+            patch("tools.recon.dnsx._run", return_value=_completed(out)),
+        ):
+            candidates = detect_takeover_candidates(["legacy.example.com"])
+
+        assert len(candidates) == 1
+        c = candidates[0]
+        assert c.hostname == "legacy.example.com"
+        assert c.reason == "cname_to_vulnerable_provider"
+        assert c.service == "AWS S3"
+        assert c.cname == "bucket.s3.amazonaws.com"
+
+    def test_flags_dangling_cname(self):
+        # CNAME exists but no A records
+        out = json.dumps(
+            {
+                "host": "abandoned.example.com",
+                "a": [],
+                "cname": ["abandoned.internal.tld"],
+            }
+        )
+        with (
+            patch("shutil.which", return_value="/usr/bin/dnsx"),
+            patch("tools.recon.dnsx._run", return_value=_completed(out)),
+        ):
+            candidates = detect_takeover_candidates(["abandoned.example.com"])
+
+        assert len(candidates) == 1
+        assert candidates[0].reason == "dangling_cname"
+        assert candidates[0].service is None
+
+    def test_does_not_flag_resolved_unknown_cname(self):
+        # CNAME exists and resolves; not a known-vulnerable provider
+        out = json.dumps(
+            {
+                "host": "alias.example.com",
+                "a": ["10.0.0.1"],
+                "cname": ["primary.example.com"],
+            }
+        )
+        with (
+            patch("shutil.which", return_value="/usr/bin/dnsx"),
+            patch("tools.recon.dnsx._run", return_value=_completed(out)),
+        ):
+            assert detect_takeover_candidates(["alias.example.com"]) == []
+
+    def test_does_not_flag_plain_a_record(self):
+        # No CNAME at all - just a plain A record
+        out = json.dumps({"host": "api.example.com", "a": ["1.2.3.4"], "cname": []})
+        with (
+            patch("shutil.which", return_value="/usr/bin/dnsx"),
+            patch("tools.recon.dnsx._run", return_value=_completed(out)),
+        ):
+            assert detect_takeover_candidates(["api.example.com"]) == []
+
+    def test_provider_match_takes_priority_over_dangling(self):
+        # If a CNAME matches a fingerprint, that's the candidate we surface,
+        # not "dangling" (even if A records are also empty).
+        out = json.dumps(
+            {
+                "host": "legacy.example.com",
+                "a": [],
+                "cname": ["legacy.example.com.s3.amazonaws.com"],
+            }
+        )
+        with (
+            patch("shutil.which", return_value="/usr/bin/dnsx"),
+            patch("tools.recon.dnsx._run", return_value=_completed(out)),
+        ):
+            candidates = detect_takeover_candidates(["legacy.example.com"])
+
+        assert len(candidates) == 1
+        assert candidates[0].reason == "cname_to_vulnerable_provider"
+        assert candidates[0].service == "AWS S3"
+
+    def test_one_candidate_per_host_on_multiple_cname_matches(self):
+        # Defensive: if a single host has multiple CNAMEs and both match
+        # vulnerable providers, the first one is surfaced. (Real-world DNS
+        # rarely returns multiple CNAMEs for a single host, but the loop
+        # handles it.)
+        out = json.dumps(
+            {
+                "host": "double.example.com",
+                "a": [],
+                "cname": ["x.s3.amazonaws.com", "y.herokuapp.com"],
+            }
+        )
+        with (
+            patch("shutil.which", return_value="/usr/bin/dnsx"),
+            patch("tools.recon.dnsx._run", return_value=_completed(out)),
+        ):
+            candidates = detect_takeover_candidates(["double.example.com"])
+
+        assert len(candidates) == 1
+
+    def test_empty_input_returns_empty(self):
+        with patch("shutil.which", return_value=None):
+            assert detect_takeover_candidates([]) == []

--- a/tests/test_nosql.py
+++ b/tests/test_nosql.py
@@ -8,7 +8,6 @@ import pytest
 
 from models import Endpoint, Severity
 from tools.pentest.nosqli import run_nosqli
-from tools.pentest.triage import _lookup_cvss
 
 pytestmark = pytest.mark.unit
 
@@ -84,13 +83,3 @@ class TestRunNosqli:
             results = run_nosqli(endpoints)
 
         assert len(results[0].evidence) <= 2000
-
-    def test_nosqli_cvss_critical(self):
-        score, vector = _lookup_cvss("NoSQLi", Severity.CRITICAL)
-        assert score == 9.8
-        assert "CVSS:3.1" in vector
-
-    def test_nosqli_cvss_high(self):
-        score, vector = _lookup_cvss("NoSQLi", Severity.HIGH)
-        assert score == 8.8
-        assert "CVSS:3.1" in vector

--- a/tests/test_owasp_data.py
+++ b/tests/test_owasp_data.py
@@ -1,0 +1,50 @@
+"""tests/test_owasp_data.py - unit tests for tools/owasp_data.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.owasp_data import OWASP_CATALOGUE, get_by_topic, lookup
+
+pytestmark = pytest.mark.unit
+
+
+class TestLookup:
+    def test_exact_title_match(self):
+        entries = lookup("SQL Injection Prevention")
+        assert entries
+        assert entries[0].topic == "SQL_Injection_Prevention"
+
+    def test_substring_match(self):
+        entries = lookup("ssrf")
+        assert any("Server_Side_Request_Forgery" in e.topic for e in entries)
+
+    def test_empty_returns_empty(self):
+        assert lookup("") == []
+
+    def test_unknown_returns_empty(self):
+        assert lookup("absolutely-not-a-cheatsheet") == []
+
+
+class TestGetByTopic:
+    def test_returns_entry_for_known_slug(self):
+        entry = get_by_topic("SQL_Injection_Prevention")
+        assert entry is not None
+
+    def test_returns_none_for_unknown(self):
+        assert get_by_topic("Not_A_Real_Slug") is None
+
+
+class TestCatalogueIntegrity:
+    def test_topics_are_unique(self):
+        topics = [e.topic for e in OWASP_CATALOGUE]
+        assert len(topics) == len(set(topics))
+
+    def test_url_format(self):
+        for entry in OWASP_CATALOGUE:
+            assert entry.url.startswith("https://cheatsheetseries.owasp.org/cheatsheets/")
+            assert entry.url.endswith("_Cheat_Sheet.html")
+
+    def test_every_entry_has_key_principles(self):
+        for entry in OWASP_CATALOGUE:
+            assert entry.key_principles

--- a/tests/test_prompt_injection.py
+++ b/tests/test_prompt_injection.py
@@ -14,7 +14,6 @@ from tools.pentest.prompt_injection import (
     PromptPayload,
     check_prompt_injection,
 )
-from tools.pentest.triage import _lookup_cvss
 from tools.recon.llm import detect_llm_endpoints
 
 pytestmark = pytest.mark.unit
@@ -141,16 +140,6 @@ class TestCheckPromptInjection:
         ):
             results = check_prompt_injection([ep])
         assert len(results) == 1
-
-    def test_prompt_injection_cvss_critical(self):
-        score, vector = _lookup_cvss("PromptInjection", Severity.CRITICAL)
-        assert score == 9.1
-        assert "CVSS:3.1" in vector
-
-    def test_prompt_injection_cvss_high(self):
-        score, vector = _lookup_cvss("PromptInjection", Severity.HIGH)
-        assert score == 7.2
-        assert "CVSS:3.1" in vector
 
     def test_payload_filter_restricts_to_named_variants(
         self, make_response: Callable[..., MagicMock]

--- a/tests/test_recon_insights.py
+++ b/tests/test_recon_insights.py
@@ -1,0 +1,283 @@
+"""tests/test_recon_insights.py - unit tests for tools/recon_insights.py."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from models import (
+    Endpoint,
+    HostInsight,
+    HostPriority,
+    HostRole,
+    ReconResult,
+)
+from tools.recon_insights import (
+    ReconFinalisationError,
+    finalise_recon,
+    insight_path,
+    load_insights,
+    save_insight,
+    uncovered_interesting_hosts,
+    validate_insight,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# Fixtures
+#
+# The `programme` (with its `*.example.com` wildcard) and the `bystander_url`
+# fixture (out-of-scope by construction) come from tests/conftest.py.
+
+
+@pytest.fixture
+def sweep(programme) -> ReconResult:
+    return ReconResult(
+        programme=programme,
+        subdomains=["api.example.com", "admin.example.com", "cdn.example.com"],
+        endpoints=[
+            Endpoint(
+                url="https://api.example.com",
+                status_code=200,
+                technologies=["Nginx", "Spring Boot 2.6"],
+            ),
+            Endpoint(
+                url="https://admin.example.com",
+                status_code=401,
+                technologies=["WordPress 5.8"],
+            ),
+            Endpoint(
+                url="https://cdn.example.com",
+                status_code=200,
+                technologies=["CloudFront"],
+            ),
+            Endpoint(
+                url="https://dead.example.com",
+                status_code=500,
+                technologies=[],
+            ),
+        ],
+    )
+
+
+def _good_insight(**overrides) -> HostInsight:
+    base: dict = {
+        "hostname": "api.example.com",
+        "role": HostRole.API,
+        "priority": HostPriority.HIGH,
+        "notes": (
+            "Public REST API gateway running Spring Boot 2.6 behind Nginx; "
+            "primary target for the programme."
+        ),
+        "detected_tech": ["Nginx", "Spring Boot 2.6"],
+    }
+    base.update(overrides)
+    return HostInsight(**base)
+
+
+# Validation
+
+
+class TestValidateInsight:
+    def test_clean_insight_passes(self, sweep, programme):
+        report = validate_insight(_good_insight(), sweep, programme)
+        assert report.ok is True
+        assert all(i.severity != "error" for i in report.issues)
+
+    def test_rejects_empty_hostname(self, sweep, programme):
+        report = validate_insight(_good_insight(hostname=""), sweep, programme)
+        assert report.ok is False
+        assert any(i.section == "hostname" for i in report.issues)
+
+    def test_rejects_out_of_scope_hostname(self, sweep, programme, bystander_url):
+        from urllib.parse import urlparse
+
+        oos_host = urlparse(bystander_url).hostname
+        report = validate_insight(_good_insight(hostname=oos_host), sweep, programme)
+        assert report.ok is False
+        assert any(
+            i.section == "hostname" and "not in programme scope" in i.message for i in report.issues
+        )
+
+    def test_rejects_thin_notes(self, sweep, programme):
+        report = validate_insight(_good_insight(notes="too short"), sweep, programme)
+        assert report.ok is False
+        assert any(i.section == "notes" for i in report.issues)
+
+    def test_rejects_thin_notes_on_high_priority(self, sweep, programme):
+        # 35 chars is >= 30 (so not the basic floor) but < 60 (the high-priority floor)
+        thirty_five = "Public API gateway hosting v2 routes."
+        report = validate_insight(_good_insight(notes=thirty_five), sweep, programme)
+        assert report.ok is False
+        assert any(
+            i.section == "notes" and "high-priority hosts" in i.message for i in report.issues
+        )
+
+    def test_rejects_thin_notes_on_skip(self, sweep, programme):
+        report = validate_insight(
+            _good_insight(priority=HostPriority.SKIP, notes="skip"),
+            sweep,
+            programme,
+        )
+        assert report.ok is False
+        assert any(i.section == "notes" for i in report.issues)
+
+    def test_warns_when_agent_drops_sweep_tech(self, sweep, programme):
+        # sweep saw ['Nginx', 'Spring Boot 2.6']; agent only carries 'Nginx'
+        report = validate_insight(
+            _good_insight(detected_tech=["Nginx"]),
+            sweep,
+            programme,
+        )
+        assert report.ok is True
+        assert any(i.section == "detected_tech" and i.severity == "warning" for i in report.issues)
+
+    def test_accepts_when_agent_adds_version_to_sweep_tech(self, sweep, programme):
+        # sweep saw 'Spring Boot 2.6'; agent carries 'Spring Boot 2.6.3' (more specific)
+        report = validate_insight(
+            _good_insight(detected_tech=["Nginx", "Spring Boot 2.6.3"]),
+            sweep,
+            programme,
+        )
+        # The version-stripping check accepts more-specific versions, but the
+        # exact comparison may still warn. Either way, no errors.
+        assert report.ok is True
+
+    def test_rejects_trivial_tech_entry(self, sweep, programme):
+        report = validate_insight(
+            _good_insight(detected_tech=["X"]),
+            sweep,
+            programme,
+        )
+        assert report.ok is False
+        assert any(i.section == "detected_tech" for i in report.issues)
+
+
+# Persistence
+
+
+class TestPersistence:
+    def test_save_insight_writes_per_host_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
+        path = save_insight(_good_insight())
+        assert path == tmp_path / "host_insights" / "api.example.com.json"
+        assert path.exists()
+        loaded = HostInsight.model_validate_json(path.read_text())
+        assert loaded.hostname == "api.example.com"
+
+    def test_save_insight_handles_special_chars_in_hostname(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
+        # Hostnames in practice are RFC 1123, but defensively sanitise unusual chars.
+        ins = _good_insight(hostname="weird host/name.example.com")
+        path = save_insight(ins)
+        assert path.exists()
+
+    def test_load_insights_orders_by_hostname(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
+        save_insight(_good_insight(hostname="zebra.example.com"))
+        save_insight(_good_insight(hostname="aardvark.example.com"))
+        loaded = load_insights()
+        assert [i.hostname for i in loaded] == [
+            "aardvark.example.com",
+            "zebra.example.com",
+        ]
+
+    def test_load_insights_empty_when_no_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
+        assert load_insights() == []
+
+    def test_insight_path_rejects_empty_hostname(self, tmp_path, monkeypatch):
+        # ``insight_path`` builds <run_dir>/host_insights/<sanitised>.json, so
+        # the sanitisation check has to run against a stub run_dir or
+        # runtime.run_dir() raises first.
+        monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
+        with pytest.raises(ValueError, match="empty after sanitisation"):
+            insight_path("///")
+
+
+# Coverage helper
+
+
+class TestUncoveredInterestingHosts:
+    def test_returns_hosts_without_insights(self, sweep):
+        # No insights yet, all interesting hosts uncovered
+        uncovered = uncovered_interesting_hosts(sweep, [])
+        # api / admin / cdn are 200/401/200 (interesting); dead is 500 (skip)
+        assert set(uncovered) == {
+            "api.example.com",
+            "admin.example.com",
+            "cdn.example.com",
+        }
+
+    def test_drops_hosts_with_insights(self, sweep):
+        uncovered = uncovered_interesting_hosts(
+            sweep,
+            [_good_insight(hostname="api.example.com")],
+        )
+        assert "api.example.com" not in uncovered
+        assert "admin.example.com" in uncovered
+
+    def test_excludes_uninteresting_status(self, sweep):
+        uncovered = uncovered_interesting_hosts(sweep, [])
+        assert "dead.example.com" not in uncovered
+
+
+# Finalisation
+
+
+def _write_sweep(tmp_path, sweep: ReconResult) -> None:
+    (tmp_path / "sweep.json").write_text(sweep.model_dump_json(), encoding="utf-8")
+
+
+class TestFinaliseRecon:
+    def test_writes_recon_json_for_clean_insights(self, sweep, programme, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
+        _write_sweep(tmp_path, sweep)
+        save_insight(_good_insight())
+        path = finalise_recon(programme)
+        assert path == tmp_path / "recon.json"
+        data = json.loads(path.read_text())
+        assert len(data["host_insights"]) == 1
+        assert data["host_insights"][0]["hostname"] == "api.example.com"
+
+    def test_refuses_without_insights(self, sweep, programme, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
+        _write_sweep(tmp_path, sweep)
+        with pytest.raises(ReconFinalisationError, match="no host_insights"):
+            finalise_recon(programme)
+
+    def test_refuses_when_no_high_priority(self, sweep, programme, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
+        _write_sweep(tmp_path, sweep)
+        save_insight(
+            _good_insight(
+                priority=HostPriority.MEDIUM,
+                notes="Standard public API with no version disclosed yet.",
+            )
+        )
+        with pytest.raises(ReconFinalisationError, match="HIGH priority"):
+            finalise_recon(programme)
+
+    def test_refuses_on_validation_errors(self, sweep, programme, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
+        _write_sweep(tmp_path, sweep)
+        save_insight(_good_insight(notes="too short"))
+        with pytest.raises(ReconFinalisationError, match="unresolved errors"):
+            finalise_recon(programme)
+
+    def test_refuses_without_sweep(self, programme, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
+        save_insight(_good_insight())
+        with pytest.raises(FileNotFoundError, match="sweep.json"):
+            finalise_recon(programme)
+
+    def test_carries_sweep_fields_through(self, sweep, programme, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
+        _write_sweep(tmp_path, sweep)
+        save_insight(_good_insight())
+        path = finalise_recon(programme)
+        data = json.loads(path.read_text())
+        assert data["subdomains"] == sweep.subdomains
+        assert len(data["endpoints"]) == len(sweep.endpoints)

--- a/tests/test_report_tools.py
+++ b/tests/test_report_tools.py
@@ -1,111 +1,323 @@
 """
-tests/test_report_tools.py - unit tests for tools/report_tools.py
+tests/test_report_tools.py - unit tests for tools/report_tools.py.
+
+Coverage targets the four primitive layers the Technical Author depends on:
+
+* CVSS scoring (calculate_cvss_score)
+* Evidence sanitisation (sanitise_evidence)
+* Draft validation (validate_draft)
+* Draft persistence and finalisation (save_draft / finalise_drafts)
+
+The DC compatibility surface (save_report) is covered at the end.
 """
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
+from models import Severity, VerifiedVulnerability
 from tools.report_tools import (
-    _VULN_CLASS_TO_CWE,
-    build_report_markdown,
-    create_disclosure_report,
+    FinalisationError,
+    ReportDraft,
+    calculate_cvss_score,
+    finalise_drafts,
+    load_drafts,
+    render_draft_markdown,
+    sanitise_evidence,
+    save_draft,
     save_report,
+    validate_draft,
 )
 
 pytestmark = pytest.mark.unit
 
 
-class TestCweMapping:
-    def test_sqli_maps_to_cwe_89(self):
-        assert _VULN_CLASS_TO_CWE["SQLi"] == 89
-
-    def test_xss_maps_to_cwe_79(self):
-        assert _VULN_CLASS_TO_CWE["XSS"] == 79
-
-    def test_cors_maps_to_cwe_942(self):
-        assert _VULN_CLASS_TO_CWE["CORS"] == 942
-
-    def test_ssrf_maps_to_cwe_918(self):
-        assert _VULN_CLASS_TO_CWE["SSRF"] == 918
+# Sanitisation
 
 
-class TestBuildReportMarkdown:
-    def test_contains_title(self, verified_vuln):
-        md = build_report_markdown("test-programme", verified_vuln, "Test summary.")
-        assert verified_vuln.title in md
+class TestSanitiseEvidence:
+    def test_preserves_xss_payload(self):
+        text = "<script>alert(document.cookie)</script>"
+        report = sanitise_evidence(text)
+        assert "<script>alert(document.cookie)</script>" in report.sanitised
+        assert report.redactions == []
 
-    def test_contains_summary(self, verified_vuln):
-        md = build_report_markdown("test-programme", verified_vuln, "My executive summary.")
-        assert "My executive summary." in md
+    def test_redacts_authorization_header(self):
+        text = "GET / HTTP/1.1\nAuthorization: Bearer abc.def.ghi\n"
+        report = sanitise_evidence(text)
+        assert "Bearer abc.def.ghi" not in report.sanitised
+        assert "Authorization: <redacted>" in report.sanitised
+        kinds = {r["kind"] for r in report.redactions}
+        assert "authorization_header" in kinds
 
-    def test_contains_cvss_score(self, verified_vuln):
-        md = build_report_markdown("test-programme", verified_vuln, "Summary.")
-        assert str(verified_vuln.cvss_score) in md
+    def test_redacts_cookie_header(self):
+        text = "Cookie: session=abc; csrf=xyz"
+        report = sanitise_evidence(text)
+        assert "session=abc" not in report.sanitised
+        assert "Cookie: <redacted>" in report.sanitised
 
-    def test_contains_cvss_vector(self, verified_vuln):
-        md = build_report_markdown("test-programme", verified_vuln, "Summary.")
-        assert verified_vuln.cvss_vector in md
+    def test_redacts_set_cookie(self):
+        text = "Set-Cookie: session=abcd; HttpOnly"
+        report = sanitise_evidence(text)
+        assert "session=abcd" not in report.sanitised
+        assert "Set-Cookie: <redacted>" in report.sanitised
 
-    def test_contains_cwe(self, verified_vuln):
-        md = build_report_markdown("test-programme", verified_vuln, "Summary.")
-        assert "CWE-89" in md
+    def test_redacts_bearer_outside_header(self):
+        text = "curl -H 'Auth: Bearer abcdefghijklmnop'"
+        report = sanitise_evidence(text)
+        assert "Bearer abcdefghijklmnop" not in report.sanitised
+        assert "Bearer <redacted>" in report.sanitised
 
-    def test_contains_reproduction_steps(self, verified_vuln):
-        md = build_report_markdown("test-programme", verified_vuln, "Summary.")
-        for step in verified_vuln.steps_to_reproduce:
-            assert step in md
+    def test_redacts_jwt(self):
+        # Three dot-separated base64 segments beginning ``eyJ`` (canonical JWT
+        # header start).
+        jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abcdefghij"
+        report = sanitise_evidence(f"token={jwt}")
+        assert jwt not in report.sanitised
 
-    def test_steps_are_numbered(self, verified_vuln):
-        md = build_report_markdown("test-programme", verified_vuln, "Summary.")
-        assert "1." in md
-        assert "2." in md
+    def test_redacts_aws_access_key(self):
+        text = "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE"
+        report = sanitise_evidence(text)
+        assert "AKIAIOSFODNN7EXAMPLE" not in report.sanitised
+        kinds = {r["kind"] for r in report.redactions}
+        assert "aws_access_key" in kinds
 
-    def test_contains_target(self, verified_vuln):
-        md = build_report_markdown("test-programme", verified_vuln, "Summary.")
-        assert verified_vuln.target in md
+    def test_redacts_secret_kv(self):
+        text = "password=hunter2 api_key=sk-livesecretvaluexx"
+        report = sanitise_evidence(text)
+        assert "hunter2" not in report.sanitised
+        assert "sk-livesecretvaluexx" not in report.sanitised
 
-    def test_contains_severity_label(self, verified_vuln):
-        md = build_report_markdown("test-programme", verified_vuln, "Summary.")
-        assert "High" in md
+    def test_truncates_long_text(self):
+        report = sanitise_evidence("X" * 5000, limit=2000)
+        assert len(report.sanitised) < 5000
+        assert report.warnings
+        assert "truncated" in report.warnings[0]
 
-    def test_evidence_truncated_to_2000_chars(self, verified_vuln):
-        long_vuln = verified_vuln.model_copy(update={"evidence": "X" * 5000})
-        md = build_report_markdown("test-programme", long_vuln, "Summary.")
-        assert md.count("X") <= 2000
-
-    def test_timestamp_present(self, verified_vuln):
-        md = build_report_markdown("test-programme", verified_vuln, "Summary.")
-        assert "UTC" in md
+    def test_empty_input_returns_clean(self):
+        report = sanitise_evidence("")
+        assert report.sanitised == ""
+        assert report.redactions == []
+        assert report.warnings == []
 
 
-class TestCreateDisclosureReport:
-    def test_returns_disclosure_report(self, verified_vuln):
-        from models import DisclosureReport
+# CVSS
 
-        report = create_disclosure_report("test-programme", verified_vuln, "Summary.")
-        assert isinstance(report, DisclosureReport)
 
-    def test_programme_handle_set(self, verified_vuln):
-        report = create_disclosure_report("test-programme", verified_vuln, "Summary.")
-        assert report.programme_handle == "test-programme"
+class TestCalculateCvssScore:
+    def test_known_vector_critical(self):
+        assert calculate_cvss_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H") == 9.8
 
-    def test_weakness_id_from_vuln_class(self, verified_vuln):
-        report = create_disclosure_report("test-programme", verified_vuln, "Summary.")
-        assert report.weakness_id == 89
+    def test_known_vector_medium(self):
+        assert calculate_cvss_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N") == 6.1
 
-    def test_body_markdown_is_nonempty(self, verified_vuln):
-        report = create_disclosure_report("test-programme", verified_vuln, "Summary.")
-        assert len(report.body_markdown) > 100
+    def test_known_vector_low(self):
+        assert calculate_cvss_score("CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N") == 3.1
 
-    def test_impact_statement_from_vuln(self, verified_vuln):
-        report = create_disclosure_report("test-programme", verified_vuln, "Summary.")
-        assert report.impact_statement == verified_vuln.impact
+    def test_zero_impact_returns_zero(self):
+        assert calculate_cvss_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N") == 0.0
 
-    def test_unknown_vuln_class_weakness_id_is_none(self, verified_vuln):
-        unknown_vuln = verified_vuln.model_copy(update={"vuln_class": "WeirdCustomVuln"})
-        report = create_disclosure_report("test-programme", unknown_vuln, "Summary.")
-        assert report.weakness_id is None
+    def test_version_30_accepted(self):
+        assert calculate_cvss_score("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H") == 9.8
+
+    def test_malformed_version_raises(self):
+        with pytest.raises(ValueError, match="Unrecognised CVSS version"):
+            calculate_cvss_score("CVSS:2.0/AV:N/AC:L/Au:N/C:C/I:C/A:C")
+
+    def test_missing_metric_raises(self):
+        with pytest.raises(ValueError, match="Missing or unknown CVSS metric"):
+            calculate_cvss_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H")
+
+    def test_malformed_component_raises(self):
+        with pytest.raises(ValueError, match="Malformed metric"):
+            calculate_cvss_score("CVSS:3.1/AV:N/BADCOMPONENT/PR:N/UI:N/S:U/C:H/I:H/A:H")
+
+
+# Draft fixtures
+
+
+def _good_draft(**overrides) -> ReportDraft:
+    base: dict = {
+        "finding_index": 0,
+        "target": "https://api.example.com/search",
+        "vuln_class": "SQLi",
+        "severity": Severity.HIGH,
+        "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "cvss_score": 9.8,
+        "cwe_id": 89,
+        "title": "SQL Injection in /search?q allows full database extraction",
+        "summary": (
+            "The /search endpoint concatenates the q parameter directly into a "
+            "SELECT statement. An unauthenticated attacker can exfiltrate the "
+            "entire database, including hashed passwords."
+        ),
+        "description": (
+            "The handler at routes/search.py builds the SQL by string concatenation: "
+            "`SELECT * FROM products WHERE name LIKE '%' + q + '%'`. There is no "
+            "parameterisation and no allow-list. Any attacker can inject arbitrary SQL "
+            "via the q querystring parameter and extract arbitrary tables."
+        ),
+        "steps_to_reproduce": [
+            "Issue GET https://api.example.com/search?q=test' UNION SELECT 1,2,3-- ",
+            "Observe the response includes the union'd rows alongside legitimate data.",
+        ],
+        "evidence": 'HTTP/1.1 200 OK\n\n[{"username":"alice"}]',
+        "impact": (
+            "An unauthenticated attacker can dump the entire users table, including "
+            "bcrypt password hashes and email addresses, enabling offline cracking "
+            "and account takeover of every user."
+        ),
+        "remediation": (
+            "Use parameterised queries via the ORM driver. See the OWASP SQL "
+            "Injection Prevention Cheat Sheet: "
+            "https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html"
+        ),
+    }
+    base.update(overrides)
+    return ReportDraft(**base)
+
+
+# Validation
+
+
+class TestValidateDraft:
+    def test_clean_draft_passes(self):
+        report = validate_draft(_good_draft())
+        assert report.ok is True
+        assert report.issues == []
+
+    def test_empty_title_errors(self):
+        report = validate_draft(_good_draft(title=""))
+        assert report.ok is False
+        assert any(i.section == "title" and "empty" in i.message for i in report.issues)
+
+    def test_title_without_formula_errors(self):
+        report = validate_draft(_good_draft(title="SQL injection bug"))
+        assert report.ok is False
+        assert any(i.section == "title" and "does not match" in i.message for i in report.issues)
+
+    def test_thin_description_errors(self):
+        report = validate_draft(_good_draft(description="Too short."))
+        assert report.ok is False
+        assert any(i.section == "description" for i in report.issues)
+
+    def test_single_step_errors(self):
+        report = validate_draft(
+            _good_draft(steps_to_reproduce=["only one step that is long enough"])
+        )
+        assert report.ok is False
+        assert any(i.section == "steps_to_reproduce" for i in report.issues)
+
+    def test_hand_wavy_impact_errors(self):
+        report = validate_draft(
+            _good_draft(impact="An attacker could compromise user data of the system.")
+        )
+        assert report.ok is False
+        assert any(i.section == "impact" and "hand-wavy" in i.message for i in report.issues)
+
+    def test_remediation_without_url_errors(self):
+        report = validate_draft(
+            _good_draft(remediation="Use parameterised queries throughout the codebase.")
+        )
+        assert report.ok is False
+        assert any(i.section == "remediation" for i in report.issues)
+
+    def test_unsanitised_evidence_errors(self):
+        bad = _good_draft(evidence="Authorization: Bearer leaked.token.here\nGET / HTTP/1.1\n")
+        report = validate_draft(bad)
+        assert report.ok is False
+        assert any(i.section == "evidence" for i in report.issues)
+
+    def test_cvss_score_mismatch_errors(self):
+        # vector computes to 9.8 but score claims 5.0
+        bad = _good_draft(cvss_score=5.0)
+        report = validate_draft(bad)
+        assert report.ok is False
+        assert any(i.section == "cvss" for i in report.issues)
+
+    def test_unknown_cwe_warns(self):
+        # warning, not error
+        report = validate_draft(_good_draft(cwe_id=99999))
+        assert any(i.section == "cwe" and i.severity == "warning" for i in report.issues)
+        # still ok since only warning
+        assert report.ok is True
+
+
+# Rendering
+
+
+class TestRenderDraftMarkdown:
+    def test_contains_title(self):
+        md = render_draft_markdown(_good_draft())
+        assert "/search?q allows full database extraction" in md
+
+    def test_contains_cwe_name(self):
+        md = render_draft_markdown(_good_draft())
+        assert "CWE-89 (SQL Injection)" in md
+
+    def test_steps_are_numbered(self):
+        md = render_draft_markdown(_good_draft())
+        assert "1. " in md
+        assert "2. " in md
+
+    def test_evidence_block_present(self):
+        md = render_draft_markdown(_good_draft())
+        assert "HTTP/1.1 200 OK" in md
+
+
+# Persistence
+
+
+class TestSaveAndLoadDraft:
+    def test_save_writes_indexed_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.report_tools.runtime.run_dir", lambda: tmp_path)
+        path = save_draft(_good_draft(finding_index=2))
+        assert path == tmp_path / "drafts" / "002.json"
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert data["finding_index"] == 2
+
+    def test_load_drafts_orders_by_index(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.report_tools.runtime.run_dir", lambda: tmp_path)
+        save_draft(_good_draft(finding_index=1))
+        save_draft(_good_draft(finding_index=0))
+        drafts = load_drafts()
+        assert [d.finding_index for d in drafts] == [0, 1]
+
+    def test_load_drafts_empty_when_no_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.report_tools.runtime.run_dir", lambda: tmp_path)
+        assert load_drafts() == []
+
+
+# Finalisation
+
+
+class TestFinaliseDrafts:
+    def test_writes_reports_json_for_clean_drafts(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.report_tools.runtime.run_dir", lambda: tmp_path)
+        save_draft(_good_draft(finding_index=0))
+        path = finalise_drafts("test-programme", "Summary line.", expected_count=1)
+        assert path == tmp_path / "reports.json"
+        contents = json.loads(path.read_text())
+        assert len(contents) == 1
+        assert contents[0]["programme_handle"] == "test-programme"
+
+    def test_refuses_when_drafts_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.report_tools.runtime.run_dir", lambda: tmp_path)
+        save_draft(_good_draft(finding_index=0))
+        with pytest.raises(FinalisationError, match="expected 2 drafts, found 1"):
+            finalise_drafts("test-programme", "Summary.", expected_count=2)
+
+    def test_refuses_on_validation_errors(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.report_tools.runtime.run_dir", lambda: tmp_path)
+        save_draft(_good_draft(finding_index=0, title="bad title"))
+        with pytest.raises(FinalisationError, match="unresolved errors"):
+            finalise_drafts("test-programme", "Summary.", expected_count=1)
+
+
+# DC compatibility
 
 
 class TestSaveReport:
@@ -124,21 +336,6 @@ class TestSaveReport:
         assert path.exists()
         assert path.suffix == ".md"
 
-    def test_file_contains_report_body(self, disclosure_report, tmp_path, monkeypatch):
-        monkeypatch.setenv("REPORTS_DIR", str(tmp_path))
-        import importlib
-
-        import config as cfg
-
-        importlib.reload(cfg)
-        import tools.report_tools as rt
-
-        rt.config = cfg.AppConfig()
-
-        path = save_report(disclosure_report)
-        content = path.read_text()
-        assert disclosure_report.body_markdown in content
-
     def test_filename_contains_handle(self, disclosure_report, tmp_path, monkeypatch):
         monkeypatch.setenv("REPORTS_DIR", str(tmp_path))
         import importlib
@@ -154,62 +351,15 @@ class TestSaveReport:
         assert "test-programme" in path.name
 
 
-# calculate_cvss_score
-class TestCalculateCvssScore:
-    def test_known_vector_critical(self):
-        from tools.report_tools import calculate_cvss_score
+# Helper: verified-finding round-trip
 
-        # AV:N AC:L PR:N UI:N S:U C:H I:H A:H -> 9.8
-        score = calculate_cvss_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
-        assert score == 9.8
 
-    def test_known_vector_medium(self):
-        from tools.report_tools import calculate_cvss_score
+class TestVerifiedRoundTrip:
+    def test_load_verified(self, tmp_path, verified_vuln: VerifiedVulnerability):
+        from tools.report_tools import load_verified
 
-        # AV:N AC:L PR:N UI:R S:C C:L I:L A:N -> 6.1
-        score = calculate_cvss_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N")
-        assert score == 6.1
-
-    def test_known_vector_low(self):
-        from tools.report_tools import calculate_cvss_score
-
-        # AV:N AC:H PR:N UI:R S:U C:L I:N A:N -> 3.1
-        score = calculate_cvss_score("CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N")
-        assert score == 3.1
-
-    def test_zero_impact_returns_zero(self):
-        from tools.report_tools import calculate_cvss_score
-
-        # C:N I:N A:N -> ISS=0 -> score=0
-        score = calculate_cvss_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N")
-        assert score == 0.0
-
-    def test_version_30_accepted(self):
-        from tools.report_tools import calculate_cvss_score
-
-        score = calculate_cvss_score("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
-        assert score == 9.8
-
-    def test_malformed_version_raises(self):
-        from tools.report_tools import calculate_cvss_score
-
-        with pytest.raises(ValueError, match="Unrecognised CVSS version"):
-            calculate_cvss_score("CVSS:2.0/AV:N/AC:L/Au:N/C:C/I:C/A:C")
-
-    def test_missing_metric_raises(self):
-        from tools.report_tools import calculate_cvss_score
-
-        with pytest.raises(ValueError, match="Missing or unknown CVSS metric"):
-            calculate_cvss_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H")
-
-    def test_malformed_component_raises(self):
-        from tools.report_tools import calculate_cvss_score
-
-        with pytest.raises(ValueError, match="Malformed metric"):
-            calculate_cvss_score("CVSS:3.1/AV:N/BADCOMPONENT/PR:N/UI:N/S:U/C:H/I:H/A:H")
-
-    def test_result_in_valid_range(self):
-        from tools.report_tools import calculate_cvss_score
-
-        score = calculate_cvss_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
-        assert 0.0 <= score <= 10.0
+        path = tmp_path / "verified.json"
+        path.write_text(json.dumps([verified_vuln.model_dump(mode="json")]))
+        loaded = load_verified(path)
+        assert len(loaded) == 1
+        assert loaded[0].vuln_class == verified_vuln.vuln_class

--- a/tests/test_squad_tools.py
+++ b/tests/test_squad_tools.py
@@ -70,8 +70,8 @@ class TestProgrammeManagerTools:
 
 
 class TestOsintAnalystTools:
-    def test_recon_tool(self, programme, recon_result, tmp_path) -> None:
-        from squad.osint_analyst import recon_tool
+    def test_run_initial_sweep_tool(self, programme, recon_result, tmp_path) -> None:
+        from squad.osint_analyst import run_initial_sweep_tool
 
         with (
             patch("squad.osint_analyst.http.set_programme") as mhttp,
@@ -84,12 +84,291 @@ class TestOsintAnalystTools:
             patch("squad.osint_analyst.run_recon", return_value=recon_result) as mrun,
             patch("runtime.run_dir", return_value=tmp_path),
         ):
-            result = recon_tool.func("acme")
+            result = run_initial_sweep_tool.func("acme")
+
+        assert result == "sweep.json"
+        assert (tmp_path / "sweep.json").exists()
+        mhttp.assert_called_once_with("acme")
+        mrun.assert_called_once_with(programme)
+
+    @staticmethod
+    def _patch_programme(programme):
+        return [
+            patch("squad.osint_analyst.http.set_programme"),
+            patch(
+                "squad.osint_analyst.h1.get_programme_policy",
+                return_value={"data": {}},
+            ),
+            patch("squad.osint_analyst.h1.get_structured_scope", return_value={}),
+            patch("squad.osint_analyst.h1.parse_programme", return_value=programme),
+        ]
+
+    def test_annotate_host_tool_writes_insight_and_returns_validation(
+        self, programme, recon_result, tmp_path
+    ) -> None:
+        from squad.osint_analyst import annotate_host_tool
+
+        (tmp_path / "sweep.json").write_text(recon_result.model_dump_json(), encoding="utf-8")
+
+        patches = self._patch_programme(programme) + [
+            patch("tools.recon_insights.runtime.run_dir", return_value=tmp_path),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            result = annotate_host_tool.func(
+                hostname="api.example.com",
+                role="api",
+                priority="high",
+                notes=(
+                    "Public REST gateway running Nginx in front of a React SPA; "
+                    "primary attack surface for the programme."
+                ),
+                detected_tech=["Nginx", "React"],
+                programme_handle="test-programme",
+            )
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        assert isinstance(result, dict)
+        assert result["validation"]["ok"] is True
+        assert (tmp_path / "host_insights" / "api.example.com.json").exists()
+
+    def test_annotate_host_tool_surfaces_validation_issues(
+        self, programme, recon_result, tmp_path
+    ) -> None:
+        from squad.osint_analyst import annotate_host_tool
+
+        (tmp_path / "sweep.json").write_text(recon_result.model_dump_json(), encoding="utf-8")
+
+        patches = self._patch_programme(programme) + [
+            patch("tools.recon_insights.runtime.run_dir", return_value=tmp_path),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            result = annotate_host_tool.func(
+                hostname="api.example.com",
+                role="api",
+                priority="high",
+                notes="too short",  # < 30 chars, also < 60 high-priority floor
+                detected_tech=["Nginx"],
+                programme_handle="test-programme",
+            )
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        assert isinstance(result, dict)
+        assert result["validation"]["ok"] is False
+        sections = {i["section"] for i in result["validation"]["issues"]}
+        assert "notes" in sections
+
+    def test_uncovered_hosts_tool_returns_missing(self, programme, recon_result, tmp_path) -> None:
+        from squad.osint_analyst import uncovered_hosts_tool
+
+        (tmp_path / "sweep.json").write_text(recon_result.model_dump_json(), encoding="utf-8")
+        with patch("tools.recon_insights.runtime.run_dir", return_value=tmp_path):
+            result = uncovered_hosts_tool.func()
+
+        assert isinstance(result, list)
+        # recon_result fixture has https://api.example.com with status 200 -> interesting
+        assert "api.example.com" in result
+
+    def test_finalise_recon_tool_writes_recon_json(self, programme, recon_result, tmp_path) -> None:
+        from squad.osint_analyst import annotate_host_tool, finalise_recon_tool
+
+        (tmp_path / "sweep.json").write_text(recon_result.model_dump_json(), encoding="utf-8")
+
+        patches = self._patch_programme(programme) + [
+            patch("tools.recon_insights.runtime.run_dir", return_value=tmp_path),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            annotate_host_tool.func(
+                hostname="api.example.com",
+                role="api",
+                priority="high",
+                notes=(
+                    "Public REST gateway running Nginx in front of a React SPA; "
+                    "primary attack surface for the programme."
+                ),
+                detected_tech=["Nginx", "React"],
+                programme_handle="test-programme",
+            )
+            result = finalise_recon_tool.func("test-programme")
+        finally:
+            for p in reversed(patches):
+                p.stop()
 
         assert result == "recon.json"
         assert (tmp_path / "recon.json").exists()
-        mhttp.assert_called_once_with("acme")
-        mrun.assert_called_once_with(programme)
+
+    def test_finalise_recon_tool_raises_without_insights(
+        self, programme, recon_result, tmp_path
+    ) -> None:
+        from squad.osint_analyst import finalise_recon_tool
+
+        (tmp_path / "sweep.json").write_text(recon_result.model_dump_json(), encoding="utf-8")
+
+        patches = self._patch_programme(programme) + [
+            patch("tools.recon_insights.runtime.run_dir", return_value=tmp_path),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            with pytest.raises(ValueError, match="no host_insights"):
+                finalise_recon_tool.func("test-programme")
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+    def test_probe_hostnames_tool(self, programme, endpoint) -> None:
+        from squad.osint_analyst import probe_hostnames_tool
+
+        patches = self._patch_programme(programme) + [
+            patch(
+                "squad.osint_analyst.filter_in_scope_impl",
+                return_value=["api.example.com"],
+            ),
+            patch(
+                "squad.osint_analyst.probe_endpoints_impl",
+                return_value=[endpoint],
+            ),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            result = probe_hostnames_tool.func(
+                ["api.example.com"], programme_handle="test-programme"
+            )
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        assert isinstance(result, list)
+        assert result[0]["url"] == endpoint.url
+
+    def test_probe_hostnames_tool_empty_list(self) -> None:
+        from squad.osint_analyst import probe_hostnames_tool
+
+        assert probe_hostnames_tool.func([], programme_handle="test-programme") == []
+
+    def test_probe_hostnames_tool_drops_out_of_scope(self, programme, bystander_url) -> None:
+        from urllib.parse import urlparse
+
+        from squad.osint_analyst import probe_hostnames_tool
+
+        oos_host = urlparse(bystander_url).hostname
+        mprobe = MagicMock()
+        patches = self._patch_programme(programme) + [
+            patch(
+                "squad.osint_analyst.filter_in_scope_impl",
+                return_value=[],
+            ),
+            patch("squad.osint_analyst.probe_endpoints_impl", mprobe),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            result = probe_hostnames_tool.func([oos_host], programme_handle="test-programme")
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        assert result == []
+        mprobe.assert_not_called()
+
+    def test_detect_takeover_candidates_tool(self, programme) -> None:
+        from squad.osint_analyst import detect_takeover_candidates_tool
+        from tools.recon.dnsx import TakeoverCandidate
+
+        candidate = TakeoverCandidate(
+            hostname="legacy.example.com",
+            cname="bucket.s3.amazonaws.com",
+            reason="cname_to_vulnerable_provider",
+            service="AWS S3",
+        )
+        patches = self._patch_programme(programme) + [
+            patch(
+                "squad.osint_analyst.filter_in_scope_impl",
+                return_value=["legacy.example.com"],
+            ),
+            patch(
+                "squad.osint_analyst.detect_takeover_candidates",
+                return_value=[candidate],
+            ),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            result = detect_takeover_candidates_tool.func(
+                ["legacy.example.com"], programme_handle="test-programme"
+            )
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        assert isinstance(result, list)
+        assert result == [
+            {
+                "hostname": "legacy.example.com",
+                "cname": "bucket.s3.amazonaws.com",
+                "reason": "cname_to_vulnerable_provider",
+                "service": "AWS S3",
+            }
+        ]
+
+    def test_detect_takeover_candidates_tool_empty(self) -> None:
+        from squad.osint_analyst import detect_takeover_candidates_tool
+
+        assert detect_takeover_candidates_tool.func([], programme_handle="test-programme") == []
+
+    def test_detect_takeover_candidates_tool_drops_out_of_scope(
+        self, programme, bystander_url
+    ) -> None:
+        from urllib.parse import urlparse
+
+        from squad.osint_analyst import detect_takeover_candidates_tool
+
+        oos_host = urlparse(bystander_url).hostname
+        mdetect = MagicMock()
+        patches = self._patch_programme(programme) + [
+            patch(
+                "squad.osint_analyst.filter_in_scope_impl",
+                return_value=[],
+            ),
+            patch("squad.osint_analyst.detect_takeover_candidates", mdetect),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            result = detect_takeover_candidates_tool.func(
+                [oos_host], programme_handle="test-programme"
+            )
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        assert result == []
+        mdetect.assert_not_called()
+
+    def test_lookup_cwe_tool(self) -> None:
+        from squad.osint_analyst import lookup_cwe_tool
+
+        result = lookup_cwe_tool.func("XSS")
+        assert isinstance(result, list)
+        assert result
+        assert result[0]["cwe_id"] == 79
+
+    def test_lookup_owasp_tool(self) -> None:
+        from squad.osint_analyst import lookup_owasp_tool
+
+        result = lookup_owasp_tool.func("sql injection")
+        assert isinstance(result, list)
+        assert any("SQL_Injection_Prevention" in r["url"] for r in result)
 
     def test_cert_transparency_tool(self) -> None:
         from squad.osint_analyst import cert_transparency_tool
@@ -202,6 +481,240 @@ class TestVulnerabilityResearcherTools:
         assert len(result) == 1
         assert result[0]["title"] is None
         assert result[0]["severity"] is None
+
+    # Triage-task tools
+
+    @staticmethod
+    def _write_findings(tmp_path, raw_finding_high) -> None:
+        (tmp_path / "findings.json").write_text(
+            json.dumps([raw_finding_high.model_dump(mode="json")]),
+            encoding="utf-8",
+        )
+
+    @staticmethod
+    def _good_authoring(**overrides):
+        base = {
+            "finding_index": 0,
+            "severity_decision": "keep",
+            "severity": "high",
+            "severity_rationale": (
+                "Unauthenticated SQLi at a public endpoint with full DB read "
+                "available - matches the PT high call."
+            ),
+            "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "title": "SQL Injection in /search?q allows database extraction",
+            "description": (
+                "The /search endpoint concatenates q into a SELECT statement without "
+                "parameterisation. sqlmap exploits classic UNION-based injection to "
+                "extract rows from the users table."
+            ),
+            "steps_to_reproduce": [
+                "GET https://api.example.com/search?q=test' UNION SELECT 1,2,3-- ",
+                "Observe the response body contains the union'd rows.",
+            ],
+            "impact": (
+                "An authenticated attacker dumps the users table including bcrypt "
+                "hashes and emails, enabling offline cracking and account takeover."
+            ),
+            "remediation": (
+                "Use parameterised queries throughout. See "
+                "https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html"
+            ),
+            "programme_handle": "test-programme",
+        }
+        base.update(overrides)
+        return base
+
+    def test_list_raw_findings_tool(self, raw_finding_high, tmp_path) -> None:
+        from squad.vulnerability_researcher import list_raw_findings_tool
+
+        self._write_findings(tmp_path, raw_finding_high)
+        with patch("tools.workspace.runtime.run_dir", return_value=tmp_path):
+            result = list_raw_findings_tool.func()
+
+        assert isinstance(result, list)
+        assert result[0]["index"] == 0
+        assert result[0]["vuln_class"] == raw_finding_high.vuln_class
+        assert result[0]["evidence_bytes"] == len(raw_finding_high.evidence)
+
+    def test_read_raw_finding_tool(self, raw_finding_high, tmp_path) -> None:
+        from squad.vulnerability_researcher import read_raw_finding_tool
+
+        self._write_findings(tmp_path, raw_finding_high)
+        with patch("tools.workspace.runtime.run_dir", return_value=tmp_path):
+            result = read_raw_finding_tool.func(0)
+
+        assert isinstance(result, dict)
+        assert result["target"] == raw_finding_high.target
+
+    def test_read_raw_finding_tool_rejects_out_of_range(self, raw_finding_high, tmp_path) -> None:
+        from squad.vulnerability_researcher import read_raw_finding_tool
+
+        self._write_findings(tmp_path, raw_finding_high)
+        with patch("tools.workspace.runtime.run_dir", return_value=tmp_path):
+            with pytest.raises(ValueError, match="out of range"):
+                read_raw_finding_tool.func(5)
+
+    def test_lookup_cwe_tool_finds_known_class(self) -> None:
+        from squad.vulnerability_researcher import lookup_cwe_tool
+
+        result = lookup_cwe_tool.func("SQLi")
+        assert isinstance(result, list)
+        assert result
+        assert result[0]["cwe_id"] == 89
+
+    def test_lookup_owasp_tool_returns_cheatsheet(self) -> None:
+        from squad.vulnerability_researcher import lookup_owasp_tool
+
+        result = lookup_owasp_tool.func("sql injection")
+        assert isinstance(result, list)
+        assert any("SQL_Injection_Prevention" in r["url"] for r in result)
+
+    def test_calculate_cvss_tool(self) -> None:
+        from squad.vulnerability_researcher import calculate_cvss_tool
+
+        result = calculate_cvss_tool.func("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
+        assert result == 9.8
+
+    @staticmethod
+    def _patch_programme(programme):
+        return [
+            patch("squad.vulnerability_researcher.http.set_programme"),
+            patch(
+                "squad.vulnerability_researcher.h1.get_programme_policy",
+                return_value={"data": {}},
+            ),
+            patch("squad.vulnerability_researcher.h1.get_structured_scope", return_value={}),
+            patch(
+                "squad.vulnerability_researcher.h1.parse_programme",
+                return_value=programme,
+            ),
+        ]
+
+    def test_assess_finding_tool_writes_assessment_and_returns_validation(
+        self, raw_finding_high, programme, tmp_path
+    ) -> None:
+        from squad.vulnerability_researcher import assess_finding_tool
+
+        self._write_findings(tmp_path, raw_finding_high)
+        patches = self._patch_programme(programme) + [
+            patch("tools.workspace.runtime.run_dir", return_value=tmp_path),
+            patch("tools.triage_tools.runtime.run_dir", return_value=tmp_path),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            result = assess_finding_tool.func(**self._good_authoring())
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        assert isinstance(result, dict)
+        assert result["validation"]["ok"] is True
+        assert (tmp_path / "assessments" / "000.json").exists()
+
+    def test_assess_finding_tool_surfaces_validation_issues(
+        self, raw_finding_high, programme, tmp_path
+    ) -> None:
+        from squad.vulnerability_researcher import assess_finding_tool
+
+        self._write_findings(tmp_path, raw_finding_high)
+        patches = self._patch_programme(programme) + [
+            patch("tools.workspace.runtime.run_dir", return_value=tmp_path),
+            patch("tools.triage_tools.runtime.run_dir", return_value=tmp_path),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            result = assess_finding_tool.func(**self._good_authoring(description="Too short."))
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        assert isinstance(result, dict)
+        assert result["validation"]["ok"] is False
+        sections = {i["section"] for i in result["validation"]["issues"]}
+        assert "description" in sections
+
+    def test_discard_finding_tool_writes_discard(self, raw_finding_high, tmp_path) -> None:
+        from squad.vulnerability_researcher import discard_finding_tool
+
+        self._write_findings(tmp_path, raw_finding_high)
+        with (
+            patch("tools.workspace.runtime.run_dir", return_value=tmp_path),
+            patch("tools.triage_tools.runtime.run_dir", return_value=tmp_path),
+        ):
+            result = discard_finding_tool.func(
+                finding_index=0,
+                reason="false_positive",
+                rationale="On reproduction the tool's marker did not appear.",
+            )
+
+        assert isinstance(result, dict)
+        assert (tmp_path / "discards" / "000.json").exists()
+
+    def test_discard_finding_tool_rejects_thin_rationale(self, raw_finding_high, tmp_path) -> None:
+        from squad.vulnerability_researcher import discard_finding_tool
+
+        self._write_findings(tmp_path, raw_finding_high)
+        with (
+            patch("tools.workspace.runtime.run_dir", return_value=tmp_path),
+            patch("tools.triage_tools.runtime.run_dir", return_value=tmp_path),
+        ):
+            with pytest.raises(ValueError, match="at least 10 chars"):
+                discard_finding_tool.func(
+                    finding_index=0, reason="false_positive", rationale="nope"
+                )
+
+    def test_finalise_triage_tool_consolidates_assessments(
+        self, raw_finding_high, programme, tmp_path
+    ) -> None:
+        from squad.vulnerability_researcher import assess_finding_tool, finalise_triage_tool
+
+        self._write_findings(tmp_path, raw_finding_high)
+        patches = self._patch_programme(programme) + [
+            patch("tools.workspace.runtime.run_dir", return_value=tmp_path),
+            patch("tools.triage_tools.runtime.run_dir", return_value=tmp_path),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            assess_finding_tool.func(**self._good_authoring())
+            result = finalise_triage_tool.func("test-programme")
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        assert result == "verified.json"
+        assert (tmp_path / "verified.json").exists()
+
+    def test_finalise_triage_tool_raises_on_unprocessed(
+        self, raw_finding_high, programme, tmp_path
+    ) -> None:
+        from squad.vulnerability_researcher import finalise_triage_tool
+
+        # write TWO raw findings but assess none
+        (tmp_path / "findings.json").write_text(
+            json.dumps(
+                [
+                    raw_finding_high.model_dump(mode="json"),
+                    raw_finding_high.model_dump(mode="json"),
+                ]
+            ),
+            encoding="utf-8",
+        )
+        patches = self._patch_programme(programme) + [
+            patch("tools.workspace.runtime.run_dir", return_value=tmp_path),
+            patch("tools.triage_tools.runtime.run_dir", return_value=tmp_path),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            with pytest.raises(ValueError, match="no assessment or discard"):
+                finalise_triage_tool.func("test-programme")
+        finally:
+            for p in reversed(patches):
+                p.stop()
 
 
 # ----------------------------------------------------------------------------

--- a/tests/test_squad_tools.py
+++ b/tests/test_squad_tools.py
@@ -210,37 +210,146 @@ class TestVulnerabilityResearcherTools:
 
 
 class TestTechnicalAuthorTools:
-    def test_create_reports_tool(self, verified_vuln, disclosure_report, tmp_path) -> None:
-        from squad.technical_author import create_reports_tool
-
-        verified_path = tmp_path / "verified.json"
-        verified_path.write_text(
+    @staticmethod
+    def _write_verified(tmp_path, verified_vuln) -> None:
+        (tmp_path / "verified.json").write_text(
             json.dumps([verified_vuln.model_dump(mode="json")]),
             encoding="utf-8",
         )
+
+    @staticmethod
+    def _good_authoring(**overrides):
+        base = {
+            "finding_index": 0,
+            "title": "SQL Injection in /search?q allows full database extraction",
+            "summary": (
+                "The /search endpoint concatenates user input into a SELECT statement. "
+                "An unauthenticated attacker can dump the entire users table."
+            ),
+            "description": (
+                "The handler at routes/search.py concatenates the q parameter directly "
+                "into the SQL statement with no parameterisation. Standard UNION-based "
+                "injection extracts arbitrary rows from the users table."
+            ),
+            "steps_to_reproduce": [
+                "Issue GET https://api.example.com/search?q=test' UNION SELECT 1,2,3-- ",
+                "Observe the response body contains the union'd rows.",
+            ],
+            "evidence": 'HTTP/1.1 200 OK\n\n[{"username":"alice"}]',
+            "impact": (
+                "An unauthenticated attacker can dump the entire users table including "
+                "bcrypt hashes and email addresses, enabling offline cracking and full "
+                "account takeover."
+            ),
+            "remediation": (
+                "Use parameterised queries throughout the ORM. See "
+                "https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html"
+            ),
+            "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "cwe_id": 89,
+        }
+        base.update(overrides)
+        return base
+
+    def test_draft_report_tool_writes_draft_and_returns_validation(
+        self, verified_vuln, tmp_path
+    ) -> None:
+        from squad.technical_author import draft_report_tool
+
+        self._write_verified(tmp_path, verified_vuln)
         with (
             patch("tools.workspace.runtime.run_dir", return_value=tmp_path),
-            patch(
-                "squad.technical_author.create_disclosure_report",
-                return_value=disclosure_report,
-            ),
-            patch("squad.technical_author.save_report") as msave,
-            patch("runtime.run_dir", return_value=tmp_path),
+            patch("tools.report_tools.runtime.run_dir", return_value=tmp_path),
         ):
-            result = create_reports_tool.func("verified.json", "acme", "summary line")
+            result = draft_report_tool.func(**self._good_authoring())
+
+        assert isinstance(result, dict)
+        assert result["validation"]["ok"] is True
+        assert (tmp_path / "drafts" / "000.json").exists()
+
+    def test_draft_report_tool_surfaces_validation_issues(self, verified_vuln, tmp_path) -> None:
+        from squad.technical_author import draft_report_tool
+
+        self._write_verified(tmp_path, verified_vuln)
+        with (
+            patch("tools.workspace.runtime.run_dir", return_value=tmp_path),
+            patch("tools.report_tools.runtime.run_dir", return_value=tmp_path),
+        ):
+            result = draft_report_tool.func(**self._good_authoring(title="bad title"))
+
+        assert isinstance(result, dict)
+        assert result["validation"]["ok"] is False
+        sections = {i["section"] for i in result["validation"]["issues"]}
+        assert "title" in sections
+
+    def test_draft_report_tool_rejects_out_of_range_index(self, verified_vuln, tmp_path) -> None:
+        from squad.technical_author import draft_report_tool
+
+        self._write_verified(tmp_path, verified_vuln)
+        with (
+            patch("tools.workspace.runtime.run_dir", return_value=tmp_path),
+            patch("tools.report_tools.runtime.run_dir", return_value=tmp_path),
+        ):
+            with pytest.raises(ValueError, match="out of range"):
+                draft_report_tool.func(**self._good_authoring(finding_index=5))
+
+    def test_finalise_reports_tool_consolidates_drafts(self, verified_vuln, tmp_path) -> None:
+        from squad.technical_author import draft_report_tool, finalise_reports_tool
+
+        self._write_verified(tmp_path, verified_vuln)
+        with (
+            patch("tools.workspace.runtime.run_dir", return_value=tmp_path),
+            patch("tools.report_tools.runtime.run_dir", return_value=tmp_path),
+        ):
+            draft_report_tool.func(**self._good_authoring())
+            result = finalise_reports_tool.func("acme", "Session summary line.")
 
         assert result == "reports.json"
         assert (tmp_path / "reports.json").exists()
-        msave.assert_called_once_with(disclosure_report)
 
-    def test_create_reports_tool_raises_when_verified_empty(self, tmp_path) -> None:
-        from squad.technical_author import create_reports_tool
+    def test_finalise_reports_tool_raises_on_unresolved_errors(
+        self, verified_vuln, tmp_path
+    ) -> None:
+        from squad.technical_author import draft_report_tool, finalise_reports_tool
 
-        verified_path = tmp_path / "verified.json"
-        verified_path.write_text("[]", encoding="utf-8")
-        with patch("tools.workspace.runtime.run_dir", return_value=tmp_path):
-            with pytest.raises(ValueError, match="No verified findings"):
-                create_reports_tool.func("verified.json", "acme", "summary line")
+        self._write_verified(tmp_path, verified_vuln)
+        with (
+            patch("tools.workspace.runtime.run_dir", return_value=tmp_path),
+            patch("tools.report_tools.runtime.run_dir", return_value=tmp_path),
+        ):
+            draft_report_tool.func(**self._good_authoring(title="bad title"))
+            with pytest.raises(ValueError, match="unresolved errors"):
+                finalise_reports_tool.func("acme", "Summary.")
+
+    def test_sanitise_evidence_tool_returns_redactions(self) -> None:
+        from squad.technical_author import sanitise_evidence_tool
+
+        result = sanitise_evidence_tool.func("Authorization: Bearer abc.def.ghi")
+        assert isinstance(result, dict)
+        assert "Bearer abc.def.ghi" not in result["sanitised"]
+        assert result["redactions"]
+
+    def test_lookup_cwe_tool_finds_known_class(self) -> None:
+        from squad.technical_author import lookup_cwe_tool
+
+        result = lookup_cwe_tool.func("SQLi")
+        assert isinstance(result, list)
+        assert result
+        assert result[0]["cwe_id"] == 89
+        assert "cwe.mitre.org" in result[0]["url"]
+
+    def test_lookup_cwe_tool_empty_for_unknown(self) -> None:
+        from squad.technical_author import lookup_cwe_tool
+
+        assert lookup_cwe_tool.func("zzz-not-a-class") == []
+
+    def test_lookup_owasp_tool_returns_cheatsheet(self) -> None:
+        from squad.technical_author import lookup_owasp_tool
+
+        result = lookup_owasp_tool.func("sql injection")
+        assert isinstance(result, list)
+        assert result
+        assert any("SQL_Injection_Prevention" in r["url"] for r in result)
 
     def test_calculate_cvss_tool(self) -> None:
         from squad.technical_author import calculate_cvss_tool
@@ -253,6 +362,36 @@ class TestTechnicalAuthorTools:
 
         assert result == 8.8
         m.assert_called_once_with("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
+
+    def test_list_programme_reports_tool(self) -> None:
+        from squad.technical_author import list_programme_reports_tool
+
+        h1_reports = [
+            {
+                "id": "1",
+                "attributes": {
+                    "title": "Existing report",
+                    "severity_rating": "high",
+                    "state": "triaged",
+                },
+            }
+        ]
+        with (
+            patch("squad.technical_author.http.set_programme") as mhttp,
+            patch("squad.technical_author.h1.list_reports", return_value=h1_reports) as mlist,
+        ):
+            result = list_programme_reports_tool.func("acme", page_size=10)
+
+        assert result == [
+            {
+                "report_id": "1",
+                "title": "Existing report",
+                "severity": "high",
+                "state": "triaged",
+            }
+        ]
+        mhttp.assert_called_once_with("acme")
+        mlist.assert_called_once_with("acme", page_size=10)
 
 
 # ----------------------------------------------------------------------------

--- a/tests/test_triage_tools.py
+++ b/tests/test_triage_tools.py
@@ -1,0 +1,428 @@
+"""
+tests/test_triage_tools.py - unit tests for tools/triage_tools.py.
+
+Coverage targets the four primitive layers the Vulnerability Researcher
+depends on:
+
+* Severity / scope gates (above_floor, in_scope)
+* Per-finding validation (validate_assessment)
+* Draft persistence (save_assessment, save_discard, mutual eviction)
+* Finalisation (finalise_triage)
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from models import RawFinding, Severity, VerifiedVulnerability
+from tools.triage_tools import (
+    DiscardEntry,
+    DiscardReason,
+    SeverityDecision,
+    TriageAssessment,
+    TriageFinalisationError,
+    finalise_triage,
+    in_scope,
+    load_assessments,
+    load_discards,
+    save_assessment,
+    save_discard,
+    validate_assessment,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# Severity / scope gates
+
+
+class TestAboveFloor:
+    """The floor reads ``config.scan.min_severity`` at call time, so swap the
+    underlying ScanConfig rather than reloading the module - reloading replaces
+    class identities (TriageAssessment, TriageFinalisationError, ...) and
+    breaks other tests' isinstance / pytest.raises matching."""
+
+    def _floor_at(self, monkeypatch, floor: Severity) -> None:
+        from tools import triage_tools
+
+        original_scan = triage_tools.config.scan
+
+        class _Scan:
+            def __getattr__(self, name):
+                if name == "min_severity":
+                    return floor.value
+                return getattr(original_scan, name)
+
+        monkeypatch.setattr(triage_tools.config, "scan", _Scan())
+
+    def test_high_above_low_floor(self, monkeypatch):
+        from tools.triage_tools import above_floor
+
+        self._floor_at(monkeypatch, Severity.LOW)
+        assert above_floor(Severity.HIGH) is True
+
+    def test_low_below_medium_floor(self, monkeypatch):
+        from tools.triage_tools import above_floor
+
+        self._floor_at(monkeypatch, Severity.MEDIUM)
+        assert above_floor(Severity.LOW) is False
+
+
+class TestInScope:
+    def test_in_scope(self, programme, victim_url):
+        assert in_scope(f"{victim_url}/x", programme) is True
+
+    def test_out_of_scope(self, programme, bystander_url):
+        assert in_scope(f"{bystander_url}/x", programme) is False
+
+
+# Fixtures
+
+
+def _good_assessment(raw: RawFinding, **overrides) -> TriageAssessment:
+    base: dict = {
+        "finding_index": 0,
+        "target": raw.target,
+        "vuln_class": raw.vuln_class,
+        "severity_hint": raw.severity_hint,
+        "severity_decision": SeverityDecision.KEEP,
+        "severity": raw.severity_hint,
+        "severity_rationale": (
+            "Unauthenticated SQLi at a public endpoint with full DB read - "
+            "blast radius is every row in users table."
+        ),
+        "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "cvss_score": 9.8,
+        "title": "SQL Injection in /search?q allows full database extraction",
+        "description": (
+            "The /search endpoint concatenates the q parameter directly into a "
+            "SELECT statement without parameterisation. sqlmap exploited classic "
+            "UNION-based injection to extract arbitrary rows from the users table."
+        ),
+        "steps_to_reproduce": [
+            "GET https://api.example.com/search?q=test' UNION SELECT 1,2,3-- ",
+            "Observe the response body returns the union'd rows alongside legitimate hits.",
+        ],
+        "impact": (
+            "An unauthenticated attacker dumps the entire users table including "
+            "bcrypt hashes and emails, enabling offline cracking and full "
+            "account takeover."
+        ),
+        "remediation": (
+            "Use parameterised queries throughout. See "
+            "https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html"
+        ),
+    }
+    base.update(overrides)
+    if "severity" in overrides or "severity_hint" in overrides:
+        # severity_decision must agree with the severity vs severity_hint relation
+        if base["severity"] != base["severity_hint"]:
+            base.setdefault("severity_decision", SeverityDecision.RAISE)
+    return TriageAssessment(**base)
+
+
+@pytest.fixture
+def in_scope_raw() -> RawFinding:
+    return RawFinding(
+        title="SQL Injection - https://api.example.com/search",
+        vuln_class="SQLi",
+        target="https://api.example.com/search",
+        evidence="sqlmap detected injection at parameter q",
+        tool="sqlmap",
+        severity_hint=Severity.HIGH,
+    )
+
+
+@pytest.fixture
+def oos_raw(bystander_url) -> RawFinding:
+    return RawFinding(
+        title="Header issue",
+        vuln_class="Headers",
+        target=f"{bystander_url}/x",
+        evidence="missing X-Frame-Options",
+        tool="nuclei",
+        severity_hint=Severity.HIGH,
+    )
+
+
+# Validation
+
+
+class TestValidateAssessment:
+    def test_clean_assessment_passes(self, in_scope_raw, programme):
+        a = _good_assessment(in_scope_raw)
+        report = validate_assessment(a, in_scope_raw, programme)
+        assert report.ok is True
+        assert all(i.severity != "error" for i in report.issues)
+
+    def test_rejects_target_rewrite(self, in_scope_raw, programme):
+        a = _good_assessment(in_scope_raw, target="https://api.example.com/different")
+        report = validate_assessment(a, in_scope_raw, programme)
+        assert report.ok is False
+        assert any(i.section == "target" and "do not rewrite" in i.message for i in report.issues)
+
+    def test_rejects_vuln_class_rewrite(self, in_scope_raw, programme):
+        a = _good_assessment(in_scope_raw, vuln_class="SomethingElse")
+        report = validate_assessment(a, in_scope_raw, programme)
+        assert report.ok is False
+        assert any(i.section == "vuln_class" for i in report.issues)
+
+    def test_rejects_out_of_scope_target(self, oos_raw, programme):
+        a = _good_assessment(oos_raw)
+        report = validate_assessment(a, oos_raw, programme)
+        assert report.ok is False
+        assert any(
+            i.section == "target" and "out of programme scope" in i.message for i in report.issues
+        )
+
+    def test_rejects_below_floor(self, in_scope_raw, programme, monkeypatch):
+        # Below-LOW: with default floor (low), informational is below.
+        a = _good_assessment(
+            in_scope_raw,
+            severity=Severity.INFORMATIONAL,
+            severity_hint=Severity.INFORMATIONAL,
+            severity_decision=SeverityDecision.KEEP,
+        )
+        # Need raw to match severity_hint
+        raw = in_scope_raw.model_copy(update={"severity_hint": Severity.INFORMATIONAL})
+        report = validate_assessment(a, raw, programme)
+        assert any(i.section == "severity" for i in report.issues)
+
+    def test_rejects_keep_with_mismatched_severity(self, in_scope_raw, programme):
+        a = _good_assessment(
+            in_scope_raw,
+            severity=Severity.CRITICAL,
+            severity_decision=SeverityDecision.KEEP,
+        )
+        report = validate_assessment(a, in_scope_raw, programme)
+        assert any(i.section == "severity_decision" for i in report.issues)
+
+    def test_rejects_raise_with_same_severity(self, in_scope_raw, programme):
+        a = _good_assessment(in_scope_raw, severity_decision=SeverityDecision.RAISE)
+        report = validate_assessment(a, in_scope_raw, programme)
+        assert any(i.section == "severity_decision" for i in report.issues)
+
+    def test_rejects_thin_severity_rationale(self, in_scope_raw, programme):
+        a = _good_assessment(in_scope_raw, severity_rationale="too short")
+        report = validate_assessment(a, in_scope_raw, programme)
+        assert any(i.section == "severity_rationale" for i in report.issues)
+
+    def test_rejects_stale_description(self, in_scope_raw, programme):
+        a = _good_assessment(
+            in_scope_raw,
+            description="Automated detection of SQLi at https://api.example.com/search.",
+        )
+        report = validate_assessment(a, in_scope_raw, programme)
+        assert any(i.section == "description" and "boilerplate" in i.message for i in report.issues)
+
+    def test_rejects_thin_description(self, in_scope_raw, programme):
+        a = _good_assessment(in_scope_raw, description="Too short.")
+        report = validate_assessment(a, in_scope_raw, programme)
+        assert any(i.section == "description" for i in report.issues)
+
+    def test_rejects_hand_wavy_impact(self, in_scope_raw, programme):
+        a = _good_assessment(
+            in_scope_raw,
+            impact="An attacker could compromise user data of various kinds in this app.",
+        )
+        report = validate_assessment(a, in_scope_raw, programme)
+        assert any(i.section == "impact" and "hand-wavy" in i.message for i in report.issues)
+
+    def test_rejects_stale_impact_placeholder(self, in_scope_raw, programme):
+        a = _good_assessment(
+            in_scope_raw,
+            impact="Potential SQLi impact - pending manual review by the team here.",
+        )
+        report = validate_assessment(a, in_scope_raw, programme)
+        assert any(
+            i.section == "impact" and "pending manual review" in i.message for i in report.issues
+        )
+
+    def test_rejects_remediation_without_url(self, in_scope_raw, programme):
+        a = _good_assessment(
+            in_scope_raw, remediation="Use parameterised queries throughout the codebase."
+        )
+        report = validate_assessment(a, in_scope_raw, programme)
+        assert any(i.section == "remediation" for i in report.issues)
+
+    def test_rejects_stale_step_placeholder(self, in_scope_raw, programme):
+        a = _good_assessment(
+            in_scope_raw,
+            steps_to_reproduce=[
+                "GET https://api.example.com/search?q=test' UNION SELECT 1,2,3-- ",
+                "Observe the following evidence:",
+            ],
+        )
+        report = validate_assessment(a, in_scope_raw, programme)
+        assert any(
+            i.section == "steps_to_reproduce" and "placeholder" in i.message for i in report.issues
+        )
+
+    def test_rejects_cvss_mismatch(self, in_scope_raw, programme):
+        a = _good_assessment(in_scope_raw, cvss_score=5.0)
+        report = validate_assessment(a, in_scope_raw, programme)
+        assert any(i.section == "cvss" and i.severity == "error" for i in report.issues)
+
+    def test_warns_when_cvss_band_disagrees_with_severity(self, in_scope_raw, programme):
+        # Vector computes to 9.8 (critical) but severity says HIGH (keep matches hint)
+        a = _good_assessment(in_scope_raw)
+        report = validate_assessment(a, in_scope_raw, programme)
+        assert any(
+            i.section == "cvss" and i.severity == "warning" and "implies severity" in i.message
+            for i in report.issues
+        )
+
+
+# Persistence
+
+
+class TestPersistence:
+    def test_save_assessment_writes_indexed_file(self, in_scope_raw, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.triage_tools.runtime.run_dir", lambda: tmp_path)
+        path = save_assessment(_good_assessment(in_scope_raw, finding_index=4))
+        assert path == tmp_path / "assessments" / "004.json"
+        assert path.exists()
+
+    def test_save_discard_writes_indexed_file(self, in_scope_raw, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.triage_tools.runtime.run_dir", lambda: tmp_path)
+        d = DiscardEntry(
+            finding_index=2,
+            target=in_scope_raw.target,
+            vuln_class=in_scope_raw.vuln_class,
+            severity_hint=in_scope_raw.severity_hint,
+            reason=DiscardReason.FALSE_POSITIVE,
+            rationale="Tool fired but evidence does not demonstrate exploitability.",
+        )
+        path = save_discard(d)
+        assert path == tmp_path / "discards" / "002.json"
+
+    def test_assessment_evicts_discard(self, in_scope_raw, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.triage_tools.runtime.run_dir", lambda: tmp_path)
+        # First discard, then change mind and assess
+        d = DiscardEntry(
+            finding_index=1,
+            target=in_scope_raw.target,
+            vuln_class=in_scope_raw.vuln_class,
+            severity_hint=in_scope_raw.severity_hint,
+            reason=DiscardReason.FALSE_POSITIVE,
+            rationale="Initial review thought this was noise.",
+        )
+        save_discard(d)
+        save_assessment(_good_assessment(in_scope_raw, finding_index=1))
+        assert not (tmp_path / "discards" / "001.json").exists()
+        assert (tmp_path / "assessments" / "001.json").exists()
+
+    def test_discard_evicts_assessment(self, in_scope_raw, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.triage_tools.runtime.run_dir", lambda: tmp_path)
+        save_assessment(_good_assessment(in_scope_raw, finding_index=1))
+        d = DiscardEntry(
+            finding_index=1,
+            target=in_scope_raw.target,
+            vuln_class=in_scope_raw.vuln_class,
+            severity_hint=in_scope_raw.severity_hint,
+            reason=DiscardReason.NON_EXPLOITABLE,
+            rationale="On second look, requires admin auth that no user holds.",
+        )
+        save_discard(d)
+        assert (tmp_path / "discards" / "001.json").exists()
+        assert not (tmp_path / "assessments" / "001.json").exists()
+
+
+# Finalisation
+
+
+class TestFinaliseTriage:
+    def test_writes_verified_json_for_clean_assessments(
+        self, in_scope_raw, tmp_path, monkeypatch, programme
+    ):
+        monkeypatch.setattr("tools.triage_tools.runtime.run_dir", lambda: tmp_path)
+        save_assessment(_good_assessment(in_scope_raw, finding_index=0))
+        path = finalise_triage(programme, [in_scope_raw])
+        assert path == tmp_path / "verified.json"
+        verified = json.loads(path.read_text())
+        assert len(verified) == 1
+        assert verified[0]["target"] == in_scope_raw.target
+
+    def test_refuses_unprocessed_findings(self, in_scope_raw, tmp_path, monkeypatch, programme):
+        monkeypatch.setattr("tools.triage_tools.runtime.run_dir", lambda: tmp_path)
+        save_assessment(_good_assessment(in_scope_raw, finding_index=0))
+        with pytest.raises(TriageFinalisationError, match=r"\[1\] have no assessment"):
+            finalise_triage(programme, [in_scope_raw, in_scope_raw])
+
+    def test_refuses_on_validation_errors(self, in_scope_raw, tmp_path, monkeypatch, programme):
+        monkeypatch.setattr("tools.triage_tools.runtime.run_dir", lambda: tmp_path)
+        save_assessment(_good_assessment(in_scope_raw, finding_index=0, description="Too short."))
+        with pytest.raises(TriageFinalisationError, match="unresolved errors"):
+            finalise_triage(programme, [in_scope_raw])
+
+    def test_discards_only_yields_empty_verified(
+        self, in_scope_raw, tmp_path, monkeypatch, programme
+    ):
+        monkeypatch.setattr("tools.triage_tools.runtime.run_dir", lambda: tmp_path)
+        save_discard(
+            DiscardEntry(
+                finding_index=0,
+                target=in_scope_raw.target,
+                vuln_class=in_scope_raw.vuln_class,
+                severity_hint=in_scope_raw.severity_hint,
+                reason=DiscardReason.FALSE_POSITIVE,
+                rationale="Confirmed false positive after manual reproduction.",
+            )
+        )
+        path = finalise_triage(programme, [in_scope_raw])
+        verified = json.loads(path.read_text())
+        assert verified == []
+
+    def test_builds_verified_vulnerability(self, in_scope_raw, tmp_path, monkeypatch, programme):
+        monkeypatch.setattr("tools.triage_tools.runtime.run_dir", lambda: tmp_path)
+        save_assessment(_good_assessment(in_scope_raw, finding_index=0))
+        finalise_triage(programme, [in_scope_raw])
+        verified = load_assessments()
+        assert verified[0].finding_index == 0
+
+    def test_carries_raw_evidence_into_verified(
+        self, in_scope_raw, tmp_path, monkeypatch, programme
+    ):
+        # The VR's authored fields go into description/impact/remediation; the
+        # evidence belongs to the PT and is carried through untouched (the TA
+        # sanitises it later).
+        monkeypatch.setattr("tools.triage_tools.runtime.run_dir", lambda: tmp_path)
+        save_assessment(_good_assessment(in_scope_raw, finding_index=0))
+        path = finalise_triage(programme, [in_scope_raw])
+        loaded = [VerifiedVulnerability.model_validate(v) for v in json.loads(path.read_text())]
+        assert loaded[0].evidence == in_scope_raw.evidence
+
+
+# Discard entry validity
+
+
+class TestDiscardEntry:
+    def test_serialises_round_trip(self, in_scope_raw):
+        d = DiscardEntry(
+            finding_index=3,
+            target=in_scope_raw.target,
+            vuln_class=in_scope_raw.vuln_class,
+            severity_hint=in_scope_raw.severity_hint,
+            reason=DiscardReason.OUT_OF_SCOPE,
+            rationale="Hostname not in structured scope; test asset belonging to vendor.",
+        )
+        again = DiscardEntry.model_validate_json(d.model_dump_json())
+        assert again.reason == DiscardReason.OUT_OF_SCOPE
+
+
+# Helper: load_discards
+
+
+class TestLoadDiscards:
+    def test_returns_empty_when_no_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.triage_tools.runtime.run_dir", lambda: tmp_path)
+        assert load_discards() == []
+
+
+# The `programme` and `victim_url` / `bystander_url` fixtures come from
+# tests/conftest.py - the shared `programme` includes `*.example.com` which
+# covers `victim_url` (https://victim.example.com), and `bystander_url`
+# (https://bystander.example.org) sits cleanly outside it for the scope-guard
+# tests.

--- a/tests/test_vuln_tools.py
+++ b/tests/test_vuln_tools.py
@@ -1,5 +1,11 @@
 """
-tests/test_vuln_tools.py - unit tests for tools/vuln_tools.py
+tests/test_vuln_tools.py - unit tests for the remaining helpers in
+tools/pentest/triage.py (scope check, NVD CVE lookup) and for the
+nuclei / CORS pentest helpers that historically lived alongside them.
+
+The mechanical ``triage_findings`` rollup and the ``_CVSS_DEFAULTS`` lookup
+table that backed it moved out when triage authoring was refactored into
+``tools/triage_tools.py`` - those tests now live in test_triage_tools.py.
 """
 
 from __future__ import annotations
@@ -8,71 +14,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from models import Endpoint, Severity, VerifiedVulnerability
-from tools.pentest import check_cors_misconfiguration, is_in_scope, run_nuclei, triage_findings
-from tools.pentest.triage import _lookup_cvss
+from models import Endpoint, Severity
+from tools.pentest import check_cors_misconfiguration, is_in_scope, run_nuclei
 
 pytestmark = pytest.mark.unit
-
-
-# _above_floor
-class TestAboveFloor:
-    def test_medium_above_medium_floor(self, monkeypatch):
-        monkeypatch.setenv("MIN_SEVERITY", "medium")
-        import importlib
-
-        import tools.pentest.triage as vt
-
-        importlib.reload(vt)
-        assert vt._above_floor(Severity.MEDIUM) is True
-
-    def test_low_below_medium_floor(self, monkeypatch):
-        monkeypatch.setenv("MIN_SEVERITY", "medium")
-        import importlib
-
-        import tools.pentest.triage as vt
-
-        importlib.reload(vt)
-        assert vt._above_floor(Severity.LOW) is False
-
-    def test_critical_always_above(self, monkeypatch):
-        monkeypatch.setenv("MIN_SEVERITY", "high")
-        import importlib
-
-        import tools.pentest.triage as vt
-
-        importlib.reload(vt)
-        assert vt._above_floor(Severity.CRITICAL) is True
-
-    def test_informational_below_low_floor(self, monkeypatch):
-        monkeypatch.setenv("MIN_SEVERITY", "low")
-        import importlib
-
-        import tools.pentest.triage as vt
-
-        importlib.reload(vt)
-        assert vt._above_floor(Severity.INFORMATIONAL) is False
-
-
-# _lookup_cvss
-class TestLookupCvss:
-    def test_sqli_critical(self):
-        score, vector = _lookup_cvss("SQLi", Severity.CRITICAL)
-        assert score == 9.8
-        assert "CVSS:3.1" in vector
-
-    def test_cors_high(self):
-        score, vector = _lookup_cvss("CORS", Severity.HIGH)
-        assert score == 7.4
-
-    def test_unknown_class_falls_back_to_default(self):
-        score, vector = _lookup_cvss("UnknownVulnType", Severity.HIGH)
-        assert score == 7.5
-
-    def test_returns_tuple(self):
-        result = _lookup_cvss("XSS", Severity.MEDIUM)
-        assert isinstance(result, tuple)
-        assert len(result) == 2
 
 
 # is_in_scope
@@ -82,49 +27,6 @@ class TestIsInScope:
 
     def test_out_of_scope_finding(self, raw_finding_oos, programme):
         assert is_in_scope(raw_finding_oos, programme) is False
-
-
-# triage_findings
-class TestTriageFindings:
-    def test_filters_out_of_scope(self, raw_finding_high, raw_finding_oos, programme):
-        results = triage_findings([raw_finding_high, raw_finding_oos], programme)
-        targets = [v.target for v in results]
-        assert raw_finding_oos.target not in targets
-
-    def test_filters_below_severity_floor(
-        self, raw_finding_high, raw_finding_low, programme, monkeypatch
-    ):
-        monkeypatch.setenv("MIN_SEVERITY", "medium")
-        import importlib
-
-        import tools.pentest.triage as vt
-
-        importlib.reload(vt)
-        results = vt.triage_findings([raw_finding_high, raw_finding_low], programme)
-        severities = [v.severity for v in results]
-        assert Severity.LOW not in severities
-
-    def test_assigns_cvss_score(self, raw_finding_high, programme):
-        results = triage_findings([raw_finding_high], programme)
-        assert len(results) == 1
-        assert results[0].cvss_score > 0
-        assert results[0].cvss_vector.startswith("CVSS:3.1")
-
-    def test_returns_verified_vulnerability_objects(self, raw_finding_high, programme):
-        results = triage_findings([raw_finding_high], programme)
-        for r in results:
-            assert isinstance(r, VerifiedVulnerability)
-
-    def test_empty_input_returns_empty(self, programme):
-        assert triage_findings([], programme) == []
-
-    def test_all_filtered_returns_empty(self, raw_finding_oos, programme):
-        assert triage_findings([raw_finding_oos], programme) == []
-
-    def test_preserves_title_and_target(self, raw_finding_high, programme):
-        results = triage_findings([raw_finding_high], programme)
-        assert results[0].title == raw_finding_high.title
-        assert results[0].target == raw_finding_high.target
 
 
 # run_nuclei

--- a/tools/cwe_data.py
+++ b/tools/cwe_data.py
@@ -1,0 +1,371 @@
+"""
+tools/cwe_data.py - local CWE catalogue keyed to the vuln_class strings the
+pentest tooling emits.
+
+The mapping that used to live as a 13-entry dict inside report_tools.py was
+correct as far as it went but the Technical Author needs more: the CWE
+*name*, a one-sentence summary suitable for inlining in a report, the canonical
+MITRE URL, and a pointer into the OWASP cheat-sheet catalogue.
+
+Entries are looked up by case-insensitive substring match against the
+vuln_class string, the CWE name, or any of the aliases. A query like "xss",
+"reflected xss", "ReflectedXSS", or "cross-site scripting" all resolve to
+CWE-79.
+
+Adding a new entry: copy the most relevant CWE from
+https://cwe.mitre.org/data/definitions/ and pick the matching OWASP cheat-sheet
+slug from `tools/owasp_data.py`.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class CWEEntry(BaseModel):
+    """A single CWE catalogue entry."""
+
+    cwe_id: int
+    name: str
+    description: str
+    aliases: list[str]
+    owasp_topic: str | None = None
+
+    @property
+    def url(self) -> str:
+        return f"https://cwe.mitre.org/data/definitions/{self.cwe_id}.html"
+
+
+# Catalogue. One entry per vuln_class the pentest stage can emit, plus a few
+# extras for severity-adjusted re-classifications (e.g. AuthZ from IDOR).
+CWE_CATALOGUE: list[CWEEntry] = [
+    CWEEntry(
+        cwe_id=22,
+        name="Path Traversal",
+        description=(
+            "Improper limitation of a pathname to a restricted directory lets an "
+            "attacker access files outside the intended location."
+        ),
+        aliases=["PathTraversal", "path traversal", "directory traversal", "LFI", "lfi"],
+        owasp_topic="File_Upload",
+    ),
+    CWEEntry(
+        cwe_id=77,
+        name="Command Injection",
+        description=(
+            "Improper neutralization of special elements used in an OS command lets "
+            "an attacker execute arbitrary commands on the host."
+        ),
+        aliases=["CommandInjection", "command injection", "OS command injection", "RCE"],
+        owasp_topic="OS_Command_Injection_Defense",
+    ),
+    CWEEntry(
+        cwe_id=78,
+        name="OS Command Injection",
+        description=(
+            "Same root cause as CWE-77 but specific to operating-system shell "
+            "commands assembled from untrusted input."
+        ),
+        aliases=["RCE", "remote code execution"],
+        owasp_topic="OS_Command_Injection_Defense",
+    ),
+    CWEEntry(
+        cwe_id=79,
+        name="Cross-site Scripting",
+        description=(
+            "Improper neutralization of input during web-page generation lets an "
+            "attacker execute script in another user's browser."
+        ),
+        aliases=["XSS", "ReflectedXSS", "stored XSS", "HeaderXSS", "cross-site scripting"],
+        owasp_topic="Cross_Site_Scripting_Prevention",
+    ),
+    CWEEntry(
+        cwe_id=89,
+        name="SQL Injection",
+        description=(
+            "Improper neutralization of special elements used in an SQL command "
+            "lets an attacker alter the meaning of a query or extract data."
+        ),
+        aliases=["SQLi", "sql injection"],
+        owasp_topic="SQL_Injection_Prevention",
+    ),
+    CWEEntry(
+        cwe_id=90,
+        name="LDAP Injection",
+        description=(
+            "Improper neutralization of special elements used in an LDAP query "
+            "lets an attacker alter directory queries."
+        ),
+        aliases=["LDAPInjection", "ldap injection"],
+        owasp_topic="LDAP_Injection_Prevention",
+    ),
+    CWEEntry(
+        cwe_id=94,
+        name="Code Injection",
+        description=(
+            "Improper control of generation of code lets an attacker execute "
+            "interpreter directives within the application context."
+        ),
+        aliases=["SSTI", "server-side template injection", "code injection"],
+        owasp_topic="Server_Side_Template_Injection_Prevention",
+    ),
+    CWEEntry(
+        cwe_id=200,
+        name="Information Exposure",
+        description=(
+            "Exposure of sensitive information to an unauthorized actor through "
+            "error messages, debug output, or backup files."
+        ),
+        aliases=[
+            "ErrorDisclosure",
+            "error disclosure",
+            "SourceMapLeak",
+            "SensitiveFileExposed",
+            "information disclosure",
+        ],
+        owasp_topic="Error_Handling",
+    ),
+    CWEEntry(
+        cwe_id=201,
+        name="Information Exposure Through Sent Data",
+        description=(
+            "The application sends sensitive information in transmitted data to "
+            "parties that should not have access."
+        ),
+        aliases=["EmailSpoofing", "spf misconfiguration"],
+        owasp_topic="Transport_Layer_Security",
+    ),
+    CWEEntry(
+        cwe_id=235,
+        name="Improper Handling of Extra Parameters",
+        description=(
+            "The application does not handle or incorrectly handles when the "
+            "number of parameters supplied differs from expected."
+        ),
+        aliases=["HPP", "HTTP Parameter Pollution"],
+        owasp_topic="Input_Validation",
+    ),
+    CWEEntry(
+        cwe_id=285,
+        name="Improper Authorization",
+        description=(
+            "The application does not verify that the actor is authorized to "
+            "perform an action on the affected resource."
+        ),
+        aliases=["AuthZ", "authorization", "AccessControlBypass", "broken access control"],
+        owasp_topic="Authorization",
+    ),
+    CWEEntry(
+        cwe_id=287,
+        name="Improper Authentication",
+        description=("The application does not adequately verify the actor's claimed identity."),
+        aliases=["AuthN", "authentication"],
+        owasp_topic="Authentication",
+    ),
+    CWEEntry(
+        cwe_id=295,
+        name="Improper Certificate Validation",
+        description=(
+            "The application does not validate or incorrectly validates an X.509 certificate."
+        ),
+        aliases=["TLSMisconfiguration", "tls misconfiguration", "certificate validation"],
+        owasp_topic="Transport_Layer_Security",
+    ),
+    CWEEntry(
+        cwe_id=352,
+        name="Cross-Site Request Forgery",
+        description=(
+            "The application does not verify that a request was intentionally "
+            "submitted by the user who submitted it."
+        ),
+        aliases=["CSRF", "csrf"],
+        owasp_topic="Cross-Site_Request_Forgery_Prevention",
+    ),
+    CWEEntry(
+        cwe_id=434,
+        name="Unrestricted File Upload",
+        description=(
+            "The application allows the attacker to upload or transfer files of "
+            "dangerous types that can be processed by the server."
+        ),
+        aliases=["UnrestrictedFileUpload", "file upload"],
+        owasp_topic="File_Upload",
+    ),
+    CWEEntry(
+        cwe_id=441,
+        name="Server-Side Request Forgery",
+        description=(
+            "The application receives a URL from an upstream component and uses it "
+            "to make an arbitrary outbound request, exposing internal resources."
+        ),
+        aliases=["SSRF", "ssrf", "server-side request forgery"],
+        owasp_topic="Server_Side_Request_Forgery_Prevention",
+    ),
+    CWEEntry(
+        cwe_id=601,
+        name="Open Redirect",
+        description=(
+            "The application accepts a user-controlled input that specifies a link "
+            "to an external site and uses it in a redirect."
+        ),
+        aliases=["OpenRedirect", "open redirect"],
+        owasp_topic="Unvalidated_Redirects_and_Forwards",
+    ),
+    CWEEntry(
+        cwe_id=611,
+        name="XML External Entity",
+        description=(
+            "The XML parser processes an XML document containing references to "
+            "external entities, exposing internal files or causing DoS."
+        ),
+        aliases=["XXE", "xxe"],
+        owasp_topic="XML_External_Entity_Prevention",
+    ),
+    CWEEntry(
+        cwe_id=639,
+        name="Insecure Direct Object Reference",
+        description=(
+            "The application authenticates the user but does not verify that they "
+            "are authorised for the specific object the request acts on."
+        ),
+        aliases=["IDOR", "idor", "insecure direct object reference"],
+        owasp_topic="Authorization",
+    ),
+    CWEEntry(
+        cwe_id=798,
+        name="Use of Hard-coded Credentials",
+        description=(
+            "The application contains hard-coded credentials such as passwords, "
+            "API keys, or cryptographic keys for inbound authentication."
+        ),
+        aliases=["hardcoded credentials", "embedded secrets"],
+        owasp_topic="Secrets_Management",
+    ),
+    CWEEntry(
+        cwe_id=829,
+        name="Inclusion of Functionality from Untrusted Source",
+        description=(
+            "The application includes functionality (script, library) from a "
+            "source outside its trust boundary without integrity verification."
+        ),
+        aliases=["MissingSRI", "missing sri", "subresource integrity"],
+        owasp_topic="Third_Party_Javascript_Management",
+    ),
+    CWEEntry(
+        cwe_id=918,
+        name="Server-Side Request Forgery (SSRF)",
+        description=(
+            "Same root cause as CWE-441 with the canonical SSRF identifier most "
+            "report intake systems expect."
+        ),
+        aliases=[],
+        owasp_topic="Server_Side_Request_Forgery_Prevention",
+    ),
+    CWEEntry(
+        cwe_id=942,
+        name="Permissive Cross-domain Policy with Untrusted Domains",
+        description=(
+            "The application uses an overly permissive CORS policy that allows "
+            "credentialed access from arbitrary origins."
+        ),
+        aliases=["CORS", "cors", "cors misconfiguration"],
+        owasp_topic="HTML5_Security",
+    ),
+    CWEEntry(
+        cwe_id=1021,
+        name="Improper Restriction of Rendered UI Layers",
+        description=(
+            "The application does not restrict rendering of its UI in frames, "
+            "allowing clickjacking."
+        ),
+        aliases=["HeaderInjection", "clickjacking", "HostHeaderInjection"],
+        owasp_topic="Clickjacking_Defense",
+    ),
+    CWEEntry(
+        cwe_id=1321,
+        name="Improperly Controlled Modification of Object Prototype Attributes",
+        description=(
+            "The application receives user input that modifies prototype attributes "
+            "of a base object, polluting subsequent object instantiations."
+        ),
+        aliases=["PrototypePollution", "prototype pollution"],
+        owasp_topic="Input_Validation",
+    ),
+    CWEEntry(
+        cwe_id=1336,
+        name="Improper Neutralization of Special Elements Used in a Template Engine",
+        description=(
+            "The application uses user input in a template engine without proper "
+            "neutralization, leading to template injection or RCE."
+        ),
+        aliases=["PromptInjection", "prompt injection"],
+        owasp_topic="LLM_Top_10",
+    ),
+    CWEEntry(
+        cwe_id=345,
+        name="Insufficient Verification of Data Authenticity",
+        description=(
+            "The application does not sufficiently verify the origin or authenticity "
+            "of data, e.g. JWT signature validation gaps."
+        ),
+        aliases=["JWT", "jwt", "JWT misconfiguration"],
+        owasp_topic="JSON_Web_Token_for_Java",
+    ),
+    CWEEntry(
+        cwe_id=16,
+        name="Configuration",
+        description=(
+            "Weaknesses introduced during the configuration of the software, "
+            "covering exposed services, admin panels, and cloud misconfigurations."
+        ),
+        aliases=[
+            "ExposedService",
+            "ExposedAdminPanel",
+            "CloudMisconfiguration",
+            "cloud misconfiguration",
+        ],
+        owasp_topic="Authorization",
+    ),
+    CWEEntry(
+        cwe_id=943,
+        name="Improper Neutralization of Special Elements in Data Query Logic",
+        description=(
+            "The application uses input in a data-query language (NoSQL, GraphQL) "
+            "without sufficient neutralization."
+        ),
+        aliases=["NoSQLi", "nosqli", "nosql injection"],
+        owasp_topic="Injection_Prevention_in_Java",
+    ),
+]
+
+
+_BY_ID: dict[int, CWEEntry] = {entry.cwe_id: entry for entry in CWE_CATALOGUE}
+
+
+def get_by_id(cwe_id: int) -> CWEEntry | None:
+    """Return the catalogue entry for ``cwe_id`` or None if unknown."""
+    return _BY_ID.get(cwe_id)
+
+
+def lookup(query: str, limit: int = 5) -> list[CWEEntry]:
+    """Return catalogue entries whose CWE name, vuln_class, or aliases match
+    ``query`` case-insensitively. Most-specific matches first (exact alias,
+    then prefix, then substring). Returns up to ``limit`` entries."""
+    if not query:
+        return []
+    needle = query.strip().lower()
+
+    exact: list[CWEEntry] = []
+    prefix: list[CWEEntry] = []
+    substring: list[CWEEntry] = []
+
+    for entry in CWE_CATALOGUE:
+        haystack = [entry.name.lower(), *(a.lower() for a in entry.aliases)]
+        if any(h == needle for h in haystack):
+            exact.append(entry)
+        elif any(h.startswith(needle) for h in haystack):
+            prefix.append(entry)
+        elif any(needle in h for h in haystack):
+            substring.append(entry)
+
+    return (exact + prefix + substring)[:limit]

--- a/tools/owasp_data.py
+++ b/tools/owasp_data.py
@@ -1,0 +1,277 @@
+"""
+tools/owasp_data.py - local OWASP Cheat Sheet catalogue.
+
+The Cheat Sheet Series at https://cheatsheetseries.owasp.org publishes
+canonical mitigation guidance keyed by URL slug. The Technical Author cites
+these in the Remediation section of every disclosure; this module is the
+single source of truth for those slugs and a short summary so the agent does
+not have to remember (or worse, hallucinate) URLs.
+
+Entries are looked up by case-insensitive substring match against the topic
+slug or title. The CWE catalogue cross-references this module via
+``owasp_topic`` so a CWE lookup hands the agent the matching cheat-sheet URL
+in one hop.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+_BASE_URL = "https://cheatsheetseries.owasp.org/cheatsheets"
+
+
+class OWASPEntry(BaseModel):
+    """A single OWASP Cheat Sheet entry."""
+
+    topic: str  # canonical slug, used to build URL
+    title: str
+    key_principles: list[str]
+    aliases: list[str] = []  # short keywords the TA may use to find this sheet
+
+    @property
+    def url(self) -> str:
+        return f"{_BASE_URL}/{self.topic}_Cheat_Sheet.html"
+
+
+# Curated subset of the OWASP Cheat Sheet Series covering the vuln_class
+# strings cybersquad emits. The "key_principles" entries are deliberately
+# short so the TA can paste them verbatim into a Remediation section without
+# rewriting.
+OWASP_CATALOGUE: list[OWASPEntry] = [
+    OWASPEntry(
+        topic="Authentication",
+        title="Authentication",
+        key_principles=[
+            "Reject weak passwords and require multi-factor authentication for "
+            "privileged accounts.",
+            "Bind session identifiers to the authenticated user and rotate them on "
+            "privilege change.",
+        ],
+    ),
+    OWASPEntry(
+        topic="Authorization",
+        title="Authorization",
+        key_principles=[
+            "Enforce authorization on every request server-side; never trust "
+            "client-supplied role or owner identifiers.",
+            "Default deny: explicitly grant access rather than removing it.",
+        ],
+    ),
+    OWASPEntry(
+        topic="Clickjacking_Defense",
+        title="Clickjacking Defense",
+        key_principles=[
+            "Send `Content-Security-Policy: frame-ancestors 'self'` (or specific "
+            "origins) on every authenticated response.",
+            "Set the `X-Frame-Options: DENY` header for legacy browser support.",
+        ],
+    ),
+    OWASPEntry(
+        topic="Cross_Site_Scripting_Prevention",
+        title="Cross-Site Scripting Prevention",
+        key_principles=[
+            "Context-aware output encoding: HTML body, attribute, JavaScript, URL, "
+            "and CSS contexts each need a different escape function.",
+            "Use a strict Content-Security-Policy with nonces or hashes for inline scripts.",
+        ],
+        aliases=["xss"],
+    ),
+    OWASPEntry(
+        topic="Cross-Site_Request_Forgery_Prevention",
+        title="Cross-Site Request Forgery Prevention",
+        key_principles=[
+            "Use the synchronizer-token or double-submit cookie pattern on every "
+            "state-changing request.",
+            "Set session cookies with `SameSite=Lax` (or `Strict` where compatible).",
+        ],
+        aliases=["csrf"],
+    ),
+    OWASPEntry(
+        topic="Error_Handling",
+        title="Error Handling",
+        key_principles=[
+            "Return generic error pages to users; log full diagnostic detail "
+            "server-side keyed by a request id.",
+            "Disable framework debug pages in production builds.",
+        ],
+    ),
+    OWASPEntry(
+        topic="File_Upload",
+        title="File Upload",
+        key_principles=[
+            "Validate file type by content (magic bytes) and reject anything "
+            "outside the allow-list.",
+            "Store uploads outside the web root and serve them through a handler "
+            "that sets `Content-Disposition: attachment`.",
+        ],
+    ),
+    OWASPEntry(
+        topic="HTML5_Security",
+        title="HTML5 Security",
+        key_principles=[
+            "Restrict CORS to a known allow-list of origins; never reflect "
+            "`Origin` into `Access-Control-Allow-Origin` with credentials.",
+            "Use postMessage with strict origin checks.",
+        ],
+        aliases=["cors", "postmessage"],
+    ),
+    OWASPEntry(
+        topic="Input_Validation",
+        title="Input Validation",
+        key_principles=[
+            "Validate against an allow-list of expected values; reject everything "
+            "else at the trust boundary.",
+            "Validate type, length, format, and range before any further processing.",
+        ],
+    ),
+    OWASPEntry(
+        topic="Injection_Prevention_in_Java",
+        title="Injection Prevention (NoSQL & GraphQL)",
+        key_principles=[
+            "Use parameterised query APIs; never concatenate user input into a query string.",
+            "For NoSQL drivers, ensure operators in user input are escaped or "
+            "rejected (e.g. `$where`, `$ne`).",
+        ],
+        aliases=["nosql", "nosqli", "graphql"],
+    ),
+    OWASPEntry(
+        topic="LDAP_Injection_Prevention",
+        title="LDAP Injection Prevention",
+        key_principles=[
+            "Escape every special character (`*`, `(`, `)`, `\\`, NUL) in user "
+            "input before composing an LDAP filter.",
+            "Bind to LDAP with the lowest privilege account that can satisfy the query.",
+        ],
+    ),
+    OWASPEntry(
+        topic="OS_Command_Injection_Defense",
+        title="OS Command Injection Defense",
+        key_principles=[
+            "Avoid invoking the shell: pass arguments as an array to `execve`-style APIs.",
+            "Validate against a strict allow-list of expected values.",
+        ],
+    ),
+    OWASPEntry(
+        topic="Secrets_Management",
+        title="Secrets Management",
+        key_principles=[
+            "Store credentials in a managed secret store (Vault, KMS); never in "
+            "source control or environment variables on a shared host.",
+            "Rotate any secret that has been exposed in logs or repositories.",
+        ],
+    ),
+    OWASPEntry(
+        topic="Server_Side_Request_Forgery_Prevention",
+        title="Server-Side Request Forgery Prevention",
+        key_principles=[
+            "Validate URLs against an allow-list of expected hosts; resolve and "
+            "compare the IP, not just the hostname.",
+            "Block private and link-local IP ranges (RFC 1918, 169.254.0.0/16) "
+            "at the egress proxy.",
+        ],
+        aliases=["ssrf"],
+    ),
+    OWASPEntry(
+        topic="Server_Side_Template_Injection_Prevention",
+        title="Server-Side Template Injection Prevention",
+        key_principles=[
+            "Never render user-controlled data as a template; pass it as a "
+            "context variable into a pre-defined template.",
+            "Sandbox the template engine to disable filesystem and process primitives.",
+        ],
+        aliases=["ssti"],
+    ),
+    OWASPEntry(
+        topic="SQL_Injection_Prevention",
+        title="SQL Injection Prevention",
+        key_principles=[
+            "Use parameterised queries (prepared statements) for every SQL operation.",
+            "Avoid dynamic SQL string concatenation; if unavoidable, use an "
+            "allow-list escape routine specific to the database engine.",
+        ],
+        aliases=["sqli"],
+    ),
+    OWASPEntry(
+        topic="Third_Party_Javascript_Management",
+        title="Third Party Javascript Management",
+        key_principles=[
+            "Include `integrity` and `crossorigin` attributes on every external "
+            "script tag (Subresource Integrity).",
+            "Vendor critical third-party scripts and serve them from your own origin under SRI.",
+        ],
+    ),
+    OWASPEntry(
+        topic="Transport_Layer_Security",
+        title="Transport Layer Security",
+        key_principles=[
+            "Disable TLS 1.0/1.1 and SSLv2/v3; require TLS 1.2 or newer.",
+            "Set `Strict-Transport-Security` with a long `max-age` and `includeSubDomains`.",
+        ],
+    ),
+    OWASPEntry(
+        topic="Unvalidated_Redirects_and_Forwards",
+        title="Unvalidated Redirects and Forwards",
+        key_principles=[
+            "Validate the redirect target against an allow-list of known destinations.",
+            "Prefer indirect redirects: accept a token that maps server-side to the real URL.",
+        ],
+        aliases=["open redirect", "openredirect"],
+    ),
+    OWASPEntry(
+        topic="XML_External_Entity_Prevention",
+        title="XML External Entity Prevention",
+        key_principles=[
+            "Disable external entity resolution in every XML parser the "
+            "application uses (`DOCTYPE`, `ENTITY`).",
+            "Where possible, switch to a non-XML data format (JSON).",
+        ],
+        aliases=["xxe"],
+    ),
+    OWASPEntry(
+        topic="JSON_Web_Token_for_Java",
+        title="JSON Web Token (JWT) Security",
+        key_principles=[
+            "Reject tokens with `alg: none` or unexpected algorithms; pin the "
+            "expected algorithm server-side.",
+            "Validate `iss`, `aud`, and `exp` on every request.",
+        ],
+        aliases=["jwt"],
+    ),
+    OWASPEntry(
+        topic="LLM_Top_10",
+        title="OWASP Top 10 for LLM Applications",
+        key_principles=[
+            "Treat all model output as untrusted input downstream; do not embed "
+            "it directly in shell or SQL.",
+            "Separate system, developer, and user prompt channels; deny the "
+            "model authority to modify its own system prompt.",
+        ],
+    ),
+]
+
+
+_BY_TOPIC: dict[str, OWASPEntry] = {e.topic: e for e in OWASP_CATALOGUE}
+
+
+def get_by_topic(topic: str) -> OWASPEntry | None:
+    """Return the catalogue entry for ``topic`` (the slug) or None."""
+    return _BY_TOPIC.get(topic)
+
+
+def lookup(query: str, limit: int = 5) -> list[OWASPEntry]:
+    """Return cheat-sheet entries whose topic, title, or aliases match
+    ``query`` case-insensitively. Returns up to ``limit`` entries, exact
+    matches first."""
+    if not query:
+        return []
+    needle = query.strip().lower()
+
+    exact: list[OWASPEntry] = []
+    substring: list[OWASPEntry] = []
+    for entry in OWASP_CATALOGUE:
+        haystack = [entry.topic.lower(), entry.title.lower(), *(a.lower() for a in entry.aliases)]
+        if any(h == needle for h in haystack):
+            exact.append(entry)
+        elif any(needle in h for h in haystack):
+            substring.append(entry)
+    return (exact + substring)[:limit]

--- a/tools/pentest/__init__.py
+++ b/tools/pentest/__init__.py
@@ -15,7 +15,7 @@ from tools.pentest.sourcemaps import check_js_source_maps
 from tools.pentest.sqlmap import run_sqlmap
 from tools.pentest.sri import check_sri
 from tools.pentest.ssrf import check_ssrf
-from tools.pentest.triage import is_in_scope, lookup_cve, triage_findings
+from tools.pentest.triage import is_in_scope, lookup_cve
 from tools.pentest.webapp_headers import check_header_injection, check_host_headers
 from tools.pentest.xss import check_reflected_xss
 
@@ -34,5 +34,4 @@ __all__ = [
     "lookup_cve",
     "run_nuclei",
     "run_sqlmap",
-    "triage_findings",
 ]

--- a/tools/pentest/triage.py
+++ b/tools/pentest/triage.py
@@ -1,68 +1,23 @@
-"""Vulnerability triage, CVSS assignment, and CVE lookup for the Vulnerability Researcher."""
+"""Scope check and CVE lookup helpers used by the Vulnerability Researcher.
+
+The mechanical ``triage_findings`` function that used to live here (and the
+``_CVSS_DEFAULTS`` class-to-vector lookup it depended on) was removed when
+triage authoring moved into ``tools/triage_tools.py``. The VR now composes
+each assessment by hand with per-finding CVSS reasoning; the validation gate
+in ``tools.triage_tools.validate_assessment`` enforces the prose-quality
+invariants the Technical Author depends on.
+"""
 
 from __future__ import annotations
 
 import logging
 
 from config import config
-from models import Programme, RawFinding, Severity, VerifiedVulnerability
+from models import Programme, RawFinding
 from tools import http
-from tools._helpers import _SEVERITY_FLOOR_ORDER
 from tools.recon.scope import extract_domain, filter_in_scope
 
 logger = logging.getLogger(__name__)
-
-
-def _above_floor(severity: Severity) -> bool:
-    floor = Severity(config.scan.min_severity)
-    return _SEVERITY_FLOOR_ORDER.index(severity) >= _SEVERITY_FLOOR_ORDER.index(floor)
-
-
-_CVSS_DEFAULTS: dict[str, dict[Severity, tuple[float, str]]] = {
-    "SQLi": {
-        Severity.CRITICAL: (9.8, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"),
-        Severity.HIGH: (8.8, "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"),
-    },
-    "NoSQLi": {
-        Severity.CRITICAL: (9.8, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"),
-        Severity.HIGH: (8.8, "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"),
-    },
-    "PromptInjection": {
-        Severity.CRITICAL: (9.1, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N"),
-        Severity.HIGH: (7.2, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N"),
-    },
-    "XSS": {
-        Severity.HIGH: (6.1, "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"),
-        Severity.MEDIUM: (4.3, "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N"),
-    },
-    "CORS": {
-        Severity.HIGH: (7.4, "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:N/A:N"),
-        Severity.MEDIUM: (4.3, "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N"),
-    },
-    "CloudMisconfiguration": {
-        Severity.CRITICAL: (9.1, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"),
-        Severity.HIGH: (7.5, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"),
-    },
-    "SourceMapLeak": {
-        Severity.CRITICAL: (8.6, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"),
-        Severity.MEDIUM: (5.3, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"),
-    },
-    "DEFAULT": {
-        Severity.CRITICAL: (9.0, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"),
-        Severity.HIGH: (7.5, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"),
-        Severity.MEDIUM: (5.3, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"),
-        Severity.LOW: (3.1, "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N"),
-    },
-}
-
-
-def _lookup_cvss(vuln_class: str, severity: Severity) -> tuple[float, str]:
-    table = _CVSS_DEFAULTS.get(vuln_class, _CVSS_DEFAULTS["DEFAULT"])
-    if severity in table:
-        return table[severity]
-    return _CVSS_DEFAULTS["DEFAULT"].get(
-        severity, (5.0, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N")
-    )
 
 
 def is_in_scope(finding: RawFinding, programme: Programme) -> bool:
@@ -71,52 +26,11 @@ def is_in_scope(finding: RawFinding, programme: Programme) -> bool:
     return bool(filter_in_scope([domain], programme))
 
 
-def triage_findings(
-    raw_findings: list[RawFinding],
-    programme: Programme,
-) -> list[VerifiedVulnerability]:
-    """
-    Vulnerability Researcher triage: drop out-of-scope and below-floor findings,
-    assign CVSS scores, and return structured VerifiedVulnerability objects.
-    """
-    verified: list[VerifiedVulnerability] = []
-
-    for finding in raw_findings:
-        if not is_in_scope(finding, programme):
-            logger.info("Out of scope, skipping: %s", finding.target)
-            continue
-        if not _above_floor(finding.severity_hint):
-            continue
-
-        cvss_score, cvss_vector = _lookup_cvss(finding.vuln_class, finding.severity_hint)
-        verified.append(
-            VerifiedVulnerability(
-                title=finding.title,
-                vuln_class=finding.vuln_class,
-                target=finding.target,
-                severity=finding.severity_hint,
-                cvss_score=cvss_score,
-                cvss_vector=cvss_vector,
-                description=f"Automated detection of {finding.vuln_class} at {finding.target}.",
-                steps_to_reproduce=[
-                    f"Navigate to {finding.target}",
-                    "Observe the following evidence:",
-                    finding.evidence,
-                ],
-                evidence=finding.evidence,
-                impact=f"Potential {finding.vuln_class} impact - pending manual review.",
-                remediation=f"Refer to OWASP guidance for {finding.vuln_class} remediation.",
-            )
-        )
-
-    logger.info("Triage complete - %d/%d findings verified", len(verified), len(raw_findings))
-    return verified
-
-
 def lookup_cve(keyword: str) -> list[dict]:
-    """
-    Query the NVD API for CVEs matching a keyword to validate CVSS scores.
-    Returns up to 5 results. Returns [] on any error so the pipeline is never blocked.
+    """Query the NVD API for CVEs matching a keyword to validate CVSS scores.
+
+    Returns up to 5 results. Returns [] on any error so the pipeline is never
+    blocked.
     """
     params: dict[str, str | int] = {"keywordSearch": keyword, "resultsPerPage": 5}
     headers: dict[str, str] = {}

--- a/tools/recon/__init__.py
+++ b/tools/recon/__init__.py
@@ -12,6 +12,7 @@ from urllib.parse import urlparse
 from models import Endpoint, Programme, ReconResult, ScopeType
 from tools.recon.cert_transparency import cert_transparency
 from tools.recon.dirfuzz import discover_paths
+from tools.recon.dnsx import TakeoverCandidate, detect_takeover_candidates
 from tools.recon.llm import detect_llm_endpoints
 from tools.recon.nmap import port_scan
 from tools.recon.probe import probe_endpoints
@@ -74,10 +75,12 @@ _ACTIVE_RECON_TYPES: frozenset[ScopeType] = frozenset(
 __all__ = [
     "_ACTIVE_RECON_TYPES",
     "_CODE_HOSTS",
+    "TakeoverCandidate",
     "cert_transparency",
     "check_dns_email_security",
     "check_tls",
     "detect_llm_endpoints",
+    "detect_takeover_candidates",
     "discover_paths",
     "enumerate_subdomains",
     "extract_domain",

--- a/tools/recon/dnsx.py
+++ b/tools/recon/dnsx.py
@@ -1,0 +1,209 @@
+"""
+DNS resolution and subdomain-takeover detection via dnsx.
+
+The OSINT Analyst calls Detect Takeover Candidates to flag subdomains
+whose CNAME points to a known-vulnerable provider or whose CNAME chain
+dangles (CNAME exists but does not resolve to any A record) - both
+classic takeover-vulnerability shapes.
+
+dnsx is the projectdiscovery DNS resolver; install via install-tools.sh.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from pydantic import BaseModel
+
+from tools._helpers import _require_binary, _run
+
+logger = logging.getLogger(__name__)
+
+# Curated subset of the can-i-take-over-xyz catalogue
+# (https://github.com/EdOverflow/can-i-take-over-xyz). Each entry maps a
+# CNAME suffix to the service it identifies. When the OA's sweep finds a
+# subdomain whose CNAME ends in one of these suffixes, the next step is to
+# HTTP-probe the host and check for the service-specific "not found" body
+# string - if it matches, the subdomain can be claimed by registering on
+# the provider.
+#
+# We intentionally keep this list to widely-encountered, high-confidence
+# patterns. Subtle providers that flip vulnerability status frequently
+# (e.g. Fastly only with no custom domain claimed) sit at the boundary;
+# we include them but the agent should treat the result as a candidate,
+# not a confirmation.
+_TAKEOVER_FINGERPRINTS: list[tuple[str, str]] = [
+    # AWS
+    (".s3.amazonaws.com", "AWS S3"),
+    (".s3-website", "AWS S3 (website)"),
+    (".elasticbeanstalk.com", "AWS Elastic Beanstalk"),
+    (".cloudfront.net", "AWS CloudFront"),
+    # Azure
+    (".cloudapp.net", "Azure (Cloud Services classic)"),
+    (".cloudapp.azure.com", "Azure (Cloud Services)"),
+    (".azurewebsites.net", "Azure Web Apps"),
+    (".blob.core.windows.net", "Azure Blob Storage"),
+    (".azureedge.net", "Azure CDN"),
+    (".azure-api.net", "Azure API Management"),
+    (".trafficmanager.net", "Azure Traffic Manager"),
+    # PaaS / hosting
+    (".herokuapp.com", "Heroku"),
+    (".herokudns.com", "Heroku DNS"),
+    (".vercel.app", "Vercel"),
+    (".netlify.app", "Netlify"),
+    (".netlify.com", "Netlify"),
+    (".surge.sh", "Surge.sh"),
+    (".pantheonsite.io", "Pantheon"),
+    (".readthedocs.io", "Read the Docs"),
+    (".fly.dev", "Fly.io"),
+    # Static / pages
+    (".github.io", "GitHub Pages"),
+    (".gitlab.io", "GitLab Pages"),
+    (".bitbucket.io", "Bitbucket Pages"),
+    # SaaS / docs / support
+    (".helpjuice.com", "Helpjuice"),
+    (".helpscoutdocs.com", "Help Scout"),
+    (".intercom.help", "Intercom"),
+    (".statuspage.io", "Statuspage"),
+    (".tumblr.com", "Tumblr"),
+    (".tictail.com", "Tictail"),
+    (".uservoice.com", "UserVoice"),
+    (".zendesk.com", "Zendesk"),
+    # Misc
+    (".gitbook.io", "GitBook"),
+    (".tilda.ws", "Tilda"),
+    (".webflow.io", "Webflow"),
+    (".wordpress.com", "WordPress"),
+    (".strikinglydns.com", "Strikingly"),
+    (".launchrock.com", "LaunchRock"),
+    # Fastly: CNAME pattern matches but exploitability requires the
+    # service-side claim status; treat as candidate.
+    (".fastly.net", "Fastly"),
+]
+
+
+class DNSRecord(BaseModel):
+    """One host's resolved DNS records, as returned by dnsx."""
+
+    hostname: str
+    a_records: list[str] = []
+    cname: list[str] = []
+
+
+class TakeoverCandidate(BaseModel):
+    """A subdomain flagged as a potential takeover target.
+
+    ``reason`` is one of:
+      - ``cname_to_vulnerable_provider``: CNAME points to a service in the
+        ``_TAKEOVER_FINGERPRINTS`` catalogue. Probe the host with HTTP and
+        look for the service-specific "not found" body.
+      - ``dangling_cname``: CNAME exists but the chain does not resolve to
+        any A records. The CNAME target may have been deprovisioned.
+    """
+
+    hostname: str
+    cname: str
+    reason: str
+    service: str | None = None
+
+
+def _match_fingerprint(cname: str) -> str | None:
+    """Return the service name if ``cname`` matches a known takeover pattern."""
+    target = cname.rstrip(".").lower()
+    for suffix, service in _TAKEOVER_FINGERPRINTS:
+        if target.endswith(suffix):
+            return service
+    return None
+
+
+def resolve_records(hostnames: list[str]) -> list[DNSRecord]:
+    """Resolve A and CNAME records for ``hostnames`` via dnsx.
+
+    Returns one ``DNSRecord`` per input host that dnsx emitted output for.
+    Hosts that resolve to nothing at all (NXDOMAIN with no CNAME) are
+    omitted from the result.
+    """
+    if not hostnames:
+        return []
+
+    dnsx = _require_binary("dnsx")
+    input_data = "\n".join(h.strip() for h in hostnames if h.strip())
+    if not input_data:
+        return []
+
+    result = _run(
+        [dnsx, "-a", "-cname", "-json", "-silent"],
+        timeout=180,
+        input=input_data,
+    )
+    records: list[DNSRecord] = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError as exc:
+            logger.debug("Skipping dnsx line: %s (%s)", line[:80], exc)
+            continue
+        hostname = entry.get("host", "").strip().lower()
+        if not hostname:
+            continue
+        records.append(
+            DNSRecord(
+                hostname=hostname,
+                a_records=entry.get("a") or [],
+                cname=entry.get("cname") or [],
+            )
+        )
+    logger.info("dnsx resolved %d/%d hosts", len(records), len(hostnames))
+    return records
+
+
+def detect_takeover_candidates(hostnames: list[str]) -> list[TakeoverCandidate]:
+    """Flag subdomains whose CNAME points to a known-vulnerable provider or
+    whose CNAME chain dangles.
+
+    A "candidate" is exactly that - the OA must follow up with an HTTP
+    probe to confirm the takeover fingerprint (Annotate Host the candidate
+    HIGH priority with a note pointing the PT at the service-specific
+    confirmation step).
+    """
+    candidates: list[TakeoverCandidate] = []
+    for record in resolve_records(hostnames):
+        for cname in record.cname:
+            service = _match_fingerprint(cname)
+            if service is not None:
+                candidates.append(
+                    TakeoverCandidate(
+                        hostname=record.hostname,
+                        cname=cname,
+                        reason="cname_to_vulnerable_provider",
+                        service=service,
+                    )
+                )
+                # One candidate per host even if multiple CNAMEs match -
+                # the first match is enough to flag it for the agent.
+                break
+        else:
+            # No CNAME matched a fingerprint. Check for a dangling CNAME -
+            # a CNAME exists but the chain produced no A records.
+            if record.cname and not record.a_records:
+                candidates.append(
+                    TakeoverCandidate(
+                        hostname=record.hostname,
+                        cname=record.cname[0],
+                        reason="dangling_cname",
+                        service=None,
+                    )
+                )
+    return candidates
+
+
+__all__ = [
+    "DNSRecord",
+    "TakeoverCandidate",
+    "detect_takeover_candidates",
+    "resolve_records",
+]

--- a/tools/recon_insights.py
+++ b/tools/recon_insights.py
@@ -1,0 +1,376 @@
+"""
+tools/recon_insights.py - Host-annotation authoring primitives for the OSINT
+Analyst.
+
+The OA's job is to turn the raw sweep (subfinder + httpx + nmap + dirfuzz +
+TLS / DNS checks) into a curated attack-surface map: every interesting host
+labelled with a role (admin / api / auth / app / cdn / ...), a priority
+(high / medium / low / skip), tech detected with versions where possible, and
+free-text notes that tell the Vulnerability Researcher WHY this host warrants
+attention. The agent does the curation; this module provides the supporting
+primitives:
+
+* ``HostInsight`` (from ``models``) - the agent's working artefact per host.
+* ``validate_insight(insight, sweep, programme)`` - quality gate. Returns the
+  issue list. Hard errors block ``finalise_recon``.
+* ``save_insight`` / ``load_insights`` - persist insights under
+  ``<run_dir>/host_insights/<hostname>.json``.
+* ``finalise_recon(programme, sweep_path)`` - load the sweep, validate every
+  insight, build the canonical ``ReconResult`` for downstream agents, and
+  write ``recon.json``. Refuses on hard errors or insufficient curation.
+
+The OA's initial sweep is written to ``sweep.json``; ``finalise_recon``
+copies the inventory through, attaches insights, and emits the final
+``recon.json`` that the Vulnerability Researcher and Penetration Tester
+consume.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+import runtime
+from models import HostInsight, HostPriority, Programme, ReconResult
+from tools.recon.scope import extract_domain, filter_in_scope
+
+_INSIGHTS_SUBDIR = "host_insights"
+_SWEEP_FILENAME = "sweep.json"
+_RECON_FILENAME = "recon.json"
+
+# Hostnames must be made filesystem-safe before persisting under
+# ``host_insights/<hostname>.json``. The replacement is reversible because we
+# never reverse it - the JSON body carries the original hostname.
+_HOSTNAME_SANITISE = re.compile(r"[^A-Za-z0-9.\-_]")
+
+
+# Validation
+
+
+class InsightValidationIssue(BaseModel):
+    """One issue produced by validate_insight."""
+
+    section: str
+    severity: str  # "error" (blocks finalise) or "warning" (advisory)
+    message: str
+
+
+class InsightValidationReport(BaseModel):
+    """Result of validating one insight."""
+
+    ok: bool
+    issues: list[InsightValidationIssue] = Field(default_factory=list)
+
+
+def validate_insight(
+    insight: HostInsight,
+    sweep: ReconResult,
+    programme: Programme,
+) -> InsightValidationReport:
+    """Apply quality heuristics to a HostInsight. Returns the issue list."""
+    issues: list[InsightValidationIssue] = []
+
+    hostname = insight.hostname.strip().lower()
+    if not hostname:
+        issues.append(
+            InsightValidationIssue(
+                section="hostname",
+                severity="error",
+                message="hostname must not be empty",
+            )
+        )
+        return InsightValidationReport(ok=False, issues=issues)
+
+    # Scope: every annotated host must be in scope. Out-of-scope hosts that
+    # somehow leaked into the sweep are not the OA's to annotate.
+    if not filter_in_scope([hostname], programme):
+        issues.append(
+            InsightValidationIssue(
+                section="hostname",
+                severity="error",
+                message=(f"{hostname!r} is not in programme scope; only annotate in-scope hosts"),
+            )
+        )
+
+    # Notes: the whole point. Too short means the agent skipped the
+    # curation work.
+    if len(insight.notes.strip()) < 30:
+        issues.append(
+            InsightValidationIssue(
+                section="notes",
+                severity="error",
+                message=(
+                    "notes are too short; explain what the host is, what tech "
+                    "stack runs on it, and what makes it interesting (or not) "
+                    "in 1-3 sentences"
+                ),
+            )
+        )
+
+    # High-priority hosts need a substantive reason.
+    if insight.priority == HostPriority.HIGH and len(insight.notes.strip()) < 60:
+        issues.append(
+            InsightValidationIssue(
+                section="notes",
+                severity="error",
+                message=(
+                    "high-priority hosts need >= 60 chars of justification - "
+                    "what tech, what surface, why it earns the budget"
+                ),
+            )
+        )
+
+    # SKIP hosts also need a reason - so a downstream reader does not
+    # silently re-include them.
+    if insight.priority == HostPriority.SKIP and len(insight.notes.strip()) < 30:
+        issues.append(
+            InsightValidationIssue(
+                section="notes",
+                severity="error",
+                message=(
+                    "skip-priority hosts need notes explaining the reason "
+                    "(third-party managed, decoy, sensitive, etc.)"
+                ),
+            )
+        )
+
+    # If the host is in the sweep's inventory we expect the agent's
+    # detected_tech to either be empty (agent could not enrich) or
+    # consistent with what the sweep saw. We only warn on disagreement -
+    # the agent can legitimately add versions httpx missed.
+    sweep_techs_by_host = _sweep_tech_by_host(sweep)
+    if hostname in sweep_techs_by_host:
+        sweep_techs = {t.lower() for t in sweep_techs_by_host[hostname]}
+        agent_techs = {t.lower() for t in insight.detected_tech}
+        # Warn when sweep saw tech the agent did not carry through - might
+        # signal the agent ignored a useful signal.
+        missing = sweep_techs - {_strip_version(t) for t in agent_techs} - agent_techs
+        if missing and len(insight.detected_tech) > 0:
+            issues.append(
+                InsightValidationIssue(
+                    section="detected_tech",
+                    severity="warning",
+                    message=(
+                        f"sweep saw tech the annotation does not carry: "
+                        f"{sorted(missing)} - keep, or note explicitly in 'notes' "
+                        "that it was deprioritised"
+                    ),
+                )
+            )
+
+    # detected_tech entries should be non-trivial strings.
+    for t in insight.detected_tech:
+        if len(t.strip()) < 2:
+            issues.append(
+                InsightValidationIssue(
+                    section="detected_tech",
+                    severity="error",
+                    message=f"tech entry too short to be a real product name: {t!r}",
+                )
+            )
+
+    ok = not any(i.severity == "error" for i in issues)
+    return InsightValidationReport(ok=ok, issues=issues)
+
+
+def _sweep_tech_by_host(sweep: ReconResult) -> dict[str, list[str]]:
+    """Build a hostname -> tech-list map from the sweep's endpoints."""
+    from urllib.parse import urlparse
+
+    by_host: dict[str, list[str]] = {}
+    for ep in sweep.endpoints:
+        host = (urlparse(ep.url).hostname or "").lower()
+        if not host:
+            continue
+        by_host.setdefault(host, []).extend(ep.technologies)
+    return by_host
+
+
+def _strip_version(tech: str) -> str:
+    """Drop trailing version suffixes from a tech string for comparison.
+
+    "WordPress 5.8.1" and "WordPress" should compare equal when checking
+    that the agent carried the sweep's tech through.
+    """
+    return re.sub(r"\s*[0-9][\w.\-]*$", "", tech).strip().lower()
+
+
+# Persistence
+
+
+def _insights_dir() -> Path:
+    return runtime.run_dir() / _INSIGHTS_SUBDIR
+
+
+def insight_path(hostname: str) -> Path:
+    """Return the on-disk path of the insight for ``hostname``.
+
+    Hostnames are used directly as filenames (with a small character
+    sanitisation pass). The body carries the original hostname.
+    """
+    safe = _HOSTNAME_SANITISE.sub("_", hostname.strip().lower())
+    if not safe or safe.strip("_") == "":
+        raise ValueError("hostname is empty after sanitisation")
+    return _insights_dir() / f"{safe}.json"
+
+
+def save_insight(insight: HostInsight) -> Path:
+    """Persist an insight to ``<run_dir>/host_insights/<host>.json``."""
+    path = insight_path(insight.hostname)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(insight.model_dump_json(indent=2), encoding="utf-8")
+    return path
+
+
+def load_insights() -> list[HostInsight]:
+    """Load every insight in the current run, ordered by hostname."""
+    dir_ = _insights_dir()
+    if not dir_.is_dir():
+        return []
+    return sorted(
+        (
+            HostInsight.model_validate_json(p.read_text(encoding="utf-8"))
+            for p in dir_.glob("*.json")
+        ),
+        key=lambda i: i.hostname,
+    )
+
+
+def load_sweep(sweep_filename: str = _SWEEP_FILENAME) -> ReconResult:
+    """Load the OA's internal sweep artefact."""
+    path = runtime.run_dir() / sweep_filename
+    if not path.is_file():
+        raise FileNotFoundError(f"{sweep_filename} not found; run Run Initial Sweep first")
+    return ReconResult.model_validate_json(path.read_text(encoding="utf-8"))
+
+
+# Finalisation
+
+
+class ReconFinalisationError(RuntimeError):
+    """Raised when finalise_recon cannot consolidate the sweep + insights."""
+
+
+# Status codes whose hosts deserve an annotation: 2xx is a live target,
+# 3xx redirects often hide gates, 401/403 confirm an auth-gated surface
+# worth probing. Pure 404/500 we let slide.
+_INTERESTING_STATUSES = {200, 201, 204, 301, 302, 307, 308, 401, 403}
+
+
+def finalise_recon(
+    programme: Programme,
+    sweep_filename: str = _SWEEP_FILENAME,
+    recon_filename: str = _RECON_FILENAME,
+) -> Path:
+    """Validate every host insight, merge them with the sweep, and write the
+    final ``recon.json`` for downstream agents.
+
+    Refuses to finalise if:
+      * no insights have been authored at all (the OA must annotate)
+      * any insight has hard validation errors
+      * no host has been marked HIGH priority on a non-empty surface (the
+        Penetration Tester needs at least one focus target)
+      * an insight references a hostname that is not in scope
+
+    Coverage warnings (non-blocking):
+      * an interesting-status host in the sweep has no insight
+      * a high-priority host is missing detected_tech
+    """
+    sweep = load_sweep(sweep_filename)
+    insights = load_insights()
+
+    if not insights:
+        raise ReconFinalisationError(
+            "no host_insights have been authored; call Annotate Host for the "
+            "interesting hosts in the sweep before finalising"
+        )
+
+    failures: list[tuple[str, list[InsightValidationIssue]]] = []
+    for insight in insights:
+        report = validate_insight(insight, sweep, programme)
+        if not report.ok:
+            failures.append(
+                (
+                    insight.hostname,
+                    [i for i in report.issues if i.severity == "error"],
+                )
+            )
+
+    if failures:
+        lines = ["one or more host insights have unresolved errors:"]
+        for hostname, errs in failures:
+            for err in errs:
+                lines.append(f"  - insight {hostname} / {err.section}: {err.message}")
+        raise ReconFinalisationError("\n".join(lines))
+
+    high_priority = [i for i in insights if i.priority == HostPriority.HIGH]
+    if sweep.subdomains and not high_priority:
+        raise ReconFinalisationError(
+            "no host has been marked HIGH priority; the Penetration Tester "
+            "needs at least one focus target on a non-empty surface"
+        )
+
+    final = ReconResult(
+        programme=sweep.programme,
+        subdomains=sweep.subdomains,
+        endpoints=sweep.endpoints,
+        open_ports=sweep.open_ports,
+        technologies=sweep.technologies,
+        passive_findings=sweep.passive_findings,
+        network_hops=sweep.network_hops,
+        host_insights=insights,
+        notes=_build_notes(sweep, insights),
+    )
+
+    out_path = runtime.run_dir() / recon_filename
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(final.model_dump_json(), encoding="utf-8")
+    return out_path
+
+
+def _build_notes(sweep: ReconResult, insights: list[HostInsight]) -> str:
+    """Compose the recon-level notes string from sweep stats + insight tally."""
+    by_priority: dict[HostPriority, int] = dict.fromkeys(HostPriority, 0)
+    for i in insights:
+        by_priority[i.priority] += 1
+    return (
+        f"sweep: {len(sweep.subdomains)} subdomains, {len(sweep.endpoints)} endpoints; "
+        f"insights: {by_priority[HostPriority.HIGH]} high, "
+        f"{by_priority[HostPriority.MEDIUM]} medium, "
+        f"{by_priority[HostPriority.LOW]} low, "
+        f"{by_priority[HostPriority.SKIP]} skip"
+    )
+
+
+# Coverage check (informational)
+
+
+def uncovered_interesting_hosts(sweep: ReconResult, insights: list[HostInsight]) -> list[str]:
+    """Return interesting-status hostnames in the sweep that have no insight."""
+    from urllib.parse import urlparse
+
+    covered = {i.hostname.lower() for i in insights}
+    interesting: set[str] = set()
+    for ep in sweep.endpoints:
+        if ep.status_code in _INTERESTING_STATUSES:
+            host = (urlparse(ep.url).hostname or "").lower()
+            if host:
+                interesting.add(host)
+    return sorted(interesting - covered)
+
+
+__all__ = [
+    "InsightValidationIssue",
+    "InsightValidationReport",
+    "ReconFinalisationError",
+    "extract_domain",
+    "finalise_recon",
+    "insight_path",
+    "load_insights",
+    "load_sweep",
+    "save_insight",
+    "uncovered_interesting_hosts",
+    "validate_insight",
+]

--- a/tools/report_tools.py
+++ b/tools/report_tools.py
@@ -1,36 +1,47 @@
 """
-tools/report_tools.py - Report generation for the Technical Author agent.
+tools/report_tools.py - Report-authoring primitives for the Technical Author.
 
-Produces structured, professional H1-compatible Markdown reports from
-verified vulnerabilities.
+The TA's job is to turn a VerifiedVulnerability into an H1-format report that a
+triager accepts on first read. The agent does the writing; this module provides
+the supporting primitives:
+
+* ``calculate_cvss_score(vector)`` - score a CVSS 3.1 vector string.
+* ``sanitise_evidence(text)`` - redact credentials / cookies / auth headers /
+  long base64 blobs from raw tool output so it is safe to inline in a report.
+* ``ReportDraft`` - the working artefact the TA composes per finding.
+* ``validate_draft(draft)`` - quality gate. Returns the issue list the TA fixes
+  before finalising. Hard errors block ``finalise_drafts``; warnings are
+  advisory.
+* ``render_draft_markdown(draft)`` - render a draft into H1 markdown.
+* ``save_draft(draft)`` / ``load_drafts()`` - persist drafts under
+  ``<run_dir>/drafts/<idx:03d>.json`` so the TA can iterate one finding at a
+  time.
+* ``finalise_drafts(programme_handle, summary, expected_count)`` - validate all
+  drafts strictly, build a ``DisclosureReport`` per draft, and write
+  ``reports.json`` for the Disclosure Coordinator. Refuses on hard errors.
+* ``save_report(report)`` - persist a finalised report to the configured
+  reports directory (kept for Disclosure Coordinator compatibility).
+
+The CWE / OWASP citation hints come from ``tools/cwe_data.py`` and
+``tools/owasp_data.py`` rather than living inline here. The Technical Author
+looks them up via the dedicated tools.
 """
 
 from __future__ import annotations
 
+import json
+import math
+import re
 import textwrap
 from datetime import UTC, datetime
 from pathlib import Path
 
+from pydantic import BaseModel, Field
+
+import runtime
 from config import config
 from models import DisclosureReport, Severity, VerifiedVulnerability
-
-# CWE quick-reference
-
-_VULN_CLASS_TO_CWE: dict[str, int] = {
-    "SQLi": 89,
-    "XSS": 79,
-    "IDOR": 639,
-    "SSRF": 918,
-    "CORS": 942,
-    "RCE": 78,
-    "LFI": 22,
-    "XXE": 611,
-    "SSTI": 94,
-    "CSRF": 352,
-    "AuthZ": 285,
-    "AuthN": 287,
-    "OpenRedirect": 601,
-}
+from tools.cwe_data import get_by_id as cwe_get_by_id
 
 _SEVERITY_LABELS: dict[Severity, str] = {
     Severity.INFORMATIONAL: "None",
@@ -39,6 +50,9 @@ _SEVERITY_LABELS: dict[Severity, str] = {
     Severity.HIGH: "High",
     Severity.CRITICAL: "Critical",
 }
+
+_DRAFTS_SUBDIR = "drafts"
+_EVIDENCE_LIMIT = 2000
 
 _REPORT_TEMPLATE = """\
 # {title}
@@ -57,7 +71,7 @@ _REPORT_TEMPLATE = """\
 | **Severity** | {severity} |
 | **CVSS Score** | {cvss_score} |
 | **CVSS Vector** | `{cvss_vector}` |
-| **CWE** | CWE-{cwe} |
+| **CWE** | CWE-{cwe} ({cwe_name}) |
 | **Target** | `{target}` |
 
 ---
@@ -98,18 +112,19 @@ _REPORT_TEMPLATE = """\
 """
 
 
+# CVSS
+
+
 def calculate_cvss_score(vector: str) -> float:
-    """
-    Compute the CVSS 3.1 base score from a vector string.
+    """Compute the CVSS 3.1 base score from a vector string.
 
     Implements the CVSS 3.1 specification formula. Returns a value in 0.0-10.0.
     Raises ValueError for unrecognised metric abbreviations or missing metrics.
     """
-    # Metric value tables from CVSS 3.1 specification
     _AV = {"N": 0.85, "A": 0.62, "L": 0.55, "P": 0.20}
     _AC = {"L": 0.77, "H": 0.44}
-    _PR_U = {"N": 0.85, "L": 0.62, "H": 0.27}  # Scope: Unchanged
-    _PR_C = {"N": 0.85, "L": 0.68, "H": 0.50}  # Scope: Changed
+    _PR_U = {"N": 0.85, "L": 0.62, "H": 0.27}
+    _PR_C = {"N": 0.85, "L": 0.68, "H": 0.50}
     _UI = {"N": 0.85, "R": 0.62}
     _CIA = {"N": 0.00, "L": 0.22, "H": 0.56}
 
@@ -152,61 +167,527 @@ def calculate_cvss_score(vector: str) -> float:
     else:
         raw = min(1.08 * (impact + exploitability), 10.0)
 
-    # CVSS Roundup: round up to nearest tenth
-    import math
-
     rounded = math.ceil(raw * 10) / 10
     return round(rounded, 1)
 
 
-def _format_steps(steps: list[str]) -> str:
-    return "\n".join(f"{i + 1}. {step}" for i, step in enumerate(steps))
+# Evidence sanitisation
 
 
-def build_report_markdown(
-    programme_handle: str,
-    vulnerability: VerifiedVulnerability,
-    summary: str,
-) -> str:
-    """Render the Markdown body of a disclosure report."""
-    cwe = _VULN_CLASS_TO_CWE.get(vulnerability.vuln_class, 0)
+class SanitisationReport(BaseModel):
+    """Result of sanitising one chunk of evidence."""
 
+    sanitised: str
+    redactions: list[dict] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+
+# Patterns are ordered so the most specific match wins. ``kind`` is the label
+# echoed back to the TA so they understand what the redactor caught.
+_REDACTION_PATTERNS: list[tuple[str, re.Pattern[str], str]] = [
+    (
+        "authorization_header",
+        re.compile(r"(?im)^\s*Authorization:\s*\S.*$"),
+        "Authorization: <redacted>",
+    ),
+    (
+        "cookie_header",
+        re.compile(r"(?im)^\s*Cookie:\s*\S.*$"),
+        "Cookie: <redacted>",
+    ),
+    (
+        "set_cookie_header",
+        re.compile(r"(?im)^\s*Set-Cookie:\s*\S.*$"),
+        "Set-Cookie: <redacted>",
+    ),
+    (
+        "bearer_token",
+        re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._\-+/=]{8,}"),
+        "Bearer <redacted>",
+    ),
+    (
+        "basic_auth",
+        re.compile(r"(?i)\bBasic\s+[A-Za-z0-9+/=]{8,}"),
+        "Basic <redacted>",
+    ),
+    (
+        "jwt",
+        # Three dot-separated base64-url segments, the first beginning ``eyJ``
+        # (the base64 of ``{"``) which is the canonical JWT header start.
+        re.compile(r"eyJ[A-Za-z0-9._\-]{10,}\.[A-Za-z0-9._\-]{10,}\.[A-Za-z0-9._\-]{8,}"),
+        "<redacted-jwt>",
+    ),
+    (
+        "secret_kv",
+        # key=value pairs where the key smells secret. Anchor on word boundary
+        # so we do not strip ``password_reset_url=...`` style tokens.
+        re.compile(
+            r"(?i)\b(password|passwd|secret|api[_-]?key|apikey|access[_-]?token|"
+            r"refresh[_-]?token|private[_-]?key)\s*[=:]\s*([^\s,;&]+)"
+        ),
+        r"\1=<redacted>",
+    ),
+    (
+        "aws_access_key",
+        re.compile(r"\b(AKIA|ASIA)[A-Z0-9]{16}\b"),
+        "<redacted-aws-key>",
+    ),
+]
+
+
+def sanitise_evidence(text: str, limit: int = _EVIDENCE_LIMIT) -> SanitisationReport:
+    """Redact credentials, tokens, cookies and other secret-shaped material
+    from ``text`` and truncate to ``limit`` characters.
+
+    Payloads (XSS strings, SQL injection vectors, SSRF URLs) are deliberately
+    *not* touched - the disclosure is private and the triager needs the literal
+    request that demonstrates the issue. Only material that would compromise
+    the researcher (or another user) if published is stripped.
+    """
+    redactions: list[dict] = []
+    warnings: list[str] = []
+    sanitised = text or ""
+
+    for kind, pattern, replacement in _REDACTION_PATTERNS:
+        matches = pattern.findall(sanitised)
+        if not matches:
+            continue
+        sample = ""
+        for match in matches:
+            sample = match if isinstance(match, str) else "".join(match)
+            break
+        redactions.append(
+            {
+                "kind": kind,
+                "count": len(matches),
+                "sample": sample[:60],
+            }
+        )
+        sanitised = pattern.sub(replacement, sanitised)
+
+    if len(sanitised) > limit:
+        original_len = len(sanitised)
+        sanitised = sanitised[:limit].rstrip() + "\n... [truncated]"
+        warnings.append(
+            f"evidence truncated from {original_len} to {limit} chars; "
+            "keep the most diagnostic excerpt"
+        )
+
+    return SanitisationReport(sanitised=sanitised, redactions=redactions, warnings=warnings)
+
+
+# Draft model
+
+
+class ReportDraft(BaseModel):
+    """One Technical-Author-composed report draft.
+
+    Only the fields a triager actually reads. CVSS, CWE, target, vuln_class,
+    and severity come from the verified finding (so the TA cannot accidentally
+    contradict the VR); the prose lives here, owned by the TA.
+    """
+
+    # Carried from verified.json
+    finding_index: int
+    target: str
+    vuln_class: str
+    severity: Severity
+    cvss_vector: str
+    cvss_score: float
+    cwe_id: int
+
+    # Authored
+    title: str
+    summary: str
+    description: str
+    steps_to_reproduce: list[str]
+    evidence: str
+    impact: str
+    remediation: str
+
+    authored_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+# Validation
+
+
+_TITLE_FORMULA = re.compile(r".+\s+in\s+.+\s+allows\s+.+", re.IGNORECASE)
+_HAND_WAVY_IMPACT = re.compile(
+    r"\b(could compromise|may allow|might allow|potentially|possibly|"
+    r"can lead to(?! \w)|attacker could|impact unknown)\b",
+    re.IGNORECASE,
+)
+_URL = re.compile(r"https?://\S+")
+_SENTENCE_END = re.compile(r"[.!?]+\s+")
+
+
+class ValidationIssue(BaseModel):
+    """A single quality finding from validate_draft."""
+
+    section: str
+    severity: str  # "error" (blocks finalise) or "warning" (advisory)
+    message: str
+
+
+class ValidationReport(BaseModel):
+    """Result of validating one draft."""
+
+    ok: bool
+    issues: list[ValidationIssue] = Field(default_factory=list)
+
+
+def _count_sentences(text: str) -> int:
+    text = text.strip()
+    if not text:
+        return 0
+    chunks = [c for c in _SENTENCE_END.split(text) if c.strip()]
+    return max(1, len(chunks))
+
+
+def validate_draft(draft: ReportDraft) -> ValidationReport:
+    """Apply quality heuristics to a draft. Returns the issue list."""
+    issues: list[ValidationIssue] = []
+
+    # Title
+    if not draft.title.strip():
+        issues.append(ValidationIssue(section="title", severity="error", message="title is empty"))
+    else:
+        if not _TITLE_FORMULA.match(draft.title.strip()):
+            issues.append(
+                ValidationIssue(
+                    section="title",
+                    severity="error",
+                    message=(
+                        "title does not match `[Type] in [Component] allows [Outcome]`; "
+                        f"got: {draft.title!r}"
+                    ),
+                )
+            )
+        if len(draft.title) > 120:
+            issues.append(
+                ValidationIssue(
+                    section="title",
+                    severity="warning",
+                    message=f"title is {len(draft.title)} chars; aim for under 120",
+                )
+            )
+
+    # Summary
+    sentences = _count_sentences(draft.summary)
+    if sentences < 2:
+        issues.append(
+            ValidationIssue(
+                section="summary",
+                severity="error",
+                message="summary should be 2-3 sentences covering root cause, location, impact",
+            )
+        )
+    elif sentences > 5:
+        issues.append(
+            ValidationIssue(
+                section="summary",
+                severity="warning",
+                message=f"summary is {sentences} sentences; aim for 2-3",
+            )
+        )
+
+    # Description
+    if len(draft.description.strip()) < 100:
+        issues.append(
+            ValidationIssue(
+                section="description",
+                severity="error",
+                message=(
+                    "description is too thin; explain root cause to a developer "
+                    "(why the code is vulnerable, not just what happens)"
+                ),
+            )
+        )
+
+    # Steps
+    if len(draft.steps_to_reproduce) < 2:
+        issues.append(
+            ValidationIssue(
+                section="steps_to_reproduce",
+                severity="error",
+                message="at least 2 numbered steps are required",
+            )
+        )
+    for n, step in enumerate(draft.steps_to_reproduce, 1):
+        if len(step.strip()) < 10:
+            issues.append(
+                ValidationIssue(
+                    section="steps_to_reproduce",
+                    severity="error",
+                    message=f"step {n} is too short to be reproducible: {step!r}",
+                )
+            )
+
+    # Evidence
+    if not draft.evidence.strip():
+        issues.append(
+            ValidationIssue(
+                section="evidence",
+                severity="error",
+                message="evidence is empty; include the captured request/response or tool output",
+            )
+        )
+    else:
+        residual = sanitise_evidence(draft.evidence)
+        if residual.redactions:
+            kinds = ", ".join(sorted({r["kind"] for r in residual.redactions}))
+            issues.append(
+                ValidationIssue(
+                    section="evidence",
+                    severity="error",
+                    message=(
+                        f"evidence still contains sensitive material ({kinds}); "
+                        "call Sanitise Evidence first and inline the sanitised result"
+                    ),
+                )
+            )
+
+    # Impact
+    if len(draft.impact.strip()) < 40:
+        issues.append(
+            ValidationIssue(
+                section="impact",
+                severity="error",
+                message=(
+                    "impact statement too short; name the data/system at risk, "
+                    "who is affected, and the realistic worst outcome"
+                ),
+            )
+        )
+    if _HAND_WAVY_IMPACT.search(draft.impact):
+        issues.append(
+            ValidationIssue(
+                section="impact",
+                severity="error",
+                message=(
+                    "impact statement uses hand-wavy language (e.g. 'could compromise', "
+                    "'may allow'); be concrete about what an attacker can actually do"
+                ),
+            )
+        )
+
+    # Remediation
+    if len(draft.remediation.strip()) < 60:
+        issues.append(
+            ValidationIssue(
+                section="remediation",
+                severity="error",
+                message="remediation too thin; give the developer a concrete fix",
+            )
+        )
+    if not _URL.search(draft.remediation):
+        issues.append(
+            ValidationIssue(
+                section="remediation",
+                severity="error",
+                message=(
+                    "remediation must cite an OWASP cheat-sheet or CWE URL; "
+                    "use Lookup OWASP / Lookup CWE to find the canonical reference"
+                ),
+            )
+        )
+
+    # CVSS
+    try:
+        recomputed = calculate_cvss_score(draft.cvss_vector)
+    except ValueError as exc:
+        issues.append(
+            ValidationIssue(
+                section="cvss",
+                severity="error",
+                message=f"cvss_vector is invalid: {exc}",
+            )
+        )
+    else:
+        if abs(recomputed - draft.cvss_score) > 0.05:
+            issues.append(
+                ValidationIssue(
+                    section="cvss",
+                    severity="error",
+                    message=(
+                        f"cvss_score ({draft.cvss_score}) does not match the vector "
+                        f"({recomputed} computed); use Calculate CVSS Score"
+                    ),
+                )
+            )
+
+    # CWE
+    if cwe_get_by_id(draft.cwe_id) is None:
+        issues.append(
+            ValidationIssue(
+                section="cwe",
+                severity="warning",
+                message=(
+                    f"CWE-{draft.cwe_id} is not in the local catalogue; double-check via Lookup CWE"
+                ),
+            )
+        )
+
+    ok = not any(i.severity == "error" for i in issues)
+    return ValidationReport(ok=ok, issues=issues)
+
+
+# Rendering
+
+
+def render_draft_markdown(draft: ReportDraft) -> str:
+    """Render a draft into H1 markdown using the report template."""
+    cwe = cwe_get_by_id(draft.cwe_id)
+    cwe_name = cwe.name if cwe else "Other"
+    steps = "\n".join(f"{i + 1}. {step}" for i, step in enumerate(draft.steps_to_reproduce))
+    evidence_block = textwrap.indent(draft.evidence[:_EVIDENCE_LIMIT], "  ")
     return _REPORT_TEMPLATE.format(
-        title=vulnerability.title,
-        summary=summary,
-        vuln_class=vulnerability.vuln_class,
-        severity=_SEVERITY_LABELS[vulnerability.severity],
-        cvss_score=vulnerability.cvss_score,
-        cvss_vector=vulnerability.cvss_vector,
-        cwe=cwe if cwe else "N/A",
-        target=vulnerability.target,
-        description=vulnerability.description,
-        steps=_format_steps(vulnerability.steps_to_reproduce),
-        evidence=textwrap.indent(vulnerability.evidence[:2000], "  "),
-        impact=vulnerability.impact,
-        remediation=vulnerability.remediation,
+        title=draft.title,
+        summary=draft.summary,
+        vuln_class=draft.vuln_class,
+        severity=_SEVERITY_LABELS[draft.severity],
+        cvss_score=draft.cvss_score,
+        cvss_vector=draft.cvss_vector,
+        cwe=draft.cwe_id,
+        cwe_name=cwe_name,
+        target=draft.target,
+        description=draft.description,
+        steps=steps,
+        evidence=evidence_block,
+        impact=draft.impact,
+        remediation=draft.remediation,
         timestamp=datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC"),
     )
 
 
-def create_disclosure_report(
-    programme_handle: str,
-    vulnerability: VerifiedVulnerability,
-    summary: str,
-) -> DisclosureReport:
-    """Assemble a complete DisclosureReport ready for submission."""
-    body_markdown = build_report_markdown(programme_handle, vulnerability, summary)
-    cwe = _VULN_CLASS_TO_CWE.get(vulnerability.vuln_class)
+# Draft persistence
 
-    return DisclosureReport(
-        programme_handle=programme_handle,
-        title=vulnerability.title,
-        vulnerability=vulnerability,
-        summary=summary,
-        body_markdown=body_markdown,
-        weakness_id=cwe,
-        impact_statement=vulnerability.impact,
+
+def _drafts_dir() -> Path:
+    return runtime.run_dir() / _DRAFTS_SUBDIR
+
+
+def draft_path(finding_index: int) -> Path:
+    """Return the path of the draft file for ``finding_index``."""
+    return _drafts_dir() / f"{finding_index:03d}.json"
+
+
+def save_draft(draft: ReportDraft) -> Path:
+    """Persist a draft to ``<run_dir>/drafts/<idx:03d>.json``."""
+    path = draft_path(draft.finding_index)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(draft.model_dump_json(indent=2), encoding="utf-8")
+    return path
+
+
+def load_draft(finding_index: int) -> ReportDraft:
+    """Load a previously saved draft. Raises FileNotFoundError if absent."""
+    path = draft_path(finding_index)
+    if not path.is_file():
+        raise FileNotFoundError(f"no draft for finding {finding_index} at {path}")
+    return ReportDraft.model_validate_json(path.read_text(encoding="utf-8"))
+
+
+def load_drafts() -> list[ReportDraft]:
+    """Load every draft in the current run, ordered by finding_index."""
+    dir_ = _drafts_dir()
+    if not dir_.is_dir():
+        return []
+    drafts: list[ReportDraft] = []
+    for path in sorted(dir_.glob("*.json")):
+        drafts.append(ReportDraft.model_validate_json(path.read_text(encoding="utf-8")))
+    return drafts
+
+
+# Verified-finding lookup
+
+
+def load_verified(verified_path: Path) -> list[VerifiedVulnerability]:
+    """Load the VR's verified.json into VerifiedVulnerability instances."""
+    raw = json.loads(verified_path.read_text(encoding="utf-8"))
+    return [VerifiedVulnerability.model_validate(v) for v in raw]
+
+
+# Finalisation
+
+
+class FinalisationError(RuntimeError):
+    """Raised when finalise_drafts is called but at least one draft has hard
+    validation errors or is missing entirely."""
+
+
+def finalise_drafts(
+    programme_handle: str,
+    summary: str,
+    expected_count: int,
+) -> Path:
+    """Validate every draft, render markdown, build DisclosureReport per draft,
+    and write ``reports.json`` for the Disclosure Coordinator.
+
+    Refuses to finalise if any draft is missing or has hard validation errors.
+    """
+    drafts = load_drafts()
+    if len(drafts) != expected_count:
+        missing = expected_count - len(drafts)
+        raise FinalisationError(
+            f"expected {expected_count} drafts, found {len(drafts)} "
+            f"({missing} missing); draft each verified finding before finalising"
+        )
+
+    failures: list[tuple[int, list[ValidationIssue]]] = []
+    for draft in drafts:
+        report = validate_draft(draft)
+        if not report.ok:
+            failures.append(
+                (draft.finding_index, [i for i in report.issues if i.severity == "error"])
+            )
+
+    if failures:
+        lines = ["one or more drafts have unresolved errors:"]
+        for idx, issues in failures:
+            for issue in issues:
+                lines.append(f"  - draft {idx} / {issue.section}: {issue.message}")
+        raise FinalisationError("\n".join(lines))
+
+    reports: list[DisclosureReport] = []
+    for draft in drafts:
+        cwe = cwe_get_by_id(draft.cwe_id)
+        vuln = VerifiedVulnerability(
+            title=draft.title,
+            vuln_class=draft.vuln_class,
+            target=draft.target,
+            severity=draft.severity,
+            cvss_score=draft.cvss_score,
+            cvss_vector=draft.cvss_vector,
+            description=draft.description,
+            steps_to_reproduce=draft.steps_to_reproduce,
+            evidence=draft.evidence,
+            impact=draft.impact,
+            remediation=draft.remediation,
+        )
+        body = render_draft_markdown(draft)
+        reports.append(
+            DisclosureReport(
+                programme_handle=programme_handle,
+                title=draft.title,
+                vulnerability=vuln,
+                summary=summary,
+                body_markdown=body,
+                weakness_id=cwe.cwe_id if cwe else None,
+                impact_statement=draft.impact,
+            )
+        )
+
+    out_path = runtime.run_dir() / "reports.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps([r.model_dump(mode="json") for r in reports], default=str),
+        encoding="utf-8",
     )
+    return out_path
+
+
+# Disclosure Coordinator compatibility
 
 
 def save_report(report: DisclosureReport) -> Path:

--- a/tools/triage_tools.py
+++ b/tools/triage_tools.py
@@ -1,0 +1,629 @@
+"""
+tools/triage_tools.py - Triage authoring primitives for the Vulnerability
+Researcher.
+
+The VR's job is to turn a Penetration Tester's RawFinding into a
+VerifiedVulnerability whose description, impact, and remediation pass the
+Technical Author's draft-validation gate. The agent does the work; this module
+provides the supporting primitives:
+
+* ``TriageAssessment`` / ``DiscardEntry`` - per-finding artefacts the VR
+  composes and persists under ``<run_dir>/assessments/NNN.json`` and
+  ``<run_dir>/discards/NNN.json``.
+* ``validate_assessment(assessment, raw, programme)`` - quality gate. Returns
+  the issue list. Hard errors block ``finalise_triage``.
+* ``save_assessment`` / ``save_discard`` / ``load_*`` - persistence.
+* ``finalise_triage(programme_handle, raw_count)`` - validate every
+  assessment, build a ``VerifiedVulnerability`` per accepted one, and write
+  ``verified.json`` for the Technical Author. Refuses on hard errors or
+  unprocessed raw findings.
+* ``above_floor`` / ``in_scope`` - the discard gates the agent's tools
+  enforce. Moved here from ``tools/pentest/triage.py`` so the triage flow
+  is self-contained.
+
+Hand-wavy-impact detection and CVSS scoring are reused from
+``tools/report_tools.py`` - the same prose-quality invariants apply at both
+the VR and TA boundaries.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+import runtime
+from config import config
+from models import Programme, RawFinding, Severity, VerifiedVulnerability
+from tools._helpers import _SEVERITY_FLOOR_ORDER
+from tools.recon.scope import extract_domain, filter_in_scope
+from tools.report_tools import _HAND_WAVY_IMPACT, _URL, calculate_cvss_score
+
+_ASSESSMENTS_SUBDIR = "assessments"
+_DISCARDS_SUBDIR = "discards"
+
+# The literal boilerplate the old triage_findings function produced. If the
+# agent submits this verbatim it means they short-circuited the analysis.
+_STALE_DESCRIPTION = re.compile(r"automated detection of", re.IGNORECASE)
+_STALE_IMPACT = re.compile(r"pending manual review", re.IGNORECASE)
+_STALE_STEP = "observe the following evidence:"
+
+
+# Enumerations
+
+
+class SeverityDecision(StrEnum):
+    """How the VR's severity call relates to the PT's severity_hint."""
+
+    KEEP = "keep"
+    RAISE = "raise"
+    LOWER = "lower"
+
+
+class DiscardReason(StrEnum):
+    """Canonical reasons a raw finding does not make it into verified.json."""
+
+    OUT_OF_SCOPE = "out_of_scope"
+    BELOW_FLOOR = "below_floor"
+    FALSE_POSITIVE = "false_positive"
+    DUPLICATE = "duplicate"
+    NON_EXPLOITABLE = "non_exploitable"
+
+
+# Scope / floor gates
+
+
+def above_floor(severity: Severity) -> bool:
+    """True when ``severity`` is at or above the configured min-severity floor."""
+    floor = Severity(config.scan.min_severity)
+    return _SEVERITY_FLOOR_ORDER.index(severity) >= _SEVERITY_FLOOR_ORDER.index(floor)
+
+
+def in_scope(target: str, programme: Programme) -> bool:
+    """True when ``target``'s hostname is in the programme's structured scope."""
+    domain = extract_domain(target)
+    return bool(filter_in_scope([domain], programme))
+
+
+# Models
+
+
+class TriageAssessment(BaseModel):
+    """One VR-authored assessment for an accepted raw finding."""
+
+    finding_index: int
+    target: str
+    vuln_class: str
+
+    # PT hint, retained for comparison
+    severity_hint: Severity
+    severity_decision: SeverityDecision
+    severity: Severity
+    severity_rationale: str
+
+    cvss_vector: str
+    cvss_score: float
+
+    # Authored prose
+    title: str
+    description: str
+    steps_to_reproduce: list[str]
+    impact: str
+    remediation: str
+
+    assessed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class DiscardEntry(BaseModel):
+    """One VR-authored discard explanation for a raw finding."""
+
+    finding_index: int
+    target: str
+    vuln_class: str
+    severity_hint: Severity
+    reason: DiscardReason
+    rationale: str
+    discarded_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+# Validation
+
+
+class TriageValidationIssue(BaseModel):
+    """One issue produced by validate_assessment."""
+
+    section: str
+    severity: str  # "error" (blocks finalise) or "warning" (advisory)
+    message: str
+
+
+class TriageValidationReport(BaseModel):
+    """Result of validating one assessment."""
+
+    ok: bool
+    issues: list[TriageValidationIssue] = Field(default_factory=list)
+
+
+def _count_steps_too_short(steps: list[str]) -> list[int]:
+    """Return 1-based indices of steps whose stripped length is < 10."""
+    return [n for n, s in enumerate(steps, 1) if len(s.strip()) < 10]
+
+
+def validate_assessment(
+    assessment: TriageAssessment,
+    raw: RawFinding,
+    programme: Programme,
+) -> TriageValidationReport:
+    """Apply quality heuristics to an assessment. Returns the issue list.
+
+    ``raw`` is the corresponding raw finding from findings.json - used to
+    enforce target/vuln_class/severity_hint consistency. ``programme`` is the
+    parsed Programme - used for scope and severity-floor checks. The same
+    hand-wavy-impact and URL-citation rules the Technical Author enforces are
+    applied here so the TA never sees an assessment that would fail its own
+    draft gate.
+    """
+    issues: list[TriageValidationIssue] = []
+
+    # Consistency with the raw finding (must not silently rewrite identifiers)
+    if assessment.target != raw.target:
+        issues.append(
+            TriageValidationIssue(
+                section="target",
+                severity="error",
+                message=(
+                    f"target {assessment.target!r} does not match the raw finding "
+                    f"target {raw.target!r}; do not rewrite target during triage"
+                ),
+            )
+        )
+    if assessment.vuln_class != raw.vuln_class:
+        issues.append(
+            TriageValidationIssue(
+                section="vuln_class",
+                severity="error",
+                message=(
+                    f"vuln_class {assessment.vuln_class!r} does not match the raw "
+                    f"finding vuln_class {raw.vuln_class!r}"
+                ),
+            )
+        )
+    if assessment.severity_hint != raw.severity_hint:
+        issues.append(
+            TriageValidationIssue(
+                section="severity_hint",
+                severity="error",
+                message=(
+                    f"severity_hint {assessment.severity_hint!r} does not match the "
+                    f"raw finding severity_hint {raw.severity_hint!r}"
+                ),
+            )
+        )
+
+    # Scope / floor: hard errors that imply a discard, not an assessment
+    if not in_scope(assessment.target, programme):
+        issues.append(
+            TriageValidationIssue(
+                section="target",
+                severity="error",
+                message=(
+                    f"target is out of programme scope; use Discard Finding with "
+                    f"reason='{DiscardReason.OUT_OF_SCOPE}' instead"
+                ),
+            )
+        )
+    if not above_floor(assessment.severity):
+        issues.append(
+            TriageValidationIssue(
+                section="severity",
+                severity="error",
+                message=(
+                    f"severity {assessment.severity} is below the configured floor; "
+                    f"use Discard Finding with reason='{DiscardReason.BELOW_FLOOR}' instead"
+                ),
+            )
+        )
+
+    # Severity rationale
+    if len(assessment.severity_rationale.strip()) < 30:
+        issues.append(
+            TriageValidationIssue(
+                section="severity_rationale",
+                severity="error",
+                message=(
+                    "severity_rationale too thin; justify the call in one or two "
+                    "sentences (exploit prerequisites, blast radius, business impact)"
+                ),
+            )
+        )
+
+    # Severity decision consistency
+    if assessment.severity_decision == SeverityDecision.KEEP:
+        if assessment.severity != assessment.severity_hint:
+            issues.append(
+                TriageValidationIssue(
+                    section="severity_decision",
+                    severity="error",
+                    message=(
+                        "severity_decision='keep' but severity differs from "
+                        "severity_hint; set decision to 'raise' or 'lower'"
+                    ),
+                )
+            )
+    elif assessment.severity == assessment.severity_hint:
+        issues.append(
+            TriageValidationIssue(
+                section="severity_decision",
+                severity="error",
+                message=(
+                    f"severity_decision='{assessment.severity_decision}' but severity "
+                    "matches severity_hint; set decision to 'keep'"
+                ),
+            )
+        )
+
+    # Title (soft - the TA rewrites)
+    if len(assessment.title.strip()) < 20:
+        issues.append(
+            TriageValidationIssue(
+                section="title",
+                severity="warning",
+                message=(
+                    "title is shorter than 20 chars; the TA can rewrite but a "
+                    "descriptive title makes the briefing easier to scan"
+                ),
+            )
+        )
+
+    # Description
+    if _STALE_DESCRIPTION.search(assessment.description):
+        issues.append(
+            TriageValidationIssue(
+                section="description",
+                severity="error",
+                message=(
+                    "description contains the legacy 'Automated detection of...' "
+                    "boilerplate; describe the root cause in your own words"
+                ),
+            )
+        )
+    if len(assessment.description.strip()) < 100:
+        issues.append(
+            TriageValidationIssue(
+                section="description",
+                severity="error",
+                message=(
+                    "description too thin; explain the root cause as if briefing "
+                    "the TA - what the bug is, why it works, what code path is "
+                    "responsible"
+                ),
+            )
+        )
+
+    # Steps
+    if len(assessment.steps_to_reproduce) < 2:
+        issues.append(
+            TriageValidationIssue(
+                section="steps_to_reproduce",
+                severity="error",
+                message="at least 2 numbered steps are required",
+            )
+        )
+    short_indices = _count_steps_too_short(assessment.steps_to_reproduce)
+    for n in short_indices:
+        issues.append(
+            TriageValidationIssue(
+                section="steps_to_reproduce",
+                severity="error",
+                message=f"step {n} is too short to be reproducible",
+            )
+        )
+    for n, step in enumerate(assessment.steps_to_reproduce, 1):
+        if step.strip().lower() == _STALE_STEP:
+            issues.append(
+                TriageValidationIssue(
+                    section="steps_to_reproduce",
+                    severity="error",
+                    message=(
+                        f"step {n} is the legacy 'Observe the following evidence:' "
+                        "placeholder; write the actual observable proof"
+                    ),
+                )
+            )
+
+    # Impact
+    if len(assessment.impact.strip()) < 40:
+        issues.append(
+            TriageValidationIssue(
+                section="impact",
+                severity="error",
+                message=(
+                    "impact statement too short; name the data/system at risk, who "
+                    "is affected, and the realistic worst outcome"
+                ),
+            )
+        )
+    if _HAND_WAVY_IMPACT.search(assessment.impact):
+        issues.append(
+            TriageValidationIssue(
+                section="impact",
+                severity="error",
+                message=(
+                    "impact statement uses hand-wavy language (e.g. 'could "
+                    "compromise', 'potential'); be concrete about what an attacker "
+                    "can actually do"
+                ),
+            )
+        )
+    if _STALE_IMPACT.search(assessment.impact):
+        issues.append(
+            TriageValidationIssue(
+                section="impact",
+                severity="error",
+                message=(
+                    "impact contains the legacy 'pending manual review' placeholder; "
+                    "the manual review is your job - write the concrete impact"
+                ),
+            )
+        )
+
+    # Remediation
+    if len(assessment.remediation.strip()) < 60:
+        issues.append(
+            TriageValidationIssue(
+                section="remediation",
+                severity="error",
+                message="remediation too thin; give the developer a concrete fix",
+            )
+        )
+    if not _URL.search(assessment.remediation):
+        issues.append(
+            TriageValidationIssue(
+                section="remediation",
+                severity="error",
+                message=(
+                    "remediation must cite an OWASP cheat-sheet or CWE URL; use "
+                    "Lookup OWASP Guidance / Lookup CWE for canonical references"
+                ),
+            )
+        )
+
+    # CVSS
+    try:
+        recomputed = calculate_cvss_score(assessment.cvss_vector)
+    except ValueError as exc:
+        issues.append(
+            TriageValidationIssue(
+                section="cvss",
+                severity="error",
+                message=f"cvss_vector is invalid: {exc}",
+            )
+        )
+    else:
+        if abs(recomputed - assessment.cvss_score) > 0.05:
+            issues.append(
+                TriageValidationIssue(
+                    section="cvss",
+                    severity="error",
+                    message=(
+                        f"cvss_score ({assessment.cvss_score}) does not match the "
+                        f"vector ({recomputed} computed); use Calculate CVSS Score"
+                    ),
+                )
+            )
+        else:
+            implied = _severity_from_score(recomputed)
+            if implied != assessment.severity:
+                issues.append(
+                    TriageValidationIssue(
+                        section="cvss",
+                        severity="warning",
+                        message=(
+                            f"CVSS score {recomputed} implies severity "
+                            f"{implied} but assessment says {assessment.severity}; "
+                            "consider revising the vector or severity"
+                        ),
+                    )
+                )
+
+    ok = not any(i.severity == "error" for i in issues)
+    return TriageValidationReport(ok=ok, issues=issues)
+
+
+# CVSS / severity bridge
+
+
+_SEVERITY_BANDS: list[tuple[float, Severity]] = [
+    (9.0, Severity.CRITICAL),
+    (7.0, Severity.HIGH),
+    (4.0, Severity.MEDIUM),
+    (0.1, Severity.LOW),
+    (0.0, Severity.INFORMATIONAL),
+]
+
+
+def _severity_from_score(score: float) -> Severity:
+    """The NVD severity band for ``score`` per the CVSS 3.1 qualitative scale."""
+    for threshold, sev in _SEVERITY_BANDS:
+        if score >= threshold:
+            return sev
+    return Severity.INFORMATIONAL
+
+
+# Persistence
+
+
+def _assessments_dir() -> Path:
+    return runtime.run_dir() / _ASSESSMENTS_SUBDIR
+
+
+def _discards_dir() -> Path:
+    return runtime.run_dir() / _DISCARDS_SUBDIR
+
+
+def assessment_path(finding_index: int) -> Path:
+    return _assessments_dir() / f"{finding_index:03d}.json"
+
+
+def discard_path(finding_index: int) -> Path:
+    return _discards_dir() / f"{finding_index:03d}.json"
+
+
+def save_assessment(assessment: TriageAssessment) -> Path:
+    """Persist an assessment to ``<run_dir>/assessments/<idx:03d>.json``."""
+    path = assessment_path(assessment.finding_index)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Discard any existing discard for the same index (the VR changed their mind).
+    _drop_discard(assessment.finding_index)
+    path.write_text(assessment.model_dump_json(indent=2), encoding="utf-8")
+    return path
+
+
+def save_discard(discard: DiscardEntry) -> Path:
+    """Persist a discard to ``<run_dir>/discards/<idx:03d>.json``."""
+    path = discard_path(discard.finding_index)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _drop_assessment(discard.finding_index)
+    path.write_text(discard.model_dump_json(indent=2), encoding="utf-8")
+    return path
+
+
+def _drop_assessment(finding_index: int) -> None:
+    path = assessment_path(finding_index)
+    if path.is_file():
+        path.unlink()
+
+
+def _drop_discard(finding_index: int) -> None:
+    path = discard_path(finding_index)
+    if path.is_file():
+        path.unlink()
+
+
+def load_assessments() -> list[TriageAssessment]:
+    """Load every assessment in the current run, ordered by finding_index."""
+    dir_ = _assessments_dir()
+    if not dir_.is_dir():
+        return []
+    return [
+        TriageAssessment.model_validate_json(p.read_text(encoding="utf-8"))
+        for p in sorted(dir_.glob("*.json"))
+    ]
+
+
+def load_discards() -> list[DiscardEntry]:
+    """Load every discard in the current run, ordered by finding_index."""
+    dir_ = _discards_dir()
+    if not dir_.is_dir():
+        return []
+    return [
+        DiscardEntry.model_validate_json(p.read_text(encoding="utf-8"))
+        for p in sorted(dir_.glob("*.json"))
+    ]
+
+
+# Raw findings loader (deliberately not on workspace - typed return)
+
+
+def load_raw_findings(findings_path: Path) -> list[RawFinding]:
+    """Load raw findings from a findings.json path."""
+    raw = json.loads(findings_path.read_text(encoding="utf-8"))
+    return [RawFinding.model_validate(f) for f in raw]
+
+
+# Finalisation
+
+
+class TriageFinalisationError(RuntimeError):
+    """Raised when finalise_triage cannot produce verified.json: missing
+    coverage (an unassessed/undiscarded raw finding) or any assessment with
+    hard validation errors."""
+
+
+def finalise_triage(
+    programme: Programme,
+    raw_findings: list[RawFinding],
+) -> Path:
+    """Validate every assessment, build a ``VerifiedVulnerability`` per
+    accepted one, and write ``verified.json`` for the Technical Author.
+
+    Refuses to finalise if:
+      * any raw finding is neither assessed nor discarded
+      * any assessment has hard validation errors
+      * a finding has both an assessment and a discard (ambiguous)
+
+    Returns the path to the written verified.json (may contain zero entries
+    if every finding was discarded - the TA briefing will explain).
+    """
+    assessments = load_assessments()
+    discards = load_discards()
+
+    assessed_idx = {a.finding_index for a in assessments}
+    discarded_idx = {d.finding_index for d in discards}
+
+    ambiguous = assessed_idx & discarded_idx
+    if ambiguous:
+        raise TriageFinalisationError(
+            f"findings {sorted(ambiguous)} are both assessed and discarded; "
+            "save_assessment / save_discard clear the other, so this should not "
+            "happen - investigate"
+        )
+
+    all_idx = set(range(len(raw_findings)))
+    missing = sorted(all_idx - assessed_idx - discarded_idx)
+    if missing:
+        raise TriageFinalisationError(
+            f"raw findings {missing} have no assessment or discard; every finding "
+            "must be either assessed or discarded before finalising"
+        )
+
+    raw_by_idx = dict(enumerate(raw_findings))
+    failures: list[tuple[int, list[TriageValidationIssue]]] = []
+    for assessment in assessments:
+        raw = raw_by_idx[assessment.finding_index]
+        report = validate_assessment(assessment, raw, programme)
+        if not report.ok:
+            failures.append(
+                (
+                    assessment.finding_index,
+                    [i for i in report.issues if i.severity == "error"],
+                )
+            )
+
+    if failures:
+        lines = ["one or more assessments have unresolved errors:"]
+        for idx, errs in failures:
+            for err in errs:
+                lines.append(f"  - assessment {idx} / {err.section}: {err.message}")
+        raise TriageFinalisationError("\n".join(lines))
+
+    verified: list[VerifiedVulnerability] = []
+    for assessment in assessments:
+        raw = raw_by_idx[assessment.finding_index]
+        verified.append(
+            VerifiedVulnerability(
+                title=assessment.title,
+                vuln_class=assessment.vuln_class,
+                target=assessment.target,
+                severity=assessment.severity,
+                cvss_score=assessment.cvss_score,
+                cvss_vector=assessment.cvss_vector,
+                description=assessment.description,
+                steps_to_reproduce=assessment.steps_to_reproduce,
+                evidence=raw.evidence,
+                impact=assessment.impact,
+                remediation=assessment.remediation,
+            )
+        )
+
+    out_path = runtime.run_dir() / "verified.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps([v.model_dump(mode="json") for v in verified], default=str),
+        encoding="utf-8",
+    )
+    return out_path


### PR DESCRIPTION
"In a vacuum" PR for #114, per your request. Branched off `feat/file-path-artifacts` so you can review the TA tooling idea on its own and either pull it in, cherry-pick parts, or close it without affecting #114.

## The problem I tried to solve

Reading `squad/technical_author/write/description.md` next to `tools/report_tools.py`, the TA's prompt and tooling don't agree on what the TA's *job* is.

The prompt asks for craft: a punchy title that matches `[Type] in [Component] allows [Outcome]`, a developer-tuned description that explains **why** the code is vulnerable, sanitised evidence with no live credentials, a specific impact statement, and remediation that cites OWASP or CWE.

The only tool that writes a report is `create_reports_tool(verified_path, programme_handle, summary)`. It reads `VerifiedVulnerability` from `verified.json` and pours every field — `title`, `description`, `steps_to_reproduce`, `evidence`, `impact`, `remediation` — directly into a markdown template. The TA's only inputs are the programme handle and a 2-3 sentence session summary; every other byte comes from the VR. The TA can't be punchy, developer-focused, sanitised, or citation-rich, because there's no argument those words could even flow through.

Three smaller things compounded that:

1. Raw `evidence` (sqlmap output, full request/response dumps, JWTs) was inlined verbatim up to 2000 chars. A bearer token or session cookie in the VR's evidence shipped straight to H1.
2. CWE lookup was a 13-entry hardcoded `dict` in `report_tools.py`. It listed `XSS` but not `ReflectedXSS`/`HeaderXSS`, listed `IDOR` but not `AccessControlBypass`, and missed `PrototypePollution`, `SSTI`, `OpenRedirect`'s several variants, JWT, etc. — many of the actual `vuln_class` strings the pentest tooling emits.
3. No quality gate. The "triage on first read" bar in the prompt isn't enforceable when nothing checks it.

## What's in the PR

Six new tools for the TA, one removed, plus the supporting infrastructure.

| Tool | Role |
|---|---|
| **Sanitise Evidence** | Redacts credentials, cookies, bearer tokens, JWTs, AWS keys, secret-shaped `key=value` pairs. Preserves payloads (XSS strings, SQLi vectors, SSRF URLs) — this is private disclosure and the triager needs the literal exploit. Returns `{sanitised, redactions, warnings}`. |
| **Lookup CWE** | Local catalogue (29 entries) covering every `vuln_class` the pentest stage emits, plus reasonable aliases. Returns id, name, description, MITRE URL, and the matching OWASP topic. |
| **Lookup OWASP Guidance** | Local OWASP Cheat Sheet Series catalogue with short, paste-friendly `key_principles` and canonical URLs. Cross-referenced from CWE lookups. |
| **Draft Vulnerability Report** | Per-finding authoring. Takes the prose the triager will read; reads `target` / `vuln_class` / `severity` from the verified finding so the TA can't contradict the VR. Persists under `drafts/NNN.json`. Returns a validation report. |
| **Finalise Reports** | Consolidates every draft into `reports.json` for the DC. Refuses if any draft is missing or has unresolved validation errors. |
| **List Programme Reports** | Same as the VR's tool; gives the TA duplicate awareness at titling time so the DC doesn't have to reject collisions post-hoc. |

`Calculate CVSS Score` and the workspace read tools stay. `Create Disclosure Reports` is gone.

## The validation gate

`validate_draft` runs every time `draft_report_tool` is called and is the gate `finalise_reports_tool` checks before consolidating. Errors block, warnings are advisory. The rules:

- **Title** — must match `[Type] in [Component] allows [Outcome]` heuristically; warns over 120 chars.
- **Summary** — between 2 and 5 sentences.
- **Description** — at least 100 chars (a thin description means the TA short-circuited the developer-tuned explanation).
- **Steps** — at least 2 entries, each at least 10 chars.
- **Evidence** — non-empty; re-running `sanitise_evidence` on the supplied evidence must find no further redactions (i.e. the TA already cleaned it).
- **Impact** — at least 40 chars; rejects hand-wavy phrases like "could compromise", "may allow", "potentially".
- **Remediation** — at least 60 chars; must contain a URL (forces an OWASP/CWE citation).
- **CVSS** — `cvss_score` must match the recomputed score from `cvss_vector` to within 0.05.
- **CWE** — warn (not error) if `cwe_id` isn't in the local catalogue.

The DisclosureReport schema is unchanged; the DC continues to consume `reports.json` exactly the same way.

## Authoring loop the TA now follows

```
for each finding in verified.json:
    Lookup CWE(vuln_class) -> cwe_id + suggested OWASP topic
    Lookup OWASP Guidance(topic) -> URL + key_principles
    Sanitise Evidence(raw evidence) -> sanitised text
    Draft Vulnerability Report(...) -> validation report
        # repeat with fixes until validation.ok
Finalise Reports(programme_handle, session summary)
```

The agent has to *type* the title, summary, description, etc. into the tool args. That's the leap from "no-op wrapper" to "ReAct authoring loop with critique feedback".

## CI

- `ruff check`, `ruff format --check`, `mypy --ignore-missing-imports`, `bandit` all clean.
- `pytest -m unit --cov` — 820 passed, **91.36% coverage** (above the 90% floor). 
- New tests: `test_cwe_data.py`, `test_owasp_data.py`, new `TestSanitiseEvidence`/`TestValidateDraft`/`TestSaveAndLoadDraft`/`TestFinaliseDrafts` in `test_report_tools.py`, and a full rewrite of `TestTechnicalAuthorTools` in `test_squad_tools.py`.

## Things I deliberately did not do

- **Did not touch the VR, PT, DC, or any other agent.** Single-agent change.
- **Did not change `DisclosureReport`, `VerifiedVulnerability`, or any other model.** Schema-compatible with #114.
- **Did not move severity prioritisation or batching.** The prompt asks for one report per finding, the tools deliver one report per finding.
- **Did not add a "preview rendered markdown" tool.** `validate_draft` returns enough signal; an explicit preview round adds tokens for marginal benefit. Easy to add later if the agent needs it.

## How to read this

I'd start with `squad/technical_author/write/description.md` (the new TA workflow), then `tools/report_tools.py` (the primitives), then `squad/technical_author/__init__.py` (the `@tool` wiring). The two catalogue modules are mostly data.
