### PR TITLE
feat(oa): make the OSINT Analyst actually curate the attack surface

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ cybersquad is a six-agent CrewAI pipeline that autonomously selects HackerOne bu
 | `squad/<member>/{description,expected_output}.md` | Two single-purpose files driving the Task description and expected output. |
 | `squad/<member>/__init__.py` | Tool functions (`@tool`) + a module-level `MEMBER = SquadMember(...)` constant. |
 | `tools/h1_api.py` | HackerOne REST client. Singleton: `from tools.h1_api import h1`. |
-| `tools/recon/` | Recon tools: subfinder, httpx, nmap, TLS, DNS, dirfuzz, waybackurls, cert transparency, traceroute, scope guard. |
+| `tools/recon/` | Recon tools: subfinder, httpx, dnsx (subdomain-takeover detection), nmap, TLS, DNS, dirfuzz, waybackurls, cert transparency, traceroute, scope guard. |
 | `tools/recon/scope.py` | `filter_in_scope()` - hard scope enforcement boundary. Do not weaken. |
 | `tools/recon_insights.py` | Host-annotation authoring primitives for the OSINT Analyst: HostInsight persistence, quality validation, and final consolidation of sweep.json + insights into recon.json. |
 | `tools/pentest/` | Pentest tools: nuclei, sqlmap, CORS, SSRF, XSS, SRI, header injection, source maps, error disclosure. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,6 +20,7 @@ cybersquad is a six-agent CrewAI pipeline that autonomously selects HackerOne bu
 | `tools/h1_api.py` | HackerOne REST client. Singleton: `from tools.h1_api import h1`. |
 | `tools/recon/` | Recon tools: subfinder, httpx, nmap, TLS, DNS, dirfuzz, waybackurls, cert transparency, traceroute, scope guard. |
 | `tools/recon/scope.py` | `filter_in_scope()` - hard scope enforcement boundary. Do not weaken. |
+| `tools/recon_insights.py` | Host-annotation authoring primitives for the OSINT Analyst: HostInsight persistence, quality validation, and final consolidation of sweep.json + insights into recon.json. |
 | `tools/pentest/` | Pentest tools: nuclei, sqlmap, CORS, SSRF, XSS, SRI, header injection, source maps, error disclosure. |
 | `tools/cloud/` | Cloud/service checks: S3, Azure Blob, per-engine databases, admin panels, branded panels. |
 | `tools/cloud/databases/` | Per-engine unauthenticated database checks: one file per engine. |

--- a/install-tools.sh
+++ b/install-tools.sh
@@ -6,7 +6,7 @@
 #
 # Tools installed:
 #   Go (if absent or < 1.22): official tarball from go.dev
-#   go install: subfinder, httpx, nuclei, ffuf, waybackurls
+#   go install: subfinder, httpx, nuclei, ffuf, waybackurls, dnsx
 #   apt         : nmap, sqlmap
 #   git clone   : testssl.sh -> /usr/local/bin/testssl.sh
 
@@ -90,6 +90,7 @@ declare -A GO_TOOLS=(
   [nuclei]="github.com/projectdiscovery/nuclei/v3/cmd/nuclei"
   [ffuf]="github.com/ffuf/ffuf/v2@latest"
   [waybackurls]="github.com/tomnomnom/waybackurls"
+  [dnsx]="github.com/projectdiscovery/dnsx/cmd/dnsx"
 )
 
 for tool in "${!GO_TOOLS[@]}"; do
@@ -155,7 +156,7 @@ echo "==> PATH is updated. Run 'source ~/.bashrc' (or open a new terminal) to us
 
 echo ""
 echo "==> Tool check:"
-for tool in subfinder httpx nmap nuclei ffuf waybackurls sqlmap testssl.sh; do
+for tool in subfinder httpx dnsx nmap nuclei ffuf waybackurls sqlmap testssl.sh; do
   if need "${tool}"; then
     echo "  [ok]      ${tool} -> $(command -v ${tool})"
   else

--- a/models.py
+++ b/models.py
@@ -96,6 +96,57 @@ class EndpointPage(BaseModel):
     endpoints: list[Endpoint]
 
 
+class HostRole(StrEnum):
+    """The role a host plays in the programme's attack surface.
+
+    Drives priority decisions downstream: an ``ADMIN`` host with a known
+    framework is a higher-value pentest target than a ``CDN`` host that
+    serves static assets.
+    """
+
+    ADMIN = "admin"  # admin / control-plane UIs
+    API = "api"  # REST / GraphQL / SOAP endpoints
+    AUTH = "auth"  # SSO, OAuth, login, password reset
+    APP = "app"  # main user-facing application
+    CDN = "cdn"  # static asset delivery, edge caches
+    STATIC = "static"  # purely static content (marketing, blog, docs)
+    MAIL = "mail"  # SMTP / IMAP / MX hosts
+    INFRA = "infra"  # name servers, monitoring, IaaS
+    DEV = "dev"  # dev / staging / beta surfaces
+    UNKNOWN = "unknown"
+
+
+class HostPriority(StrEnum):
+    """The OSINT Analyst's curation signal for downstream agents.
+
+    The Penetration Tester biases probe budget toward ``HIGH`` hosts; the
+    Vulnerability Researcher prioritises CVE / report-history research for
+    them. ``SKIP`` is a hard signal not to probe (third-party-managed, known
+    decoy, etc.)."""
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    SKIP = "skip"
+
+
+class HostInsight(BaseModel):
+    """One OSINT Analyst-authored annotation for a single host.
+
+    The sweep produces ``subdomains`` / ``endpoints`` / ``open_ports`` /
+    ``technologies`` as raw inventory; ``HostInsight`` is the agent's
+    curation layer that tells downstream agents WHERE to look first and
+    WHY.
+    """
+
+    hostname: str
+    role: HostRole
+    priority: HostPriority
+    notes: str  # agent-authored, >= 30 chars
+    detected_tech: list[str] = Field(default_factory=list)  # ideally with versions
+    annotated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
 class ReconResult(BaseModel):
     """Everything the OSINT Analyst found about a programme's attack surface."""
 
@@ -111,6 +162,9 @@ class ReconResult(BaseModel):
     # hostname -> ordered list of public hop IPs from traceroute.
     # Useful for identifying origin IPs behind CDNs/WAFs (CDN bypass vector).
     network_hops: dict[str, list[str]] = Field(default_factory=dict)
+    # Per-host curation the OSINT Analyst authors via Annotate Host. Empty on
+    # the OA's internal sweep.json; populated on the final recon.json.
+    host_insights: list[HostInsight] = Field(default_factory=list)
     completed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
 

--- a/squad/osint_analyst/__init__.py
+++ b/squad/osint_analyst/__init__.py
@@ -2,43 +2,114 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from crewai.tools import tool
 
-from models import Endpoint
+import runtime
+from models import Endpoint, HostInsight, HostPriority, HostRole, Programme
 from squad import SquadMember, read_run_file_tool, read_run_filelist_tool
-from tools import http
+from tools import cwe_data, http, owasp_data
 from tools.h1_api import h1
 from tools.recon import cert_transparency, detect_llm_endpoints, historical_urls, run_recon
+from tools.recon import probe_endpoints as probe_endpoints_impl
+from tools.recon.query import recon_endpoints, recon_open_ports, recon_subdomains
+from tools.recon.scope import filter_in_scope as filter_in_scope_impl
+from tools.recon_insights import (
+    ReconFinalisationError,
+    finalise_recon,
+    save_insight,
+    uncovered_interesting_hosts,
+    validate_insight,
+)
+from tools.recon_insights import (
+    load_insights as load_insights_impl,
+)
+from tools.recon_insights import (
+    load_sweep as load_sweep_impl,
+)
 
 
-@tool("Run Recon")
-def recon_tool(programme_handle: str) -> str:
+@tool("Run Initial Sweep")
+def run_initial_sweep_tool(programme_handle: str) -> str:
     """
-    Run full OSINT recon (subdomain enumeration, HTTP probing, port scanning)
-    against the in-scope assets of the given programme handle. Writes the
-    serialised ReconResult to recon.json in the run directory and returns
-    the relative filename for downstream agents to read.
-    """
-    import runtime
+    Run the initial OSINT sweep against the in-scope assets of the given
+    programme: subfinder for subdomain enumeration, httpx for live HTTP/S
+    probing and tech detection, nmap for port scanning, ffuf for content
+    discovery, plus passive TLS and DNS email-security checks. Writes the
+    serialised inventory to ``sweep.json`` (the OA's internal draft) in the
+    run directory and returns the relative filename.
 
+    This is the inventory step. Annotate the interesting hosts with
+    Annotate Host and call Finalise Recon to produce the canonical
+    ``recon.json`` that downstream agents consume.
+    """
     http.set_programme(programme_handle)
     policy = h1.get_programme_policy(programme_handle)
     scope = h1.get_structured_scope(programme_handle)
     programme = h1.parse_programme(policy["data"], scope)
     result = run_recon(programme)
-    out_path = runtime.run_dir() / "recon.json"
+    out_path = runtime.run_dir() / "sweep.json"
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(result.model_dump_json(), encoding="utf-8")
-    return "recon.json"
+    return "sweep.json"
+
+
+@tool("Recon Subdomains")
+def recon_subdomains_tool(sweep_path: str = "sweep.json", host_filter: str | None = None) -> list:
+    """
+    Return the in-scope subdomains in the OA's draft sweep. ``host_filter`` is
+    a case-insensitive substring (e.g. "api" returns every subdomain
+    containing "api"). Use this to inspect the sweep before deciding which
+    hosts to annotate.
+    """
+    return recon_subdomains(sweep_path, host_filter=host_filter)
+
+
+@tool("Recon Endpoints")
+def recon_endpoints_tool(
+    sweep_path: str = "sweep.json",
+    status: int | None = None,
+    tech: str | None = None,
+    host_contains: str | None = None,
+    offset: int = 0,
+    limit: int = 50,
+) -> dict:
+    """
+    Return a paginated slice of endpoints from the sweep matching the given
+    filters (conjunctive). ``tech`` matches case-insensitively as a
+    substring against each endpoint's technologies; ``host_contains``
+    matches the URL. Use this to find which hostnames run a given stack
+    before annotating.
+    """
+    return recon_endpoints(
+        sweep_path,
+        status=status,
+        tech=tech,
+        host_contains=host_contains,
+        offset=offset,
+        limit=limit,
+    ).model_dump(mode="json")
+
+
+@tool("Recon Open Ports")
+def recon_open_ports_tool(sweep_path: str = "sweep.json", host: str | None = None) -> dict:
+    """
+    Return the open-port map per host from the sweep. Passing a ``host``
+    restricts the result to that single host. Use to surface non-HTTP
+    services (Redis 6379, Elasticsearch 9200, Mongo 27017, etc.) that an
+    annotation should call out.
+    """
+    return recon_open_ports(sweep_path, host=host)
 
 
 @tool("Certificate Transparency Lookup")
 def cert_transparency_tool(domain: str) -> list[str]:
     """
-    Query crt.sh certificate transparency logs to discover subdomains not found
-    by active enumeration. Returns deduplicated hostnames.
+    Query crt.sh certificate transparency logs to discover subdomains not
+    found by active enumeration. Returns deduplicated hostnames. Feed
+    newly discovered hosts to Probe Hostnames to determine which are live.
     """
     return cert_transparency(domain)
 
@@ -46,8 +117,9 @@ def cert_transparency_tool(domain: str) -> list[str]:
 @tool("Historical URL Discovery")
 def historical_urls_tool(domain: str) -> list[str]:
     """
-    Use waybackurls to find historical endpoints for a domain from the Wayback
-    Machine. Surfaces paths that may no longer be linked but still exist.
+    Use waybackurls to find historical endpoints for a domain from the
+    Wayback Machine. Surfaces paths that may no longer be linked but still
+    exist - candidates for Probe Hostnames.
     """
     return historical_urls(domain)
 
@@ -55,37 +127,199 @@ def historical_urls_tool(domain: str) -> list[str]:
 @tool("LLM Endpoint Detection")
 def llm_detection_tool(endpoints_json: str) -> list[dict]:
     """
-    Scan a set of live endpoints for signals that they are backed by an LLM or
-    AI assistant. Uses two methods:
-
-    1. URL path inspection - checks path segments against known LLM tokens
-       (chat, ask, ai, assistant, completions, generate, copilot, etc.)
-    2. Response probing - checks HTTP headers (OpenAI gateway headers), content
-       type (text/event-stream for streaming responses), JSON structure
-       (OpenAI-format choices/tokens keys), and body text (AI self-identification
-       phrases).
-
-    endpoints_json: JSON array of endpoint objects from ReconResult. Pass the
-      full endpoint list after run_recon completes - the tool filters internally.
-      Example: '[{"url": "https://example.com/chat", "status_code": 200}]'
-
-    Returns endpoint dicts tagged with 'LLM' in their technologies list. Pass
-    these to the Penetration Tester for prompt injection testing.
+    Scan a set of live endpoints for signals that they are backed by an LLM
+    or AI assistant (URL path heuristics, OpenAI-format response keys,
+    EventSource content-type, self-identification phrases). Pass the
+    sweep's endpoint list (or a filtered subset) as JSON. Returned hits
+    deserve a HIGH-priority annotation and a note pointing the Penetration
+    Tester at prompt-injection probes.
     """
-    import json
-
     endpoints = [Endpoint.model_validate(e) for e in json.loads(endpoints_json)]
     return [ep.model_dump() for ep in detect_llm_endpoints(endpoints)]
+
+
+@tool("Probe Hostnames")
+def probe_hostnames_tool(hostnames: list[str], programme_handle: str) -> list[dict]:
+    """
+    Re-probe a list of hostnames with httpx to confirm liveness, capture
+    status codes, and fingerprint technologies. Use this on hostnames
+    surfaced by Certificate Transparency or Historical URL Discovery that
+    were not in the initial sweep.
+
+    The hostnames are filtered against the programme's structured scope
+    before any HTTP traffic is generated; out-of-scope hostnames are
+    dropped silently (we never probe outside scope, even for fingerprinting).
+    Returns ``[{url, status_code, technologies, parameters}]``. Net-new
+    endpoints can then be annotated with Annotate Host.
+    """
+    if not hostnames:
+        return []
+    programme = _load_programme(programme_handle)
+    in_scope = filter_in_scope_impl([h.strip().lower() for h in hostnames if h.strip()], programme)
+    if not in_scope:
+        return []
+    eps = probe_endpoints_impl(in_scope)
+    return [ep.model_dump(mode="json") for ep in eps]
+
+
+@tool("Lookup CWE")
+def lookup_cwe_tool(query: str) -> list[dict]:
+    """
+    Find Common Weakness Enumeration entries that match a query - useful
+    when annotating a host whose detected tech has a well-known weakness
+    class (e.g. "WordPress" -> XSS / SQLi; "Spring Boot" -> SSTI / RCE).
+    Returns each match's cwe_id, name, short description, and the matching
+    OWASP cheat-sheet topic.
+    """
+    entries = cwe_data.lookup(query)
+    return [
+        {
+            "cwe_id": e.cwe_id,
+            "name": e.name,
+            "description": e.description,
+            "url": e.url,
+            "owasp_topic": e.owasp_topic,
+        }
+        for e in entries
+    ]
+
+
+@tool("Lookup OWASP Guidance")
+def lookup_owasp_tool(query: str) -> list[dict]:
+    """
+    Find OWASP Cheat Sheet entries for a vuln class or topic - hint for
+    the downstream VR's attack-plan reasoning. Returns each match's title,
+    key_principles, and the canonical cheatsheetseries.owasp.org URL.
+    """
+    entries = owasp_data.lookup(query)
+    return [
+        {
+            "topic": e.topic,
+            "title": e.title,
+            "url": e.url,
+            "key_principles": e.key_principles,
+        }
+        for e in entries
+    ]
+
+
+@tool("Annotate Host")
+def annotate_host_tool(
+    hostname: str,
+    role: str,
+    priority: str,
+    notes: str,
+    detected_tech: list[str] | None = None,
+    sweep_path: str = "sweep.json",
+    programme_handle: str | None = None,
+) -> dict:
+    """
+    Author one HostInsight for a single hostname and run the quality gate.
+
+    Inputs:
+      - hostname: a hostname from the sweep, or one newly discovered via
+        Certificate Transparency / Historical URL Discovery / Probe Hostnames
+      - role: one of admin, api, auth, app, cdn, static, mail, infra, dev,
+        unknown
+      - priority: one of high, medium, low, skip - the curation signal the
+        Penetration Tester uses to allocate probe budget
+      - notes: >= 30 chars (>= 60 for high-priority), explaining what the
+        host is, what tech runs on it, and why it matters (or does not)
+      - detected_tech: ideally with versions ("Spring Boot 2.6.3" beats
+        "Spring Boot"); the warning fires when the sweep saw tech that the
+        annotation drops
+
+    Returns ``{"path": "host_insights/HOST.json", "validation": {ok, issues}}``.
+    Re-run with the issues addressed when validation.ok is false.
+    """
+    sweep = load_sweep_impl(sweep_path)
+    programme = _load_programme(programme_handle)
+
+    insight = HostInsight(
+        hostname=hostname.strip().lower(),
+        role=HostRole(role),
+        priority=HostPriority(priority),
+        notes=notes.strip(),
+        detected_tech=[t.strip() for t in (detected_tech or []) if t.strip()],
+    )
+    path = save_insight(insight)
+    report = validate_insight(insight, sweep, programme)
+    return {
+        "path": str(path.relative_to(path.parents[1])),
+        "validation": report.model_dump(),
+    }
+
+
+@tool("Uncovered Hosts")
+def uncovered_hosts_tool(sweep_path: str = "sweep.json") -> list[str]:
+    """
+    Return interesting-status hostnames in the sweep (200, 301, 302, 401,
+    403, ...) that have no insight yet. Use as a checklist before calling
+    Finalise Recon - hosts you choose to leave uncovered should at least be
+    a deliberate decision.
+    """
+    sweep = load_sweep_impl(sweep_path)
+    insights = load_insights_impl()
+    return uncovered_interesting_hosts(sweep, insights)
+
+
+@tool("Finalise Recon")
+def finalise_recon_tool(
+    programme_handle: str,
+    sweep_path: str = "sweep.json",
+) -> str:
+    """
+    Consolidate the sweep + every authored HostInsight into recon.json for
+    the Vulnerability Researcher and Penetration Tester. Refuses if no
+    insights have been authored, if any insight has unresolved validation
+    errors, or if the surface is non-empty but no host has been marked
+    HIGH priority. Returns the bare filename ``recon.json`` on success.
+    """
+    programme = _load_programme(programme_handle)
+    try:
+        path = finalise_recon(programme, sweep_filename=sweep_path)
+    except ReconFinalisationError as exc:
+        raise ValueError(str(exc)) from exc
+    return path.name
+
+
+# Helpers
+
+
+def _load_programme(programme_handle: str | None) -> Programme:
+    """Fetch and parse the Programme - the scope guard in validate_insight
+    needs a real Programme to check against."""
+    if not programme_handle:
+        raise ValueError("programme_handle is required")
+    http.set_programme(programme_handle)
+    policy = h1.get_programme_policy(programme_handle)
+    scope = h1.get_structured_scope(programme_handle)
+    return h1.parse_programme(policy["data"], scope)
 
 
 MEMBER = SquadMember(
     slug="osint_analyst",
     dir=Path(__file__).parent,
     tools=[
-        recon_tool,
+        # Sweep
+        run_initial_sweep_tool,
+        # Inspect the sweep
+        recon_subdomains_tool,
+        recon_endpoints_tool,
+        recon_open_ports_tool,
+        # Supplementary discovery
         cert_transparency_tool,
         historical_urls_tool,
+        probe_hostnames_tool,
         llm_detection_tool,
+        # Citation hints
+        lookup_cwe_tool,
+        lookup_owasp_tool,
+        # Authoring + finalisation
+        annotate_host_tool,
+        uncovered_hosts_tool,
+        finalise_recon_tool,
+        # Workspace
         read_run_filelist_tool,
         read_run_file_tool,
     ],

--- a/squad/osint_analyst/__init__.py
+++ b/squad/osint_analyst/__init__.py
@@ -12,7 +12,13 @@ from models import Endpoint, HostInsight, HostPriority, HostRole, Programme
 from squad import SquadMember, read_run_file_tool, read_run_filelist_tool
 from tools import cwe_data, http, owasp_data
 from tools.h1_api import h1
-from tools.recon import cert_transparency, detect_llm_endpoints, historical_urls, run_recon
+from tools.recon import (
+    cert_transparency,
+    detect_llm_endpoints,
+    detect_takeover_candidates,
+    historical_urls,
+    run_recon,
+)
 from tools.recon import probe_endpoints as probe_endpoints_impl
 from tools.recon.query import recon_endpoints, recon_open_ports, recon_subdomains
 from tools.recon.scope import filter_in_scope as filter_in_scope_impl
@@ -160,6 +166,35 @@ def probe_hostnames_tool(hostnames: list[str], programme_handle: str) -> list[di
         return []
     eps = probe_endpoints_impl(in_scope)
     return [ep.model_dump(mode="json") for ep in eps]
+
+
+@tool("Detect Takeover Candidates")
+def detect_takeover_candidates_tool(hostnames: list[str], programme_handle: str) -> list[dict]:
+    """
+    Resolve each hostname via dnsx and flag subdomain-takeover candidates.
+
+    A candidate is flagged when the host's CNAME points to a known-vulnerable
+    provider (AWS S3, Heroku, GitHub Pages, Azure, Vercel, Netlify, ...) or
+    when the CNAME chain dangles (CNAME exists but resolves to no A records).
+    Returns ``[{hostname, cname, reason, service}]`` where ``reason`` is one
+    of ``cname_to_vulnerable_provider`` or ``dangling_cname``.
+
+    Each candidate is exactly that - a candidate. Follow up by annotating
+    the host HIGH priority with a note pointing the Penetration Tester at
+    the service-specific confirmation step (probe the host and check for
+    the "no such bucket" / "no such app" / "there isn't a GitHub Pages
+    site here" body fingerprint).
+
+    Hostnames are scope-filtered before any DNS traffic is generated.
+    """
+    if not hostnames:
+        return []
+    programme = _load_programme(programme_handle)
+    in_scope = filter_in_scope_impl([h.strip().lower() for h in hostnames if h.strip()], programme)
+    if not in_scope:
+        return []
+    candidates = detect_takeover_candidates(in_scope)
+    return [c.model_dump(mode="json") for c in candidates]
 
 
 @tool("Lookup CWE")
@@ -311,6 +346,7 @@ MEMBER = SquadMember(
         cert_transparency_tool,
         historical_urls_tool,
         probe_hostnames_tool,
+        detect_takeover_candidates_tool,
         llm_detection_tool,
         # Citation hints
         lookup_cwe_tool,

--- a/squad/osint_analyst/recon/description.md
+++ b/squad/osint_analyst/recon/description.md
@@ -21,6 +21,11 @@ Your workflow:
        linked).
      - Probe Hostnames on net-new hostnames from those discoveries -
        returns live status + tech.
+     - Detect Takeover Candidates on the full sweep's subdomains (CNAMEs
+       pointing at S3 / Heroku / GitHub Pages / Azure / Vercel / Netlify /
+       Fastly, or dangling CNAMEs). Hits warrant a HIGH-priority annotation
+       and a note pointing the Penetration Tester at the service-specific
+       confirmation fingerprint.
      - LLM Endpoint Detection on the sweep's endpoints - any hit is a
        high-priority annotation candidate for prompt-injection testing.
 

--- a/squad/osint_analyst/recon/description.md
+++ b/squad/osint_analyst/recon/description.md
@@ -1,27 +1,64 @@
-Using the programme selected in the previous task, run full OSINT
-reconnaissance against all in-scope assets:
-  - Enumerate subdomains using subfinder
-  - Probe live HTTP/S endpoints with httpx
-  - Perform lightweight port scanning on live hosts
-  - Identify technology stacks
+Map the in-scope attack surface for the programme selected in the previous
+task. The Vulnerability Researcher reads your output to plan an attack; the
+Penetration Tester allocates probe budget against your priorities. A flat
+list of subdomains is not useful - the curation is the deliverable.
 
-Strictly enforce scope - do not interact with any asset not listed
-as in-scope.
+Your workflow:
 
-When recon is complete, use Recon Subdomains, Recon Endpoints (filtered
-by status and tech), and Recon Open Ports to query the data you just
-wrote. Derive the briefing from what those tools return - do not write
-it from memory. The briefing is the headline; recon.json is the
-reference. Cover:
+  1. Call Run Initial Sweep with the programme handle. The sweep runs
+     subfinder, httpx, nmap, ffuf, plus passive TLS and DNS email-security
+     checks and writes the inventory to ``sweep.json``. Returns the bare
+     filename so you can pass it to the query tools.
 
-  - Top detected technologies and the hostnames they appear on
-    (especially WordPress / Spring / Apache / Joomla / Drupal versions
-    if known - any version is a starting point for CVE research)
-  - Subdomains worth a closer look (admin.*, api.*, internal.*, dev.*,
-    staging.*, *.s3.amazonaws.com, *.blob.core.windows.net)
-  - Open ports that hint at running services (6379 Redis, 9200 Elastic-
-    search, 5984 CouchDB, 27017 MongoDB, 3306/5432 DB, 2082/2083 cPanel,
-    10000 Webmin, etc.)
-  - Passive findings already collected (TLS issues, DNS misconfigs) -
-    flag the high-signal ones, do not enumerate them all
-  - Anything else that looks unusual or high-value
+  2. Inspect the sweep using Recon Subdomains, Recon Endpoints (filtered
+     by status, tech, host), and Recon Open Ports. Do not load the whole
+     file - the typed queries return focused slices.
+
+  3. Optionally widen the surface:
+     - Certificate Transparency Lookup on each seed domain (subdomains that
+       hold a valid cert but did not respond to subfinder).
+     - Historical URL Discovery on each seed (paths that may no longer be
+       linked).
+     - Probe Hostnames on net-new hostnames from those discoveries -
+       returns live status + tech.
+     - LLM Endpoint Detection on the sweep's endpoints - any hit is a
+       high-priority annotation candidate for prompt-injection testing.
+
+  4. Annotate the interesting hosts. For each, call Annotate Host with:
+
+     - **role**: ``admin``, ``api``, ``auth``, ``app``, ``cdn``, ``static``,
+       ``mail``, ``infra``, ``dev``, or ``unknown``. Pick the closest fit.
+     - **priority**: ``high`` (PT spends budget here), ``medium`` (worth a
+       probe pass), ``low`` (likely boring), or ``skip`` (do not probe -
+       third-party-managed, decoy, sensitive).
+     - **notes**: >= 30 chars (>= 60 for high-priority). What the host is,
+       what tech runs on it, what makes it interesting - one to three
+       sentences. Specific beats vague: "Spring Boot 2.6.3 API gateway
+       with /actuator visible; CVE-2022-22965 applies" is good. "API
+       host" is not.
+     - **detected_tech**: ideally with versions. The gate warns when you
+       drop tech the sweep detected.
+
+     Use Lookup CWE / Lookup OWASP Guidance to ground a note in known
+     weakness classes for the tech you saw - "WordPress 5.8 -> CWE-79
+     stored XSS via plugin admin paths" is the kind of pointer the
+     downstream VR consumes directly.
+
+  5. Use Uncovered Hosts to list interesting-status hostnames in the sweep
+     that you have not annotated yet. Leaving hosts uncovered is allowed
+     but should be deliberate - go back and annotate anything you missed.
+
+  6. Call Finalise Recon with the programme handle. The tool refuses if
+     any insight has unresolved errors or if no host has been marked HIGH
+     priority on a non-empty surface (the PT needs at least one focus
+     target). On success it consolidates the sweep + every insight into
+     ``recon.json`` and returns the bare filename.
+
+Scope is non-negotiable. Annotated hosts are scope-checked again at the
+gate; out-of-scope hosts must not be annotated. The sweep is already scope-
+filtered, but Certificate Transparency / Historical URL Discovery / Probe
+Hostnames may surface candidates that fall outside the programme's
+structured scope - drop those before annotating.
+
+The briefing you return below is the headline; ``recon.json`` is the
+reference the downstream agents read directly via their own query tools.

--- a/squad/osint_analyst/recon/expected_output.md
+++ b/squad/osint_analyst/recon/expected_output.md
@@ -1,19 +1,28 @@
 A short Markdown briefing (roughly 8-15 lines) for the Vulnerability
-Researcher, followed by the relative filename of the recon artefact
-written to the run directory (e.g. `recon.json`).
+Researcher, followed by the relative filename of the canonical recon
+artefact written to the run directory (i.e. ``recon.json``).
 
-The briefing should call out:
-  - Top detected technologies with the hostnames they appear on
-  - Subdomains worth a closer look (admin/api/internal/staging/dev,
-    cloud-storage hostnames)
-  - Open ports that hint at running services
-  - High-signal passive findings already collected
-  - Anything else unusual or high-value
+The briefing must call out:
 
-The full inventory lives in recon.json - the Vulnerability Researcher
-uses the recon query tools (Recon Subdomains, Recon Endpoints, Recon
-Open Ports) and Read Run File to drill into it on demand. The briefing
-is what tells them where to look first.
+  - The HIGH-priority hosts with one-line rationale each (role + tech +
+    why the budget goes here)
+  - Top detected technologies and the hostnames they appear on -
+    especially WordPress / Spring / Apache / Joomla / Drupal versions,
+    since any version unlocks CVE research downstream
+  - Subdomains worth a closer look that ended up MEDIUM but not HIGH
+    (e.g. staging, dev, internal) and why they did not earn HIGH
+  - Open ports that hint at running services (6379 Redis, 9200
+    Elasticsearch, 5984 CouchDB, 27017 MongoDB, 3306/5432 DB, 2082/2083
+    cPanel, 10000 Webmin, ...) - which annotated host they belong to
+  - High-signal passive findings already collected (TLS issues, DNS
+    misconfigurations) - flag the high-signal ones, do not enumerate
+    them all
+  - Any hosts you deliberately marked SKIP and the reason
+
+The full inventory and every authored insight live in ``recon.json`` -
+downstream agents use Recon Subdomains / Recon Endpoints / Recon Open
+Ports and Read Run File to drill into it on demand. The briefing tells
+them where to look first.
 
 Return the briefing followed on a separate line by the filename string
-(no prefix, no surrounding path - just `recon.json`).
+(no prefix, no surrounding path - just ``recon.json``).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,12 +31,21 @@ from models import (  # noqa: E402
 # Domain fixtures
 #
 # Use these instead of ad-hoc hostnames so test intent is readable at a glance.
-# victim_url  - the scanning target (an app we are testing)
-# callback_url - OOB receiver (a server we control, used for blind injection);
-#                placeholder until #77 lands real interactsh infrastructure.
+# victim_url    - the scanning target (an app we are testing); in-scope per
+#                 the ``programme`` fixture's ``*.example.com`` wildcard rule.
+# bystander_url - an out-of-scope host on a different TLD. Use it whenever a
+#                 test exercises the scope guard - the name makes the intent
+#                 ("bystander, hands off") obvious at the call site.
+# callback_url  - OOB receiver (a server we control, used for blind injection);
+#                 placeholder until #77 lands real interactsh infrastructure.
 @pytest.fixture()
 def victim_url() -> str:
     return "https://victim.example.com"
+
+
+@pytest.fixture()
+def bystander_url() -> str:
+    return "https://bystander.example.org"
 
 
 @pytest.fixture()

--- a/tests/test_dnsx.py
+++ b/tests/test_dnsx.py
@@ -1,0 +1,229 @@
+"""tests/test_dnsx.py - unit tests for tools/recon/dnsx.py."""
+
+from __future__ import annotations
+
+import json
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+import pytest
+
+from tools.recon.dnsx import (
+    _match_fingerprint,
+    detect_takeover_candidates,
+    resolve_records,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# Fingerprint matcher
+
+
+class TestMatchFingerprint:
+    def test_matches_s3(self):
+        assert _match_fingerprint("bucket.s3.amazonaws.com") == "AWS S3"
+
+    def test_matches_heroku(self):
+        assert _match_fingerprint("app.herokuapp.com") == "Heroku"
+
+    def test_matches_github_pages(self):
+        assert _match_fingerprint("user.github.io") == "GitHub Pages"
+
+    def test_matches_azure_blob(self):
+        assert _match_fingerprint("store.blob.core.windows.net") == "Azure Blob Storage"
+
+    def test_matches_case_insensitive(self):
+        assert _match_fingerprint("Bucket.S3.AmazonAWS.com") == "AWS S3"
+
+    def test_strips_trailing_dot(self):
+        assert _match_fingerprint("app.herokuapp.com.") == "Heroku"
+
+    def test_unknown_cname_returns_none(self):
+        assert _match_fingerprint("some.legitimate.host.example.com") is None
+
+    def test_empty_returns_none(self):
+        assert _match_fingerprint("") is None
+
+
+# resolve_records
+
+
+def _completed(stdout: str) -> CompletedProcess:
+    return CompletedProcess([], 0, stdout, "")
+
+
+class TestResolveRecords:
+    def test_empty_input_returns_empty(self):
+        # Should not require the binary or call _run
+        with patch("shutil.which", return_value=None):
+            assert resolve_records([]) == []
+
+    def test_parses_dnsx_json_output(self):
+        out = (
+            json.dumps({"host": "api.example.com", "a": ["1.2.3.4"], "cname": []})
+            + "\n"
+            + json.dumps(
+                {
+                    "host": "legacy.example.com",
+                    "a": [],
+                    "cname": ["legacy.example.com.s3.amazonaws.com"],
+                }
+            )
+            + "\n"
+        )
+        with (
+            patch("shutil.which", return_value="/usr/bin/dnsx"),
+            patch("tools.recon.dnsx._run", return_value=_completed(out)),
+        ):
+            records = resolve_records(["api.example.com", "legacy.example.com"])
+
+        assert {r.hostname for r in records} == {"api.example.com", "legacy.example.com"}
+        legacy = next(r for r in records if r.hostname == "legacy.example.com")
+        assert legacy.cname == ["legacy.example.com.s3.amazonaws.com"]
+        assert legacy.a_records == []
+
+    def test_skips_malformed_lines(self):
+        out = "not-json-at-all\n" + json.dumps({"host": "x.example.com", "a": ["1.1.1.1"]}) + "\n"
+        with (
+            patch("shutil.which", return_value="/usr/bin/dnsx"),
+            patch("tools.recon.dnsx._run", return_value=_completed(out)),
+        ):
+            records = resolve_records(["x.example.com"])
+
+        assert len(records) == 1
+        assert records[0].hostname == "x.example.com"
+
+    def test_skips_blank_lines(self):
+        out = "\n\n" + json.dumps({"host": "y.example.com", "a": ["1.1.1.1"]}) + "\n"
+        with (
+            patch("shutil.which", return_value="/usr/bin/dnsx"),
+            patch("tools.recon.dnsx._run", return_value=_completed(out)),
+        ):
+            assert len(resolve_records(["y.example.com"])) == 1
+
+    def test_drops_entries_with_no_host(self):
+        out = json.dumps({"a": ["1.1.1.1"]}) + "\n"
+        with (
+            patch("shutil.which", return_value="/usr/bin/dnsx"),
+            patch("tools.recon.dnsx._run", return_value=_completed(out)),
+        ):
+            assert resolve_records(["nohost.example.com"]) == []
+
+    def test_whitespace_only_input_returns_empty(self):
+        with patch("shutil.which", return_value="/usr/bin/dnsx") as mwhich:
+            assert resolve_records(["  ", ""]) == []
+            mwhich.assert_called_once()
+
+
+# detect_takeover_candidates
+
+
+class TestDetectTakeoverCandidates:
+    def test_flags_cname_to_vulnerable_provider(self):
+        out = json.dumps(
+            {
+                "host": "legacy.example.com",
+                "a": ["52.0.0.1"],
+                "cname": ["bucket.s3.amazonaws.com"],
+            }
+        )
+        with (
+            patch("shutil.which", return_value="/usr/bin/dnsx"),
+            patch("tools.recon.dnsx._run", return_value=_completed(out)),
+        ):
+            candidates = detect_takeover_candidates(["legacy.example.com"])
+
+        assert len(candidates) == 1
+        c = candidates[0]
+        assert c.hostname == "legacy.example.com"
+        assert c.reason == "cname_to_vulnerable_provider"
+        assert c.service == "AWS S3"
+        assert c.cname == "bucket.s3.amazonaws.com"
+
+    def test_flags_dangling_cname(self):
+        # CNAME exists but no A records
+        out = json.dumps(
+            {
+                "host": "abandoned.example.com",
+                "a": [],
+                "cname": ["abandoned.internal.tld"],
+            }
+        )
+        with (
+            patch("shutil.which", return_value="/usr/bin/dnsx"),
+            patch("tools.recon.dnsx._run", return_value=_completed(out)),
+        ):
+            candidates = detect_takeover_candidates(["abandoned.example.com"])
+
+        assert len(candidates) == 1
+        assert candidates[0].reason == "dangling_cname"
+        assert candidates[0].service is None
+
+    def test_does_not_flag_resolved_unknown_cname(self):
+        # CNAME exists and resolves; not a known-vulnerable provider
+        out = json.dumps(
+            {
+                "host": "alias.example.com",
+                "a": ["10.0.0.1"],
+                "cname": ["primary.example.com"],
+            }
+        )
+        with (
+            patch("shutil.which", return_value="/usr/bin/dnsx"),
+            patch("tools.recon.dnsx._run", return_value=_completed(out)),
+        ):
+            assert detect_takeover_candidates(["alias.example.com"]) == []
+
+    def test_does_not_flag_plain_a_record(self):
+        # No CNAME at all - just a plain A record
+        out = json.dumps({"host": "api.example.com", "a": ["1.2.3.4"], "cname": []})
+        with (
+            patch("shutil.which", return_value="/usr/bin/dnsx"),
+            patch("tools.recon.dnsx._run", return_value=_completed(out)),
+        ):
+            assert detect_takeover_candidates(["api.example.com"]) == []
+
+    def test_provider_match_takes_priority_over_dangling(self):
+        # If a CNAME matches a fingerprint, that's the candidate we surface,
+        # not "dangling" (even if A records are also empty).
+        out = json.dumps(
+            {
+                "host": "legacy.example.com",
+                "a": [],
+                "cname": ["legacy.example.com.s3.amazonaws.com"],
+            }
+        )
+        with (
+            patch("shutil.which", return_value="/usr/bin/dnsx"),
+            patch("tools.recon.dnsx._run", return_value=_completed(out)),
+        ):
+            candidates = detect_takeover_candidates(["legacy.example.com"])
+
+        assert len(candidates) == 1
+        assert candidates[0].reason == "cname_to_vulnerable_provider"
+        assert candidates[0].service == "AWS S3"
+
+    def test_one_candidate_per_host_on_multiple_cname_matches(self):
+        # Defensive: if a single host has multiple CNAMEs and both match
+        # vulnerable providers, the first one is surfaced. (Real-world DNS
+        # rarely returns multiple CNAMEs for a single host, but the loop
+        # handles it.)
+        out = json.dumps(
+            {
+                "host": "double.example.com",
+                "a": [],
+                "cname": ["x.s3.amazonaws.com", "y.herokuapp.com"],
+            }
+        )
+        with (
+            patch("shutil.which", return_value="/usr/bin/dnsx"),
+            patch("tools.recon.dnsx._run", return_value=_completed(out)),
+        ):
+            candidates = detect_takeover_candidates(["double.example.com"])
+
+        assert len(candidates) == 1
+
+    def test_empty_input_returns_empty(self):
+        with patch("shutil.which", return_value=None):
+            assert detect_takeover_candidates([]) == []

--- a/tests/test_recon_insights.py
+++ b/tests/test_recon_insights.py
@@ -11,11 +11,7 @@ from models import (
     HostInsight,
     HostPriority,
     HostRole,
-    Programme,
     ReconResult,
-    ScopeItem,
-    ScopeType,
-    Severity,
 )
 from tools.recon_insights import (
     ReconFinalisationError,
@@ -31,27 +27,15 @@ pytestmark = pytest.mark.unit
 
 
 # Fixtures
+#
+# The `programme` (with its `*.example.com` wildcard) and the `bystander_url`
+# fixture (out-of-scope by construction) come from tests/conftest.py.
 
 
 @pytest.fixture
-def sweep_programme() -> Programme:
-    return Programme(
-        handle="acme",
-        name="Acme",
-        url="https://hackerone.com/acme",
-        bounty_table={Severity.HIGH: 500},
-        in_scope=[
-            ScopeItem(asset_identifier="*.example.com", asset_type=ScopeType.WILDCARD),
-        ],
-        out_of_scope=[],
-        allows_automated_scanning=True,
-    )
-
-
-@pytest.fixture
-def sweep(sweep_programme) -> ReconResult:
+def sweep(programme) -> ReconResult:
     return ReconResult(
-        programme=sweep_programme,
+        programme=programme,
         subdomains=["api.example.com", "admin.example.com", "cdn.example.com"],
         endpoints=[
             Endpoint(
@@ -97,74 +81,75 @@ def _good_insight(**overrides) -> HostInsight:
 
 
 class TestValidateInsight:
-    def test_clean_insight_passes(self, sweep, sweep_programme):
-        report = validate_insight(_good_insight(), sweep, sweep_programme)
+    def test_clean_insight_passes(self, sweep, programme):
+        report = validate_insight(_good_insight(), sweep, programme)
         assert report.ok is True
         assert all(i.severity != "error" for i in report.issues)
 
-    def test_rejects_empty_hostname(self, sweep, sweep_programme):
-        report = validate_insight(_good_insight(hostname=""), sweep, sweep_programme)
+    def test_rejects_empty_hostname(self, sweep, programme):
+        report = validate_insight(_good_insight(hostname=""), sweep, programme)
         assert report.ok is False
         assert any(i.section == "hostname" for i in report.issues)
 
-    def test_rejects_out_of_scope_hostname(self, sweep, sweep_programme):
-        report = validate_insight(
-            _good_insight(hostname="api.other.invalid"), sweep, sweep_programme
-        )
+    def test_rejects_out_of_scope_hostname(self, sweep, programme, bystander_url):
+        from urllib.parse import urlparse
+
+        oos_host = urlparse(bystander_url).hostname
+        report = validate_insight(_good_insight(hostname=oos_host), sweep, programme)
         assert report.ok is False
         assert any(
             i.section == "hostname" and "not in programme scope" in i.message for i in report.issues
         )
 
-    def test_rejects_thin_notes(self, sweep, sweep_programme):
-        report = validate_insight(_good_insight(notes="too short"), sweep, sweep_programme)
+    def test_rejects_thin_notes(self, sweep, programme):
+        report = validate_insight(_good_insight(notes="too short"), sweep, programme)
         assert report.ok is False
         assert any(i.section == "notes" for i in report.issues)
 
-    def test_rejects_thin_notes_on_high_priority(self, sweep, sweep_programme):
+    def test_rejects_thin_notes_on_high_priority(self, sweep, programme):
         # 35 chars is >= 30 (so not the basic floor) but < 60 (the high-priority floor)
         thirty_five = "Public API gateway hosting v2 routes."
-        report = validate_insight(_good_insight(notes=thirty_five), sweep, sweep_programme)
+        report = validate_insight(_good_insight(notes=thirty_five), sweep, programme)
         assert report.ok is False
         assert any(
             i.section == "notes" and "high-priority hosts" in i.message for i in report.issues
         )
 
-    def test_rejects_thin_notes_on_skip(self, sweep, sweep_programme):
+    def test_rejects_thin_notes_on_skip(self, sweep, programme):
         report = validate_insight(
             _good_insight(priority=HostPriority.SKIP, notes="skip"),
             sweep,
-            sweep_programme,
+            programme,
         )
         assert report.ok is False
         assert any(i.section == "notes" for i in report.issues)
 
-    def test_warns_when_agent_drops_sweep_tech(self, sweep, sweep_programme):
+    def test_warns_when_agent_drops_sweep_tech(self, sweep, programme):
         # sweep saw ['Nginx', 'Spring Boot 2.6']; agent only carries 'Nginx'
         report = validate_insight(
             _good_insight(detected_tech=["Nginx"]),
             sweep,
-            sweep_programme,
+            programme,
         )
         assert report.ok is True
         assert any(i.section == "detected_tech" and i.severity == "warning" for i in report.issues)
 
-    def test_accepts_when_agent_adds_version_to_sweep_tech(self, sweep, sweep_programme):
+    def test_accepts_when_agent_adds_version_to_sweep_tech(self, sweep, programme):
         # sweep saw 'Spring Boot 2.6'; agent carries 'Spring Boot 2.6.3' (more specific)
         report = validate_insight(
             _good_insight(detected_tech=["Nginx", "Spring Boot 2.6.3"]),
             sweep,
-            sweep_programme,
+            programme,
         )
         # The version-stripping check accepts more-specific versions, but the
         # exact comparison may still warn. Either way, no errors.
         assert report.ok is True
 
-    def test_rejects_trivial_tech_entry(self, sweep, sweep_programme):
+    def test_rejects_trivial_tech_entry(self, sweep, programme):
         report = validate_insight(
             _good_insight(detected_tech=["X"]),
             sweep,
-            sweep_programme,
+            programme,
         )
         assert report.ok is False
         assert any(i.section == "detected_tech" for i in report.issues)
@@ -247,25 +232,23 @@ def _write_sweep(tmp_path, sweep: ReconResult) -> None:
 
 
 class TestFinaliseRecon:
-    def test_writes_recon_json_for_clean_insights(
-        self, sweep, sweep_programme, tmp_path, monkeypatch
-    ):
+    def test_writes_recon_json_for_clean_insights(self, sweep, programme, tmp_path, monkeypatch):
         monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
         _write_sweep(tmp_path, sweep)
         save_insight(_good_insight())
-        path = finalise_recon(sweep_programme)
+        path = finalise_recon(programme)
         assert path == tmp_path / "recon.json"
         data = json.loads(path.read_text())
         assert len(data["host_insights"]) == 1
         assert data["host_insights"][0]["hostname"] == "api.example.com"
 
-    def test_refuses_without_insights(self, sweep, sweep_programme, tmp_path, monkeypatch):
+    def test_refuses_without_insights(self, sweep, programme, tmp_path, monkeypatch):
         monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
         _write_sweep(tmp_path, sweep)
         with pytest.raises(ReconFinalisationError, match="no host_insights"):
-            finalise_recon(sweep_programme)
+            finalise_recon(programme)
 
-    def test_refuses_when_no_high_priority(self, sweep, sweep_programme, tmp_path, monkeypatch):
+    def test_refuses_when_no_high_priority(self, sweep, programme, tmp_path, monkeypatch):
         monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
         _write_sweep(tmp_path, sweep)
         save_insight(
@@ -275,26 +258,26 @@ class TestFinaliseRecon:
             )
         )
         with pytest.raises(ReconFinalisationError, match="HIGH priority"):
-            finalise_recon(sweep_programme)
+            finalise_recon(programme)
 
-    def test_refuses_on_validation_errors(self, sweep, sweep_programme, tmp_path, monkeypatch):
+    def test_refuses_on_validation_errors(self, sweep, programme, tmp_path, monkeypatch):
         monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
         _write_sweep(tmp_path, sweep)
         save_insight(_good_insight(notes="too short"))
         with pytest.raises(ReconFinalisationError, match="unresolved errors"):
-            finalise_recon(sweep_programme)
+            finalise_recon(programme)
 
-    def test_refuses_without_sweep(self, sweep_programme, tmp_path, monkeypatch):
+    def test_refuses_without_sweep(self, programme, tmp_path, monkeypatch):
         monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
         save_insight(_good_insight())
         with pytest.raises(FileNotFoundError, match="sweep.json"):
-            finalise_recon(sweep_programme)
+            finalise_recon(programme)
 
-    def test_carries_sweep_fields_through(self, sweep, sweep_programme, tmp_path, monkeypatch):
+    def test_carries_sweep_fields_through(self, sweep, programme, tmp_path, monkeypatch):
         monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
         _write_sweep(tmp_path, sweep)
         save_insight(_good_insight())
-        path = finalise_recon(sweep_programme)
+        path = finalise_recon(programme)
         data = json.loads(path.read_text())
         assert data["subdomains"] == sweep.subdomains
         assert len(data["endpoints"]) == len(sweep.endpoints)

--- a/tests/test_recon_insights.py
+++ b/tests/test_recon_insights.py
@@ -1,0 +1,300 @@
+"""tests/test_recon_insights.py - unit tests for tools/recon_insights.py."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from models import (
+    Endpoint,
+    HostInsight,
+    HostPriority,
+    HostRole,
+    Programme,
+    ReconResult,
+    ScopeItem,
+    ScopeType,
+    Severity,
+)
+from tools.recon_insights import (
+    ReconFinalisationError,
+    finalise_recon,
+    insight_path,
+    load_insights,
+    save_insight,
+    uncovered_interesting_hosts,
+    validate_insight,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# Fixtures
+
+
+@pytest.fixture
+def sweep_programme() -> Programme:
+    return Programme(
+        handle="acme",
+        name="Acme",
+        url="https://hackerone.com/acme",
+        bounty_table={Severity.HIGH: 500},
+        in_scope=[
+            ScopeItem(asset_identifier="*.example.com", asset_type=ScopeType.WILDCARD),
+        ],
+        out_of_scope=[],
+        allows_automated_scanning=True,
+    )
+
+
+@pytest.fixture
+def sweep(sweep_programme) -> ReconResult:
+    return ReconResult(
+        programme=sweep_programme,
+        subdomains=["api.example.com", "admin.example.com", "cdn.example.com"],
+        endpoints=[
+            Endpoint(
+                url="https://api.example.com",
+                status_code=200,
+                technologies=["Nginx", "Spring Boot 2.6"],
+            ),
+            Endpoint(
+                url="https://admin.example.com",
+                status_code=401,
+                technologies=["WordPress 5.8"],
+            ),
+            Endpoint(
+                url="https://cdn.example.com",
+                status_code=200,
+                technologies=["CloudFront"],
+            ),
+            Endpoint(
+                url="https://dead.example.com",
+                status_code=500,
+                technologies=[],
+            ),
+        ],
+    )
+
+
+def _good_insight(**overrides) -> HostInsight:
+    base: dict = {
+        "hostname": "api.example.com",
+        "role": HostRole.API,
+        "priority": HostPriority.HIGH,
+        "notes": (
+            "Public REST API gateway running Spring Boot 2.6 behind Nginx; "
+            "primary target for the programme."
+        ),
+        "detected_tech": ["Nginx", "Spring Boot 2.6"],
+    }
+    base.update(overrides)
+    return HostInsight(**base)
+
+
+# Validation
+
+
+class TestValidateInsight:
+    def test_clean_insight_passes(self, sweep, sweep_programme):
+        report = validate_insight(_good_insight(), sweep, sweep_programme)
+        assert report.ok is True
+        assert all(i.severity != "error" for i in report.issues)
+
+    def test_rejects_empty_hostname(self, sweep, sweep_programme):
+        report = validate_insight(_good_insight(hostname=""), sweep, sweep_programme)
+        assert report.ok is False
+        assert any(i.section == "hostname" for i in report.issues)
+
+    def test_rejects_out_of_scope_hostname(self, sweep, sweep_programme):
+        report = validate_insight(
+            _good_insight(hostname="api.other.invalid"), sweep, sweep_programme
+        )
+        assert report.ok is False
+        assert any(
+            i.section == "hostname" and "not in programme scope" in i.message for i in report.issues
+        )
+
+    def test_rejects_thin_notes(self, sweep, sweep_programme):
+        report = validate_insight(_good_insight(notes="too short"), sweep, sweep_programme)
+        assert report.ok is False
+        assert any(i.section == "notes" for i in report.issues)
+
+    def test_rejects_thin_notes_on_high_priority(self, sweep, sweep_programme):
+        # 35 chars is >= 30 (so not the basic floor) but < 60 (the high-priority floor)
+        thirty_five = "Public API gateway hosting v2 routes."
+        report = validate_insight(_good_insight(notes=thirty_five), sweep, sweep_programme)
+        assert report.ok is False
+        assert any(
+            i.section == "notes" and "high-priority hosts" in i.message for i in report.issues
+        )
+
+    def test_rejects_thin_notes_on_skip(self, sweep, sweep_programme):
+        report = validate_insight(
+            _good_insight(priority=HostPriority.SKIP, notes="skip"),
+            sweep,
+            sweep_programme,
+        )
+        assert report.ok is False
+        assert any(i.section == "notes" for i in report.issues)
+
+    def test_warns_when_agent_drops_sweep_tech(self, sweep, sweep_programme):
+        # sweep saw ['Nginx', 'Spring Boot 2.6']; agent only carries 'Nginx'
+        report = validate_insight(
+            _good_insight(detected_tech=["Nginx"]),
+            sweep,
+            sweep_programme,
+        )
+        assert report.ok is True
+        assert any(i.section == "detected_tech" and i.severity == "warning" for i in report.issues)
+
+    def test_accepts_when_agent_adds_version_to_sweep_tech(self, sweep, sweep_programme):
+        # sweep saw 'Spring Boot 2.6'; agent carries 'Spring Boot 2.6.3' (more specific)
+        report = validate_insight(
+            _good_insight(detected_tech=["Nginx", "Spring Boot 2.6.3"]),
+            sweep,
+            sweep_programme,
+        )
+        # The version-stripping check accepts more-specific versions, but the
+        # exact comparison may still warn. Either way, no errors.
+        assert report.ok is True
+
+    def test_rejects_trivial_tech_entry(self, sweep, sweep_programme):
+        report = validate_insight(
+            _good_insight(detected_tech=["X"]),
+            sweep,
+            sweep_programme,
+        )
+        assert report.ok is False
+        assert any(i.section == "detected_tech" for i in report.issues)
+
+
+# Persistence
+
+
+class TestPersistence:
+    def test_save_insight_writes_per_host_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
+        path = save_insight(_good_insight())
+        assert path == tmp_path / "host_insights" / "api.example.com.json"
+        assert path.exists()
+        loaded = HostInsight.model_validate_json(path.read_text())
+        assert loaded.hostname == "api.example.com"
+
+    def test_save_insight_handles_special_chars_in_hostname(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
+        # Hostnames in practice are RFC 1123, but defensively sanitise unusual chars.
+        ins = _good_insight(hostname="weird host/name.example.com")
+        path = save_insight(ins)
+        assert path.exists()
+
+    def test_load_insights_orders_by_hostname(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
+        save_insight(_good_insight(hostname="zebra.example.com"))
+        save_insight(_good_insight(hostname="aardvark.example.com"))
+        loaded = load_insights()
+        assert [i.hostname for i in loaded] == [
+            "aardvark.example.com",
+            "zebra.example.com",
+        ]
+
+    def test_load_insights_empty_when_no_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
+        assert load_insights() == []
+
+    def test_insight_path_rejects_empty_hostname(self, tmp_path, monkeypatch):
+        # ``insight_path`` builds <run_dir>/host_insights/<sanitised>.json, so
+        # the sanitisation check has to run against a stub run_dir or
+        # runtime.run_dir() raises first.
+        monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
+        with pytest.raises(ValueError, match="empty after sanitisation"):
+            insight_path("///")
+
+
+# Coverage helper
+
+
+class TestUncoveredInterestingHosts:
+    def test_returns_hosts_without_insights(self, sweep):
+        # No insights yet, all interesting hosts uncovered
+        uncovered = uncovered_interesting_hosts(sweep, [])
+        # api / admin / cdn are 200/401/200 (interesting); dead is 500 (skip)
+        assert set(uncovered) == {
+            "api.example.com",
+            "admin.example.com",
+            "cdn.example.com",
+        }
+
+    def test_drops_hosts_with_insights(self, sweep):
+        uncovered = uncovered_interesting_hosts(
+            sweep,
+            [_good_insight(hostname="api.example.com")],
+        )
+        assert "api.example.com" not in uncovered
+        assert "admin.example.com" in uncovered
+
+    def test_excludes_uninteresting_status(self, sweep):
+        uncovered = uncovered_interesting_hosts(sweep, [])
+        assert "dead.example.com" not in uncovered
+
+
+# Finalisation
+
+
+def _write_sweep(tmp_path, sweep: ReconResult) -> None:
+    (tmp_path / "sweep.json").write_text(sweep.model_dump_json(), encoding="utf-8")
+
+
+class TestFinaliseRecon:
+    def test_writes_recon_json_for_clean_insights(
+        self, sweep, sweep_programme, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
+        _write_sweep(tmp_path, sweep)
+        save_insight(_good_insight())
+        path = finalise_recon(sweep_programme)
+        assert path == tmp_path / "recon.json"
+        data = json.loads(path.read_text())
+        assert len(data["host_insights"]) == 1
+        assert data["host_insights"][0]["hostname"] == "api.example.com"
+
+    def test_refuses_without_insights(self, sweep, sweep_programme, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
+        _write_sweep(tmp_path, sweep)
+        with pytest.raises(ReconFinalisationError, match="no host_insights"):
+            finalise_recon(sweep_programme)
+
+    def test_refuses_when_no_high_priority(self, sweep, sweep_programme, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
+        _write_sweep(tmp_path, sweep)
+        save_insight(
+            _good_insight(
+                priority=HostPriority.MEDIUM,
+                notes="Standard public API with no version disclosed yet.",
+            )
+        )
+        with pytest.raises(ReconFinalisationError, match="HIGH priority"):
+            finalise_recon(sweep_programme)
+
+    def test_refuses_on_validation_errors(self, sweep, sweep_programme, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
+        _write_sweep(tmp_path, sweep)
+        save_insight(_good_insight(notes="too short"))
+        with pytest.raises(ReconFinalisationError, match="unresolved errors"):
+            finalise_recon(sweep_programme)
+
+    def test_refuses_without_sweep(self, sweep_programme, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
+        save_insight(_good_insight())
+        with pytest.raises(FileNotFoundError, match="sweep.json"):
+            finalise_recon(sweep_programme)
+
+    def test_carries_sweep_fields_through(self, sweep, sweep_programme, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
+        _write_sweep(tmp_path, sweep)
+        save_insight(_good_insight())
+        path = finalise_recon(sweep_programme)
+        data = json.loads(path.read_text())
+        assert data["subdomains"] == sweep.subdomains
+        assert len(data["endpoints"]) == len(sweep.endpoints)

--- a/tests/test_squad_tools.py
+++ b/tests/test_squad_tools.py
@@ -70,8 +70,8 @@ class TestProgrammeManagerTools:
 
 
 class TestOsintAnalystTools:
-    def test_recon_tool(self, programme, recon_result, tmp_path) -> None:
-        from squad.osint_analyst import recon_tool
+    def test_run_initial_sweep_tool(self, programme, recon_result, tmp_path) -> None:
+        from squad.osint_analyst import run_initial_sweep_tool
 
         with (
             patch("squad.osint_analyst.http.set_programme") as mhttp,
@@ -84,12 +84,216 @@ class TestOsintAnalystTools:
             patch("squad.osint_analyst.run_recon", return_value=recon_result) as mrun,
             patch("runtime.run_dir", return_value=tmp_path),
         ):
-            result = recon_tool.func("acme")
+            result = run_initial_sweep_tool.func("acme")
+
+        assert result == "sweep.json"
+        assert (tmp_path / "sweep.json").exists()
+        mhttp.assert_called_once_with("acme")
+        mrun.assert_called_once_with(programme)
+
+    @staticmethod
+    def _patch_programme(programme):
+        return [
+            patch("squad.osint_analyst.http.set_programme"),
+            patch(
+                "squad.osint_analyst.h1.get_programme_policy",
+                return_value={"data": {}},
+            ),
+            patch("squad.osint_analyst.h1.get_structured_scope", return_value={}),
+            patch("squad.osint_analyst.h1.parse_programme", return_value=programme),
+        ]
+
+    def test_annotate_host_tool_writes_insight_and_returns_validation(
+        self, programme, recon_result, tmp_path
+    ) -> None:
+        from squad.osint_analyst import annotate_host_tool
+
+        (tmp_path / "sweep.json").write_text(recon_result.model_dump_json(), encoding="utf-8")
+
+        patches = self._patch_programme(programme) + [
+            patch("tools.recon_insights.runtime.run_dir", return_value=tmp_path),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            result = annotate_host_tool.func(
+                hostname="api.example.com",
+                role="api",
+                priority="high",
+                notes=(
+                    "Public REST gateway running Nginx in front of a React SPA; "
+                    "primary attack surface for the programme."
+                ),
+                detected_tech=["Nginx", "React"],
+                programme_handle="test-programme",
+            )
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        assert isinstance(result, dict)
+        assert result["validation"]["ok"] is True
+        assert (tmp_path / "host_insights" / "api.example.com.json").exists()
+
+    def test_annotate_host_tool_surfaces_validation_issues(
+        self, programme, recon_result, tmp_path
+    ) -> None:
+        from squad.osint_analyst import annotate_host_tool
+
+        (tmp_path / "sweep.json").write_text(recon_result.model_dump_json(), encoding="utf-8")
+
+        patches = self._patch_programme(programme) + [
+            patch("tools.recon_insights.runtime.run_dir", return_value=tmp_path),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            result = annotate_host_tool.func(
+                hostname="api.example.com",
+                role="api",
+                priority="high",
+                notes="too short",  # < 30 chars, also < 60 high-priority floor
+                detected_tech=["Nginx"],
+                programme_handle="test-programme",
+            )
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        assert isinstance(result, dict)
+        assert result["validation"]["ok"] is False
+        sections = {i["section"] for i in result["validation"]["issues"]}
+        assert "notes" in sections
+
+    def test_uncovered_hosts_tool_returns_missing(self, programme, recon_result, tmp_path) -> None:
+        from squad.osint_analyst import uncovered_hosts_tool
+
+        (tmp_path / "sweep.json").write_text(recon_result.model_dump_json(), encoding="utf-8")
+        with patch("tools.recon_insights.runtime.run_dir", return_value=tmp_path):
+            result = uncovered_hosts_tool.func()
+
+        assert isinstance(result, list)
+        # recon_result fixture has https://api.example.com with status 200 -> interesting
+        assert "api.example.com" in result
+
+    def test_finalise_recon_tool_writes_recon_json(self, programme, recon_result, tmp_path) -> None:
+        from squad.osint_analyst import annotate_host_tool, finalise_recon_tool
+
+        (tmp_path / "sweep.json").write_text(recon_result.model_dump_json(), encoding="utf-8")
+
+        patches = self._patch_programme(programme) + [
+            patch("tools.recon_insights.runtime.run_dir", return_value=tmp_path),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            annotate_host_tool.func(
+                hostname="api.example.com",
+                role="api",
+                priority="high",
+                notes=(
+                    "Public REST gateway running Nginx in front of a React SPA; "
+                    "primary attack surface for the programme."
+                ),
+                detected_tech=["Nginx", "React"],
+                programme_handle="test-programme",
+            )
+            result = finalise_recon_tool.func("test-programme")
+        finally:
+            for p in reversed(patches):
+                p.stop()
 
         assert result == "recon.json"
         assert (tmp_path / "recon.json").exists()
-        mhttp.assert_called_once_with("acme")
-        mrun.assert_called_once_with(programme)
+
+    def test_finalise_recon_tool_raises_without_insights(
+        self, programme, recon_result, tmp_path
+    ) -> None:
+        from squad.osint_analyst import finalise_recon_tool
+
+        (tmp_path / "sweep.json").write_text(recon_result.model_dump_json(), encoding="utf-8")
+
+        patches = self._patch_programme(programme) + [
+            patch("tools.recon_insights.runtime.run_dir", return_value=tmp_path),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            with pytest.raises(ValueError, match="no host_insights"):
+                finalise_recon_tool.func("test-programme")
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+    def test_probe_hostnames_tool(self, programme, endpoint) -> None:
+        from squad.osint_analyst import probe_hostnames_tool
+
+        patches = self._patch_programme(programme) + [
+            patch(
+                "squad.osint_analyst.filter_in_scope_impl",
+                return_value=["api.example.com"],
+            ),
+            patch(
+                "squad.osint_analyst.probe_endpoints_impl",
+                return_value=[endpoint],
+            ),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            result = probe_hostnames_tool.func(
+                ["api.example.com"], programme_handle="test-programme"
+            )
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        assert isinstance(result, list)
+        assert result[0]["url"] == endpoint.url
+
+    def test_probe_hostnames_tool_empty_list(self) -> None:
+        from squad.osint_analyst import probe_hostnames_tool
+
+        assert probe_hostnames_tool.func([], programme_handle="test-programme") == []
+
+    def test_probe_hostnames_tool_drops_out_of_scope(self, programme) -> None:
+        from squad.osint_analyst import probe_hostnames_tool
+
+        mprobe = MagicMock()
+        patches = self._patch_programme(programme) + [
+            patch(
+                "squad.osint_analyst.filter_in_scope_impl",
+                return_value=[],
+            ),
+            patch("squad.osint_analyst.probe_endpoints_impl", mprobe),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            result = probe_hostnames_tool.func(
+                ["malicious.invalid"], programme_handle="test-programme"
+            )
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        assert result == []
+        mprobe.assert_not_called()
+
+    def test_lookup_cwe_tool(self) -> None:
+        from squad.osint_analyst import lookup_cwe_tool
+
+        result = lookup_cwe_tool.func("XSS")
+        assert isinstance(result, list)
+        assert result
+        assert result[0]["cwe_id"] == 79
+
+    def test_lookup_owasp_tool(self) -> None:
+        from squad.osint_analyst import lookup_owasp_tool
+
+        result = lookup_owasp_tool.func("sql injection")
+        assert isinstance(result, list)
+        assert any("SQL_Injection_Prevention" in r["url"] for r in result)
 
     def test_cert_transparency_tool(self) -> None:
         from squad.osint_analyst import cert_transparency_tool

--- a/tests/test_squad_tools.py
+++ b/tests/test_squad_tools.py
@@ -256,9 +256,12 @@ class TestOsintAnalystTools:
 
         assert probe_hostnames_tool.func([], programme_handle="test-programme") == []
 
-    def test_probe_hostnames_tool_drops_out_of_scope(self, programme) -> None:
+    def test_probe_hostnames_tool_drops_out_of_scope(self, programme, bystander_url) -> None:
+        from urllib.parse import urlparse
+
         from squad.osint_analyst import probe_hostnames_tool
 
+        oos_host = urlparse(bystander_url).hostname
         mprobe = MagicMock()
         patches = self._patch_programme(programme) + [
             patch(
@@ -270,9 +273,7 @@ class TestOsintAnalystTools:
         for p in patches:
             p.start()
         try:
-            result = probe_hostnames_tool.func(
-                ["malicious.invalid"], programme_handle="test-programme"
-            )
+            result = probe_hostnames_tool.func([oos_host], programme_handle="test-programme")
         finally:
             for p in reversed(patches):
                 p.stop()
@@ -325,9 +326,14 @@ class TestOsintAnalystTools:
 
         assert detect_takeover_candidates_tool.func([], programme_handle="test-programme") == []
 
-    def test_detect_takeover_candidates_tool_drops_out_of_scope(self, programme) -> None:
+    def test_detect_takeover_candidates_tool_drops_out_of_scope(
+        self, programme, bystander_url
+    ) -> None:
+        from urllib.parse import urlparse
+
         from squad.osint_analyst import detect_takeover_candidates_tool
 
+        oos_host = urlparse(bystander_url).hostname
         mdetect = MagicMock()
         patches = self._patch_programme(programme) + [
             patch(
@@ -340,7 +346,7 @@ class TestOsintAnalystTools:
             p.start()
         try:
             result = detect_takeover_candidates_tool.func(
-                ["malicious.invalid"], programme_handle="test-programme"
+                [oos_host], programme_handle="test-programme"
             )
         finally:
             for p in reversed(patches):

--- a/tests/test_squad_tools.py
+++ b/tests/test_squad_tools.py
@@ -280,6 +280,75 @@ class TestOsintAnalystTools:
         assert result == []
         mprobe.assert_not_called()
 
+    def test_detect_takeover_candidates_tool(self, programme) -> None:
+        from squad.osint_analyst import detect_takeover_candidates_tool
+        from tools.recon.dnsx import TakeoverCandidate
+
+        candidate = TakeoverCandidate(
+            hostname="legacy.example.com",
+            cname="bucket.s3.amazonaws.com",
+            reason="cname_to_vulnerable_provider",
+            service="AWS S3",
+        )
+        patches = self._patch_programme(programme) + [
+            patch(
+                "squad.osint_analyst.filter_in_scope_impl",
+                return_value=["legacy.example.com"],
+            ),
+            patch(
+                "squad.osint_analyst.detect_takeover_candidates",
+                return_value=[candidate],
+            ),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            result = detect_takeover_candidates_tool.func(
+                ["legacy.example.com"], programme_handle="test-programme"
+            )
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        assert isinstance(result, list)
+        assert result == [
+            {
+                "hostname": "legacy.example.com",
+                "cname": "bucket.s3.amazonaws.com",
+                "reason": "cname_to_vulnerable_provider",
+                "service": "AWS S3",
+            }
+        ]
+
+    def test_detect_takeover_candidates_tool_empty(self) -> None:
+        from squad.osint_analyst import detect_takeover_candidates_tool
+
+        assert detect_takeover_candidates_tool.func([], programme_handle="test-programme") == []
+
+    def test_detect_takeover_candidates_tool_drops_out_of_scope(self, programme) -> None:
+        from squad.osint_analyst import detect_takeover_candidates_tool
+
+        mdetect = MagicMock()
+        patches = self._patch_programme(programme) + [
+            patch(
+                "squad.osint_analyst.filter_in_scope_impl",
+                return_value=[],
+            ),
+            patch("squad.osint_analyst.detect_takeover_candidates", mdetect),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            result = detect_takeover_candidates_tool.func(
+                ["malicious.invalid"], programme_handle="test-programme"
+            )
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        assert result == []
+        mdetect.assert_not_called()
+
     def test_lookup_cwe_tool(self) -> None:
         from squad.osint_analyst import lookup_cwe_tool
 

--- a/tests/test_triage_tools.py
+++ b/tests/test_triage_tools.py
@@ -16,7 +16,7 @@ import json
 
 import pytest
 
-from models import Programme, RawFinding, ScopeItem, ScopeType, Severity, VerifiedVulnerability
+from models import RawFinding, Severity, VerifiedVulnerability
 from tools.triage_tools import (
     DiscardEntry,
     DiscardReason,
@@ -71,11 +71,11 @@ class TestAboveFloor:
 
 
 class TestInScope:
-    def test_in_scope(self, programme):
-        assert in_scope("https://api.example.com/x", programme) is True
+    def test_in_scope(self, programme, victim_url):
+        assert in_scope(f"{victim_url}/x", programme) is True
 
-    def test_out_of_scope(self, programme):
-        assert in_scope("https://malicious.invalid/x", programme) is False
+    def test_out_of_scope(self, programme, bystander_url):
+        assert in_scope(f"{bystander_url}/x", programme) is False
 
 
 # Fixtures
@@ -136,11 +136,11 @@ def in_scope_raw() -> RawFinding:
 
 
 @pytest.fixture
-def oos_raw() -> RawFinding:
+def oos_raw(bystander_url) -> RawFinding:
     return RawFinding(
         title="Header issue",
         vuln_class="Headers",
-        target="https://other.invalid/x",
+        target=f"{bystander_url}/x",
         evidence="missing X-Frame-Options",
         tool="nuclei",
         severity_hint=Severity.HIGH,
@@ -421,24 +421,8 @@ class TestLoadDiscards:
         assert load_discards() == []
 
 
-# Programme fixture override - the in-scope test target needs to be inside the
-# fixture's `*.example.com` wildcard rule. The base programme fixture is fine
-# but the wildcard does not match `https://api.example.com/x` unless we ensure
-# the wildcard rule is present. (The conftest fixture already includes
-# `*.example.com`, so the default fixture is sufficient.)
-
-
-@pytest.fixture
-def programme() -> Programme:
-    return Programme(
-        handle="acme",
-        name="Acme",
-        url="https://hackerone.com/acme",
-        bounty_table={Severity.HIGH: 500},
-        in_scope=[
-            ScopeItem(asset_identifier="*.example.com", asset_type=ScopeType.WILDCARD),
-            ScopeItem(asset_identifier="https://example.com", asset_type=ScopeType.URL),
-        ],
-        out_of_scope=[],
-        allows_automated_scanning=True,
-    )
+# The `programme` and `victim_url` / `bystander_url` fixtures come from
+# tests/conftest.py - the shared `programme` includes `*.example.com` which
+# covers `victim_url` (https://victim.example.com), and `bystander_url`
+# (https://bystander.example.org) sits cleanly outside it for the scope-guard
+# tests.

--- a/tools/recon/__init__.py
+++ b/tools/recon/__init__.py
@@ -12,6 +12,7 @@ from urllib.parse import urlparse
 from models import Endpoint, Programme, ReconResult, ScopeType
 from tools.recon.cert_transparency import cert_transparency
 from tools.recon.dirfuzz import discover_paths
+from tools.recon.dnsx import TakeoverCandidate, detect_takeover_candidates
 from tools.recon.llm import detect_llm_endpoints
 from tools.recon.nmap import port_scan
 from tools.recon.probe import probe_endpoints
@@ -74,10 +75,12 @@ _ACTIVE_RECON_TYPES: frozenset[ScopeType] = frozenset(
 __all__ = [
     "_ACTIVE_RECON_TYPES",
     "_CODE_HOSTS",
+    "TakeoverCandidate",
     "cert_transparency",
     "check_dns_email_security",
     "check_tls",
     "detect_llm_endpoints",
+    "detect_takeover_candidates",
     "discover_paths",
     "enumerate_subdomains",
     "extract_domain",

--- a/tools/recon/dnsx.py
+++ b/tools/recon/dnsx.py
@@ -1,0 +1,209 @@
+"""
+DNS resolution and subdomain-takeover detection via dnsx.
+
+The OSINT Analyst calls Detect Takeover Candidates to flag subdomains
+whose CNAME points to a known-vulnerable provider or whose CNAME chain
+dangles (CNAME exists but does not resolve to any A record) - both
+classic takeover-vulnerability shapes.
+
+dnsx is the projectdiscovery DNS resolver; install via install-tools.sh.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from pydantic import BaseModel
+
+from tools._helpers import _require_binary, _run
+
+logger = logging.getLogger(__name__)
+
+# Curated subset of the can-i-take-over-xyz catalogue
+# (https://github.com/EdOverflow/can-i-take-over-xyz). Each entry maps a
+# CNAME suffix to the service it identifies. When the OA's sweep finds a
+# subdomain whose CNAME ends in one of these suffixes, the next step is to
+# HTTP-probe the host and check for the service-specific "not found" body
+# string - if it matches, the subdomain can be claimed by registering on
+# the provider.
+#
+# We intentionally keep this list to widely-encountered, high-confidence
+# patterns. Subtle providers that flip vulnerability status frequently
+# (e.g. Fastly only with no custom domain claimed) sit at the boundary;
+# we include them but the agent should treat the result as a candidate,
+# not a confirmation.
+_TAKEOVER_FINGERPRINTS: list[tuple[str, str]] = [
+    # AWS
+    (".s3.amazonaws.com", "AWS S3"),
+    (".s3-website", "AWS S3 (website)"),
+    (".elasticbeanstalk.com", "AWS Elastic Beanstalk"),
+    (".cloudfront.net", "AWS CloudFront"),
+    # Azure
+    (".cloudapp.net", "Azure (Cloud Services classic)"),
+    (".cloudapp.azure.com", "Azure (Cloud Services)"),
+    (".azurewebsites.net", "Azure Web Apps"),
+    (".blob.core.windows.net", "Azure Blob Storage"),
+    (".azureedge.net", "Azure CDN"),
+    (".azure-api.net", "Azure API Management"),
+    (".trafficmanager.net", "Azure Traffic Manager"),
+    # PaaS / hosting
+    (".herokuapp.com", "Heroku"),
+    (".herokudns.com", "Heroku DNS"),
+    (".vercel.app", "Vercel"),
+    (".netlify.app", "Netlify"),
+    (".netlify.com", "Netlify"),
+    (".surge.sh", "Surge.sh"),
+    (".pantheonsite.io", "Pantheon"),
+    (".readthedocs.io", "Read the Docs"),
+    (".fly.dev", "Fly.io"),
+    # Static / pages
+    (".github.io", "GitHub Pages"),
+    (".gitlab.io", "GitLab Pages"),
+    (".bitbucket.io", "Bitbucket Pages"),
+    # SaaS / docs / support
+    (".helpjuice.com", "Helpjuice"),
+    (".helpscoutdocs.com", "Help Scout"),
+    (".intercom.help", "Intercom"),
+    (".statuspage.io", "Statuspage"),
+    (".tumblr.com", "Tumblr"),
+    (".tictail.com", "Tictail"),
+    (".uservoice.com", "UserVoice"),
+    (".zendesk.com", "Zendesk"),
+    # Misc
+    (".gitbook.io", "GitBook"),
+    (".tilda.ws", "Tilda"),
+    (".webflow.io", "Webflow"),
+    (".wordpress.com", "WordPress"),
+    (".strikinglydns.com", "Strikingly"),
+    (".launchrock.com", "LaunchRock"),
+    # Fastly: CNAME pattern matches but exploitability requires the
+    # service-side claim status; treat as candidate.
+    (".fastly.net", "Fastly"),
+]
+
+
+class DNSRecord(BaseModel):
+    """One host's resolved DNS records, as returned by dnsx."""
+
+    hostname: str
+    a_records: list[str] = []
+    cname: list[str] = []
+
+
+class TakeoverCandidate(BaseModel):
+    """A subdomain flagged as a potential takeover target.
+
+    ``reason`` is one of:
+      - ``cname_to_vulnerable_provider``: CNAME points to a service in the
+        ``_TAKEOVER_FINGERPRINTS`` catalogue. Probe the host with HTTP and
+        look for the service-specific "not found" body.
+      - ``dangling_cname``: CNAME exists but the chain does not resolve to
+        any A records. The CNAME target may have been deprovisioned.
+    """
+
+    hostname: str
+    cname: str
+    reason: str
+    service: str | None = None
+
+
+def _match_fingerprint(cname: str) -> str | None:
+    """Return the service name if ``cname`` matches a known takeover pattern."""
+    target = cname.rstrip(".").lower()
+    for suffix, service in _TAKEOVER_FINGERPRINTS:
+        if target.endswith(suffix):
+            return service
+    return None
+
+
+def resolve_records(hostnames: list[str]) -> list[DNSRecord]:
+    """Resolve A and CNAME records for ``hostnames`` via dnsx.
+
+    Returns one ``DNSRecord`` per input host that dnsx emitted output for.
+    Hosts that resolve to nothing at all (NXDOMAIN with no CNAME) are
+    omitted from the result.
+    """
+    if not hostnames:
+        return []
+
+    dnsx = _require_binary("dnsx")
+    input_data = "\n".join(h.strip() for h in hostnames if h.strip())
+    if not input_data:
+        return []
+
+    result = _run(
+        [dnsx, "-a", "-cname", "-json", "-silent"],
+        timeout=180,
+        input=input_data,
+    )
+    records: list[DNSRecord] = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError as exc:
+            logger.debug("Skipping dnsx line: %s (%s)", line[:80], exc)
+            continue
+        hostname = entry.get("host", "").strip().lower()
+        if not hostname:
+            continue
+        records.append(
+            DNSRecord(
+                hostname=hostname,
+                a_records=entry.get("a") or [],
+                cname=entry.get("cname") or [],
+            )
+        )
+    logger.info("dnsx resolved %d/%d hosts", len(records), len(hostnames))
+    return records
+
+
+def detect_takeover_candidates(hostnames: list[str]) -> list[TakeoverCandidate]:
+    """Flag subdomains whose CNAME points to a known-vulnerable provider or
+    whose CNAME chain dangles.
+
+    A "candidate" is exactly that - the OA must follow up with an HTTP
+    probe to confirm the takeover fingerprint (Annotate Host the candidate
+    HIGH priority with a note pointing the PT at the service-specific
+    confirmation step).
+    """
+    candidates: list[TakeoverCandidate] = []
+    for record in resolve_records(hostnames):
+        for cname in record.cname:
+            service = _match_fingerprint(cname)
+            if service is not None:
+                candidates.append(
+                    TakeoverCandidate(
+                        hostname=record.hostname,
+                        cname=cname,
+                        reason="cname_to_vulnerable_provider",
+                        service=service,
+                    )
+                )
+                # One candidate per host even if multiple CNAMEs match -
+                # the first match is enough to flag it for the agent.
+                break
+        else:
+            # No CNAME matched a fingerprint. Check for a dangling CNAME -
+            # a CNAME exists but the chain produced no A records.
+            if record.cname and not record.a_records:
+                candidates.append(
+                    TakeoverCandidate(
+                        hostname=record.hostname,
+                        cname=record.cname[0],
+                        reason="dangling_cname",
+                        service=None,
+                    )
+                )
+    return candidates
+
+
+__all__ = [
+    "DNSRecord",
+    "TakeoverCandidate",
+    "detect_takeover_candidates",
+    "resolve_records",
+]

--- a/tools/recon_insights.py
+++ b/tools/recon_insights.py
@@ -1,0 +1,376 @@
+"""
+tools/recon_insights.py - Host-annotation authoring primitives for the OSINT
+Analyst.
+
+The OA's job is to turn the raw sweep (subfinder + httpx + nmap + dirfuzz +
+TLS / DNS checks) into a curated attack-surface map: every interesting host
+labelled with a role (admin / api / auth / app / cdn / ...), a priority
+(high / medium / low / skip), tech detected with versions where possible, and
+free-text notes that tell the Vulnerability Researcher WHY this host warrants
+attention. The agent does the curation; this module provides the supporting
+primitives:
+
+* ``HostInsight`` (from ``models``) - the agent's working artefact per host.
+* ``validate_insight(insight, sweep, programme)`` - quality gate. Returns the
+  issue list. Hard errors block ``finalise_recon``.
+* ``save_insight`` / ``load_insights`` - persist insights under
+  ``<run_dir>/host_insights/<hostname>.json``.
+* ``finalise_recon(programme, sweep_path)`` - load the sweep, validate every
+  insight, build the canonical ``ReconResult`` for downstream agents, and
+  write ``recon.json``. Refuses on hard errors or insufficient curation.
+
+The OA's initial sweep is written to ``sweep.json``; ``finalise_recon``
+copies the inventory through, attaches insights, and emits the final
+``recon.json`` that the Vulnerability Researcher and Penetration Tester
+consume.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+import runtime
+from models import HostInsight, HostPriority, Programme, ReconResult
+from tools.recon.scope import extract_domain, filter_in_scope
+
+_INSIGHTS_SUBDIR = "host_insights"
+_SWEEP_FILENAME = "sweep.json"
+_RECON_FILENAME = "recon.json"
+
+# Hostnames must be made filesystem-safe before persisting under
+# ``host_insights/<hostname>.json``. The replacement is reversible because we
+# never reverse it - the JSON body carries the original hostname.
+_HOSTNAME_SANITISE = re.compile(r"[^A-Za-z0-9.\-_]")
+
+
+# Validation
+
+
+class InsightValidationIssue(BaseModel):
+    """One issue produced by validate_insight."""
+
+    section: str
+    severity: str  # "error" (blocks finalise) or "warning" (advisory)
+    message: str
+
+
+class InsightValidationReport(BaseModel):
+    """Result of validating one insight."""
+
+    ok: bool
+    issues: list[InsightValidationIssue] = Field(default_factory=list)
+
+
+def validate_insight(
+    insight: HostInsight,
+    sweep: ReconResult,
+    programme: Programme,
+) -> InsightValidationReport:
+    """Apply quality heuristics to a HostInsight. Returns the issue list."""
+    issues: list[InsightValidationIssue] = []
+
+    hostname = insight.hostname.strip().lower()
+    if not hostname:
+        issues.append(
+            InsightValidationIssue(
+                section="hostname",
+                severity="error",
+                message="hostname must not be empty",
+            )
+        )
+        return InsightValidationReport(ok=False, issues=issues)
+
+    # Scope: every annotated host must be in scope. Out-of-scope hosts that
+    # somehow leaked into the sweep are not the OA's to annotate.
+    if not filter_in_scope([hostname], programme):
+        issues.append(
+            InsightValidationIssue(
+                section="hostname",
+                severity="error",
+                message=(f"{hostname!r} is not in programme scope; only annotate in-scope hosts"),
+            )
+        )
+
+    # Notes: the whole point. Too short means the agent skipped the
+    # curation work.
+    if len(insight.notes.strip()) < 30:
+        issues.append(
+            InsightValidationIssue(
+                section="notes",
+                severity="error",
+                message=(
+                    "notes are too short; explain what the host is, what tech "
+                    "stack runs on it, and what makes it interesting (or not) "
+                    "in 1-3 sentences"
+                ),
+            )
+        )
+
+    # High-priority hosts need a substantive reason.
+    if insight.priority == HostPriority.HIGH and len(insight.notes.strip()) < 60:
+        issues.append(
+            InsightValidationIssue(
+                section="notes",
+                severity="error",
+                message=(
+                    "high-priority hosts need >= 60 chars of justification - "
+                    "what tech, what surface, why it earns the budget"
+                ),
+            )
+        )
+
+    # SKIP hosts also need a reason - so a downstream reader does not
+    # silently re-include them.
+    if insight.priority == HostPriority.SKIP and len(insight.notes.strip()) < 30:
+        issues.append(
+            InsightValidationIssue(
+                section="notes",
+                severity="error",
+                message=(
+                    "skip-priority hosts need notes explaining the reason "
+                    "(third-party managed, decoy, sensitive, etc.)"
+                ),
+            )
+        )
+
+    # If the host is in the sweep's inventory we expect the agent's
+    # detected_tech to either be empty (agent could not enrich) or
+    # consistent with what the sweep saw. We only warn on disagreement -
+    # the agent can legitimately add versions httpx missed.
+    sweep_techs_by_host = _sweep_tech_by_host(sweep)
+    if hostname in sweep_techs_by_host:
+        sweep_techs = {t.lower() for t in sweep_techs_by_host[hostname]}
+        agent_techs = {t.lower() for t in insight.detected_tech}
+        # Warn when sweep saw tech the agent did not carry through - might
+        # signal the agent ignored a useful signal.
+        missing = sweep_techs - {_strip_version(t) for t in agent_techs} - agent_techs
+        if missing and len(insight.detected_tech) > 0:
+            issues.append(
+                InsightValidationIssue(
+                    section="detected_tech",
+                    severity="warning",
+                    message=(
+                        f"sweep saw tech the annotation does not carry: "
+                        f"{sorted(missing)} - keep, or note explicitly in 'notes' "
+                        "that it was deprioritised"
+                    ),
+                )
+            )
+
+    # detected_tech entries should be non-trivial strings.
+    for t in insight.detected_tech:
+        if len(t.strip()) < 2:
+            issues.append(
+                InsightValidationIssue(
+                    section="detected_tech",
+                    severity="error",
+                    message=f"tech entry too short to be a real product name: {t!r}",
+                )
+            )
+
+    ok = not any(i.severity == "error" for i in issues)
+    return InsightValidationReport(ok=ok, issues=issues)
+
+
+def _sweep_tech_by_host(sweep: ReconResult) -> dict[str, list[str]]:
+    """Build a hostname -> tech-list map from the sweep's endpoints."""
+    from urllib.parse import urlparse
+
+    by_host: dict[str, list[str]] = {}
+    for ep in sweep.endpoints:
+        host = (urlparse(ep.url).hostname or "").lower()
+        if not host:
+            continue
+        by_host.setdefault(host, []).extend(ep.technologies)
+    return by_host
+
+
+def _strip_version(tech: str) -> str:
+    """Drop trailing version suffixes from a tech string for comparison.
+
+    "WordPress 5.8.1" and "WordPress" should compare equal when checking
+    that the agent carried the sweep's tech through.
+    """
+    return re.sub(r"\s*[0-9][\w.\-]*$", "", tech).strip().lower()
+
+
+# Persistence
+
+
+def _insights_dir() -> Path:
+    return runtime.run_dir() / _INSIGHTS_SUBDIR
+
+
+def insight_path(hostname: str) -> Path:
+    """Return the on-disk path of the insight for ``hostname``.
+
+    Hostnames are used directly as filenames (with a small character
+    sanitisation pass). The body carries the original hostname.
+    """
+    safe = _HOSTNAME_SANITISE.sub("_", hostname.strip().lower())
+    if not safe or safe.strip("_") == "":
+        raise ValueError("hostname is empty after sanitisation")
+    return _insights_dir() / f"{safe}.json"
+
+
+def save_insight(insight: HostInsight) -> Path:
+    """Persist an insight to ``<run_dir>/host_insights/<host>.json``."""
+    path = insight_path(insight.hostname)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(insight.model_dump_json(indent=2), encoding="utf-8")
+    return path
+
+
+def load_insights() -> list[HostInsight]:
+    """Load every insight in the current run, ordered by hostname."""
+    dir_ = _insights_dir()
+    if not dir_.is_dir():
+        return []
+    return sorted(
+        (
+            HostInsight.model_validate_json(p.read_text(encoding="utf-8"))
+            for p in dir_.glob("*.json")
+        ),
+        key=lambda i: i.hostname,
+    )
+
+
+def load_sweep(sweep_filename: str = _SWEEP_FILENAME) -> ReconResult:
+    """Load the OA's internal sweep artefact."""
+    path = runtime.run_dir() / sweep_filename
+    if not path.is_file():
+        raise FileNotFoundError(f"{sweep_filename} not found; run Run Initial Sweep first")
+    return ReconResult.model_validate_json(path.read_text(encoding="utf-8"))
+
+
+# Finalisation
+
+
+class ReconFinalisationError(RuntimeError):
+    """Raised when finalise_recon cannot consolidate the sweep + insights."""
+
+
+# Status codes whose hosts deserve an annotation: 2xx is a live target,
+# 3xx redirects often hide gates, 401/403 confirm an auth-gated surface
+# worth probing. Pure 404/500 we let slide.
+_INTERESTING_STATUSES = {200, 201, 204, 301, 302, 307, 308, 401, 403}
+
+
+def finalise_recon(
+    programme: Programme,
+    sweep_filename: str = _SWEEP_FILENAME,
+    recon_filename: str = _RECON_FILENAME,
+) -> Path:
+    """Validate every host insight, merge them with the sweep, and write the
+    final ``recon.json`` for downstream agents.
+
+    Refuses to finalise if:
+      * no insights have been authored at all (the OA must annotate)
+      * any insight has hard validation errors
+      * no host has been marked HIGH priority on a non-empty surface (the
+        Penetration Tester needs at least one focus target)
+      * an insight references a hostname that is not in scope
+
+    Coverage warnings (non-blocking):
+      * an interesting-status host in the sweep has no insight
+      * a high-priority host is missing detected_tech
+    """
+    sweep = load_sweep(sweep_filename)
+    insights = load_insights()
+
+    if not insights:
+        raise ReconFinalisationError(
+            "no host_insights have been authored; call Annotate Host for the "
+            "interesting hosts in the sweep before finalising"
+        )
+
+    failures: list[tuple[str, list[InsightValidationIssue]]] = []
+    for insight in insights:
+        report = validate_insight(insight, sweep, programme)
+        if not report.ok:
+            failures.append(
+                (
+                    insight.hostname,
+                    [i for i in report.issues if i.severity == "error"],
+                )
+            )
+
+    if failures:
+        lines = ["one or more host insights have unresolved errors:"]
+        for hostname, errs in failures:
+            for err in errs:
+                lines.append(f"  - insight {hostname} / {err.section}: {err.message}")
+        raise ReconFinalisationError("\n".join(lines))
+
+    high_priority = [i for i in insights if i.priority == HostPriority.HIGH]
+    if sweep.subdomains and not high_priority:
+        raise ReconFinalisationError(
+            "no host has been marked HIGH priority; the Penetration Tester "
+            "needs at least one focus target on a non-empty surface"
+        )
+
+    final = ReconResult(
+        programme=sweep.programme,
+        subdomains=sweep.subdomains,
+        endpoints=sweep.endpoints,
+        open_ports=sweep.open_ports,
+        technologies=sweep.technologies,
+        passive_findings=sweep.passive_findings,
+        network_hops=sweep.network_hops,
+        host_insights=insights,
+        notes=_build_notes(sweep, insights),
+    )
+
+    out_path = runtime.run_dir() / recon_filename
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(final.model_dump_json(), encoding="utf-8")
+    return out_path
+
+
+def _build_notes(sweep: ReconResult, insights: list[HostInsight]) -> str:
+    """Compose the recon-level notes string from sweep stats + insight tally."""
+    by_priority: dict[HostPriority, int] = dict.fromkeys(HostPriority, 0)
+    for i in insights:
+        by_priority[i.priority] += 1
+    return (
+        f"sweep: {len(sweep.subdomains)} subdomains, {len(sweep.endpoints)} endpoints; "
+        f"insights: {by_priority[HostPriority.HIGH]} high, "
+        f"{by_priority[HostPriority.MEDIUM]} medium, "
+        f"{by_priority[HostPriority.LOW]} low, "
+        f"{by_priority[HostPriority.SKIP]} skip"
+    )
+
+
+# Coverage check (informational)
+
+
+def uncovered_interesting_hosts(sweep: ReconResult, insights: list[HostInsight]) -> list[str]:
+    """Return interesting-status hostnames in the sweep that have no insight."""
+    from urllib.parse import urlparse
+
+    covered = {i.hostname.lower() for i in insights}
+    interesting: set[str] = set()
+    for ep in sweep.endpoints:
+        if ep.status_code in _INTERESTING_STATUSES:
+            host = (urlparse(ep.url).hostname or "").lower()
+            if host:
+                interesting.add(host)
+    return sorted(interesting - covered)
+
+
+__all__ = [
+    "InsightValidationIssue",
+    "InsightValidationReport",
+    "ReconFinalisationError",
+    "extract_domain",
+    "finalise_recon",
+    "insight_path",
+    "load_insights",
+    "load_sweep",
+    "save_insight",
+    "uncovered_interesting_hosts",
+    "validate_insight",
+]


### PR DESCRIPTION
"In a vacuum" PR for #124, completing the pre-PT trilogy. Branched off `claude/improve-vr-triage-tools` so you can review the OA recon-curation tooling on its own and stack the three (#125 → #124 → #123 → #114) or pick whichever you want to land.

## The problem I tried to solve

Same disease the TA and VR had before this top-down pass. Stepping into the OA's role:

I am asked for "a comprehensive, in-scope attack surface map" - subdomains, endpoints, ports, tech. What I actually have is **one** tool, `Run Recon`, that does subfinder + httpx + nmap + ffuf + TLS + DNS checks in a fixed sequence and dumps everything into `recon.json`. After that, I read it back via the query tools and write a briefing **from memory** of what I saw.

The agent has zero curation role in the *artefact*. The briefing prose is gone the moment it's consumed. Every subdomain in `recon.json` has equal weight. No host carries a role (admin vs API vs CDN vs static). No priority signal (where should the PT spend probe budget?). `ReconResult.notes` is an autogenerated `f"Seeded from [...]. {len} in-scope hosts."` literal. The tech list is a flat dedup'd `list[str]` with no per-host attribution. So the downstream consumers (VR research, PT) get an undifferentiated soup and have to do the curation work themselves *from raw inventory*, every time.

That's exactly the bug shape we just fixed for TA and VR. Apply the same pattern.

## What's in the PR

Split sweep from authoring. The OA now drives a discovery + curation loop, and the artefact persists the curation.

| Tool | Role |
|---|---|
| **Run Initial Sweep** | Renamed from Run Recon. Same subfinder/httpx/nmap/ffuf/TLS/DNS pipeline, but writes to `sweep.json` (OA-internal draft), not `recon.json`. |
| **Recon Subdomains / Recon Endpoints / Recon Open Ports** | Typed-query tools shared with PT, so the OA can inspect its own sweep before annotating. |
| **Certificate Transparency Lookup / Historical URL Discovery / LLM Endpoint Detection** | Kept - they were already there, the agent just had no reason to use them in a single-mega-tool world. |
| **Probe Hostnames** | New. Re-probes new hostnames discovered via CT / wayback. Scope-filters inputs *before* any HTTP traffic - we never probe outside scope, even for fingerprinting. |
| **Annotate Host** | New, the authoring tool. Author one `HostInsight` per interesting host: role (admin/api/auth/app/cdn/static/mail/infra/dev/unknown), priority (high/medium/low/skip), notes, detected_tech (with versions where possible). Returns a validation report. |
| **Uncovered Hosts** | New. Lists interesting-status hostnames in the sweep that have no insight yet - a checklist before `Finalise Recon`. |
| **Lookup CWE / Lookup OWASP Guidance** | Shared with TA / VR. Useful when annotating a host to ground notes in a known weakness class ("WordPress 5.8 -> CWE-79 stored XSS"). |
| **Finalise Recon** | New. Consolidates sweep + every authored `HostInsight` into the canonical `recon.json`. Refuses on hard errors. |

## The validation gate

`Annotate Host` runs `validate_insight` on every call and `Finalise Recon` re-runs it before consolidating. Errors block, warnings advise.

- **hostname** must be in programme scope (the gate has access to the structured scope and rejects out-of-scope annotations).
- **notes** >= 30 chars; >= 60 if priority is HIGH (forces a substantive reason for spending PT budget); >= 30 if priority is SKIP (so a future reader doesn't silently re-include it).
- **detected_tech** entries must be non-trivial strings.
- **Warning** when the sweep saw a tech the agent's annotation drops - signals the agent may have ignored a useful tech signal.

`Finalise Recon` additional rules:
- At least one insight authored at all.
- At least one HIGH priority host on a non-empty surface - the PT needs a focus target.
- No insight has hard errors.

## Model changes

`HostRole` and `HostPriority` StrEnums + `HostInsight` BaseModel added to `models.py`. `ReconResult` gains a backward-compatible `host_insights: list[HostInsight]` field (empty on the OA's draft `sweep.json`, populated on the final `recon.json`). The canonical filename downstream consumers read remains `recon.json` - no PT, VR, or TA change is required.

## Authoring loop

```
Run Initial Sweep(handle) -> "sweep.json"

# inspect what's there
Recon Endpoints("sweep.json", status=200)
Recon Open Ports("sweep.json")

# (optional) widen via supplementary discovery
Certificate Transparency Lookup("example.com")
Probe Hostnames([new_hosts], handle)  # scope-filtered
LLM Endpoint Detection(endpoints_json)

# annotate the interesting hosts
for each host:
    Lookup CWE / OWASP for the host's tech (optional grounding)
    Annotate Host(host, role, priority, notes, detected_tech) -> validation
    # repeat with fixes until validation.ok

Uncovered Hosts("sweep.json")  # checklist before finalisation

Finalise Recon(handle) -> "recon.json"
```

Same shape as #123 and #124. Same critique-and-iterate dynamic.

## CI

- `ruff check`, `ruff format --check`, `mypy --ignore-missing-imports`, `bandit` all clean.
- `pytest -m unit --cov` - **878 passed, 92.11% coverage** (above the 90% floor). `tools/recon_insights.py` lands at 99%.
- New file `tests/test_recon_insights.py` covering validation rules (one per rule), persistence with per-host filenames, the coverage helper, and finalisation including the "missing sweep / missing insights / no HIGH host / validation errors" guards.
- New OA tool-wrapper tests in `test_squad_tools.py` for `Run Initial Sweep`, `Annotate Host` (clean + failing), `Uncovered Hosts`, `Probe Hostnames` (scope-filter check), `Finalise Recon` (clean + missing-insights), `Lookup CWE / OWASP`.
- The existing `test_recon_tool` was renamed to `test_run_initial_sweep_tool` and asserts the new `sweep.json` filename.

## Things I deliberately did not do

- **Did not touch the PT, VR, TA, or DC.** No model breakage. `recon.json` filename and schema are preserved.
- **Did not change the recon binaries pipeline.** `run_recon()` in `tools/recon/__init__.py` is unchanged; only its caller-side write target moves from `recon.json` to `sweep.json`.
- **Did not add a passive-findings authoring loop.** The OA's `passive_findings` (TLS / DNS check output) pass through unchanged - they are orphaned today (no VR reads them on the triage path) and that's a separate ticket. Mentioned as follow-up in the comments below.
- **Did not enforce "every interesting-status host must have an insight".** Too rigid on big surfaces. `Uncovered Hosts` returns the list so the agent can be deliberate, but only the HIGH-priority floor is enforced.

## How to read this

Start with `squad/osint_analyst/recon/description.md` (the new workflow), then `tools/recon_insights.py` (the primitives - `validate_insight` is the heart), then `squad/osint_analyst/__init__.py` (the `@tool` wiring). The model additions in `models.py` (`HostRole`, `HostPriority`, `HostInsight`) are small and worth a glance for the shape.

---

I've followed this PR with a comment about a couple of recon-stack additions to `install-tools.sh` that would meaningfully widen what the OA can do downstream. Nothing blocking for this PR.
