### PR TITLE
test: introduce bystander_url, hoist fixtures for the OA/VR/TA test s…

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,12 +31,21 @@ from models import (  # noqa: E402
 # Domain fixtures
 #
 # Use these instead of ad-hoc hostnames so test intent is readable at a glance.
-# victim_url  - the scanning target (an app we are testing)
-# callback_url - OOB receiver (a server we control, used for blind injection);
-#                placeholder until #77 lands real interactsh infrastructure.
+# victim_url    - the scanning target (an app we are testing); in-scope per
+#                 the ``programme`` fixture's ``*.example.com`` wildcard rule.
+# bystander_url - an out-of-scope host on a different TLD. Use it whenever a
+#                 test exercises the scope guard - the name makes the intent
+#                 ("bystander, hands off") obvious at the call site.
+# callback_url  - OOB receiver (a server we control, used for blind injection);
+#                 placeholder until #77 lands real interactsh infrastructure.
 @pytest.fixture()
 def victim_url() -> str:
     return "https://victim.example.com"
+
+
+@pytest.fixture()
+def bystander_url() -> str:
+    return "https://bystander.example.org"
 
 
 @pytest.fixture()

--- a/tests/test_recon_insights.py
+++ b/tests/test_recon_insights.py
@@ -11,11 +11,7 @@ from models import (
     HostInsight,
     HostPriority,
     HostRole,
-    Programme,
     ReconResult,
-    ScopeItem,
-    ScopeType,
-    Severity,
 )
 from tools.recon_insights import (
     ReconFinalisationError,
@@ -31,27 +27,15 @@ pytestmark = pytest.mark.unit
 
 
 # Fixtures
+#
+# The `programme` (with its `*.example.com` wildcard) and the `bystander_url`
+# fixture (out-of-scope by construction) come from tests/conftest.py.
 
 
 @pytest.fixture
-def sweep_programme() -> Programme:
-    return Programme(
-        handle="acme",
-        name="Acme",
-        url="https://hackerone.com/acme",
-        bounty_table={Severity.HIGH: 500},
-        in_scope=[
-            ScopeItem(asset_identifier="*.example.com", asset_type=ScopeType.WILDCARD),
-        ],
-        out_of_scope=[],
-        allows_automated_scanning=True,
-    )
-
-
-@pytest.fixture
-def sweep(sweep_programme) -> ReconResult:
+def sweep(programme) -> ReconResult:
     return ReconResult(
-        programme=sweep_programme,
+        programme=programme,
         subdomains=["api.example.com", "admin.example.com", "cdn.example.com"],
         endpoints=[
             Endpoint(
@@ -97,74 +81,75 @@ def _good_insight(**overrides) -> HostInsight:
 
 
 class TestValidateInsight:
-    def test_clean_insight_passes(self, sweep, sweep_programme):
-        report = validate_insight(_good_insight(), sweep, sweep_programme)
+    def test_clean_insight_passes(self, sweep, programme):
+        report = validate_insight(_good_insight(), sweep, programme)
         assert report.ok is True
         assert all(i.severity != "error" for i in report.issues)
 
-    def test_rejects_empty_hostname(self, sweep, sweep_programme):
-        report = validate_insight(_good_insight(hostname=""), sweep, sweep_programme)
+    def test_rejects_empty_hostname(self, sweep, programme):
+        report = validate_insight(_good_insight(hostname=""), sweep, programme)
         assert report.ok is False
         assert any(i.section == "hostname" for i in report.issues)
 
-    def test_rejects_out_of_scope_hostname(self, sweep, sweep_programme):
-        report = validate_insight(
-            _good_insight(hostname="api.other.invalid"), sweep, sweep_programme
-        )
+    def test_rejects_out_of_scope_hostname(self, sweep, programme, bystander_url):
+        from urllib.parse import urlparse
+
+        oos_host = urlparse(bystander_url).hostname
+        report = validate_insight(_good_insight(hostname=oos_host), sweep, programme)
         assert report.ok is False
         assert any(
             i.section == "hostname" and "not in programme scope" in i.message for i in report.issues
         )
 
-    def test_rejects_thin_notes(self, sweep, sweep_programme):
-        report = validate_insight(_good_insight(notes="too short"), sweep, sweep_programme)
+    def test_rejects_thin_notes(self, sweep, programme):
+        report = validate_insight(_good_insight(notes="too short"), sweep, programme)
         assert report.ok is False
         assert any(i.section == "notes" for i in report.issues)
 
-    def test_rejects_thin_notes_on_high_priority(self, sweep, sweep_programme):
+    def test_rejects_thin_notes_on_high_priority(self, sweep, programme):
         # 35 chars is >= 30 (so not the basic floor) but < 60 (the high-priority floor)
         thirty_five = "Public API gateway hosting v2 routes."
-        report = validate_insight(_good_insight(notes=thirty_five), sweep, sweep_programme)
+        report = validate_insight(_good_insight(notes=thirty_five), sweep, programme)
         assert report.ok is False
         assert any(
             i.section == "notes" and "high-priority hosts" in i.message for i in report.issues
         )
 
-    def test_rejects_thin_notes_on_skip(self, sweep, sweep_programme):
+    def test_rejects_thin_notes_on_skip(self, sweep, programme):
         report = validate_insight(
             _good_insight(priority=HostPriority.SKIP, notes="skip"),
             sweep,
-            sweep_programme,
+            programme,
         )
         assert report.ok is False
         assert any(i.section == "notes" for i in report.issues)
 
-    def test_warns_when_agent_drops_sweep_tech(self, sweep, sweep_programme):
+    def test_warns_when_agent_drops_sweep_tech(self, sweep, programme):
         # sweep saw ['Nginx', 'Spring Boot 2.6']; agent only carries 'Nginx'
         report = validate_insight(
             _good_insight(detected_tech=["Nginx"]),
             sweep,
-            sweep_programme,
+            programme,
         )
         assert report.ok is True
         assert any(i.section == "detected_tech" and i.severity == "warning" for i in report.issues)
 
-    def test_accepts_when_agent_adds_version_to_sweep_tech(self, sweep, sweep_programme):
+    def test_accepts_when_agent_adds_version_to_sweep_tech(self, sweep, programme):
         # sweep saw 'Spring Boot 2.6'; agent carries 'Spring Boot 2.6.3' (more specific)
         report = validate_insight(
             _good_insight(detected_tech=["Nginx", "Spring Boot 2.6.3"]),
             sweep,
-            sweep_programme,
+            programme,
         )
         # The version-stripping check accepts more-specific versions, but the
         # exact comparison may still warn. Either way, no errors.
         assert report.ok is True
 
-    def test_rejects_trivial_tech_entry(self, sweep, sweep_programme):
+    def test_rejects_trivial_tech_entry(self, sweep, programme):
         report = validate_insight(
             _good_insight(detected_tech=["X"]),
             sweep,
-            sweep_programme,
+            programme,
         )
         assert report.ok is False
         assert any(i.section == "detected_tech" for i in report.issues)
@@ -247,25 +232,23 @@ def _write_sweep(tmp_path, sweep: ReconResult) -> None:
 
 
 class TestFinaliseRecon:
-    def test_writes_recon_json_for_clean_insights(
-        self, sweep, sweep_programme, tmp_path, monkeypatch
-    ):
+    def test_writes_recon_json_for_clean_insights(self, sweep, programme, tmp_path, monkeypatch):
         monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
         _write_sweep(tmp_path, sweep)
         save_insight(_good_insight())
-        path = finalise_recon(sweep_programme)
+        path = finalise_recon(programme)
         assert path == tmp_path / "recon.json"
         data = json.loads(path.read_text())
         assert len(data["host_insights"]) == 1
         assert data["host_insights"][0]["hostname"] == "api.example.com"
 
-    def test_refuses_without_insights(self, sweep, sweep_programme, tmp_path, monkeypatch):
+    def test_refuses_without_insights(self, sweep, programme, tmp_path, monkeypatch):
         monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
         _write_sweep(tmp_path, sweep)
         with pytest.raises(ReconFinalisationError, match="no host_insights"):
-            finalise_recon(sweep_programme)
+            finalise_recon(programme)
 
-    def test_refuses_when_no_high_priority(self, sweep, sweep_programme, tmp_path, monkeypatch):
+    def test_refuses_when_no_high_priority(self, sweep, programme, tmp_path, monkeypatch):
         monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
         _write_sweep(tmp_path, sweep)
         save_insight(
@@ -275,26 +258,26 @@ class TestFinaliseRecon:
             )
         )
         with pytest.raises(ReconFinalisationError, match="HIGH priority"):
-            finalise_recon(sweep_programme)
+            finalise_recon(programme)
 
-    def test_refuses_on_validation_errors(self, sweep, sweep_programme, tmp_path, monkeypatch):
+    def test_refuses_on_validation_errors(self, sweep, programme, tmp_path, monkeypatch):
         monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
         _write_sweep(tmp_path, sweep)
         save_insight(_good_insight(notes="too short"))
         with pytest.raises(ReconFinalisationError, match="unresolved errors"):
-            finalise_recon(sweep_programme)
+            finalise_recon(programme)
 
-    def test_refuses_without_sweep(self, sweep_programme, tmp_path, monkeypatch):
+    def test_refuses_without_sweep(self, programme, tmp_path, monkeypatch):
         monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
         save_insight(_good_insight())
         with pytest.raises(FileNotFoundError, match="sweep.json"):
-            finalise_recon(sweep_programme)
+            finalise_recon(programme)
 
-    def test_carries_sweep_fields_through(self, sweep, sweep_programme, tmp_path, monkeypatch):
+    def test_carries_sweep_fields_through(self, sweep, programme, tmp_path, monkeypatch):
         monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
         _write_sweep(tmp_path, sweep)
         save_insight(_good_insight())
-        path = finalise_recon(sweep_programme)
+        path = finalise_recon(programme)
         data = json.loads(path.read_text())
         assert data["subdomains"] == sweep.subdomains
         assert len(data["endpoints"]) == len(sweep.endpoints)

--- a/tests/test_squad_tools.py
+++ b/tests/test_squad_tools.py
@@ -256,9 +256,12 @@ class TestOsintAnalystTools:
 
         assert probe_hostnames_tool.func([], programme_handle="test-programme") == []
 
-    def test_probe_hostnames_tool_drops_out_of_scope(self, programme) -> None:
+    def test_probe_hostnames_tool_drops_out_of_scope(self, programme, bystander_url) -> None:
+        from urllib.parse import urlparse
+
         from squad.osint_analyst import probe_hostnames_tool
 
+        oos_host = urlparse(bystander_url).hostname
         mprobe = MagicMock()
         patches = self._patch_programme(programme) + [
             patch(
@@ -270,9 +273,7 @@ class TestOsintAnalystTools:
         for p in patches:
             p.start()
         try:
-            result = probe_hostnames_tool.func(
-                ["malicious.invalid"], programme_handle="test-programme"
-            )
+            result = probe_hostnames_tool.func([oos_host], programme_handle="test-programme")
         finally:
             for p in reversed(patches):
                 p.stop()
@@ -325,9 +326,14 @@ class TestOsintAnalystTools:
 
         assert detect_takeover_candidates_tool.func([], programme_handle="test-programme") == []
 
-    def test_detect_takeover_candidates_tool_drops_out_of_scope(self, programme) -> None:
+    def test_detect_takeover_candidates_tool_drops_out_of_scope(
+        self, programme, bystander_url
+    ) -> None:
+        from urllib.parse import urlparse
+
         from squad.osint_analyst import detect_takeover_candidates_tool
 
+        oos_host = urlparse(bystander_url).hostname
         mdetect = MagicMock()
         patches = self._patch_programme(programme) + [
             patch(
@@ -340,7 +346,7 @@ class TestOsintAnalystTools:
             p.start()
         try:
             result = detect_takeover_candidates_tool.func(
-                ["malicious.invalid"], programme_handle="test-programme"
+                [oos_host], programme_handle="test-programme"
             )
         finally:
             for p in reversed(patches):

--- a/tests/test_triage_tools.py
+++ b/tests/test_triage_tools.py
@@ -16,7 +16,7 @@ import json
 
 import pytest
 
-from models import Programme, RawFinding, ScopeItem, ScopeType, Severity, VerifiedVulnerability
+from models import RawFinding, Severity, VerifiedVulnerability
 from tools.triage_tools import (
     DiscardEntry,
     DiscardReason,
@@ -71,11 +71,11 @@ class TestAboveFloor:
 
 
 class TestInScope:
-    def test_in_scope(self, programme):
-        assert in_scope("https://api.example.com/x", programme) is True
+    def test_in_scope(self, programme, victim_url):
+        assert in_scope(f"{victim_url}/x", programme) is True
 
-    def test_out_of_scope(self, programme):
-        assert in_scope("https://malicious.invalid/x", programme) is False
+    def test_out_of_scope(self, programme, bystander_url):
+        assert in_scope(f"{bystander_url}/x", programme) is False
 
 
 # Fixtures
@@ -136,11 +136,11 @@ def in_scope_raw() -> RawFinding:
 
 
 @pytest.fixture
-def oos_raw() -> RawFinding:
+def oos_raw(bystander_url) -> RawFinding:
     return RawFinding(
         title="Header issue",
         vuln_class="Headers",
-        target="https://other.invalid/x",
+        target=f"{bystander_url}/x",
         evidence="missing X-Frame-Options",
         tool="nuclei",
         severity_hint=Severity.HIGH,
@@ -421,24 +421,8 @@ class TestLoadDiscards:
         assert load_discards() == []
 
 
-# Programme fixture override - the in-scope test target needs to be inside the
-# fixture's `*.example.com` wildcard rule. The base programme fixture is fine
-# but the wildcard does not match `https://api.example.com/x` unless we ensure
-# the wildcard rule is present. (The conftest fixture already includes
-# `*.example.com`, so the default fixture is sufficient.)
-
-
-@pytest.fixture
-def programme() -> Programme:
-    return Programme(
-        handle="acme",
-        name="Acme",
-        url="https://hackerone.com/acme",
-        bounty_table={Severity.HIGH: 500},
-        in_scope=[
-            ScopeItem(asset_identifier="*.example.com", asset_type=ScopeType.WILDCARD),
-            ScopeItem(asset_identifier="https://example.com", asset_type=ScopeType.URL),
-        ],
-        out_of_scope=[],
-        allows_automated_scanning=True,
-    )
+# The `programme` and `victim_url` / `bystander_url` fixtures come from
+# tests/conftest.py - the shared `programme` includes `*.example.com` which
+# covers `victim_url` (https://victim.example.com), and `bystander_url`
+# (https://bystander.example.org) sits cleanly outside it for the scope-guard
+# tests.


### PR DESCRIPTION
Pulls the three new test suites (#123 TA, #124 VR, #125 OA) onto the shared conftest fixtures so the scope-guard and "in-scope target" intents are readable at the call site.

- Add ``bystander_url`` (``https://bystander.example.org``) to ``tests/conftest.py``. Sits outside the shared ``programme`` fixture's ``*.example.com`` wildcard, so it is the canonical out-of-scope target for any scope-guard assertion.
- ``tests/test_triage_tools.py``: drop the local ``programme`` override (a near-duplicate of the conftest one, its own comment said "the default fixture is sufficient"); route ``oos_raw`` and the ``TestInScope`` cases through ``victim_url`` / ``bystander_url``.
- ``tests/test_recon_insights.py``: collapse ``sweep_programme`` onto the shared ``programme`` fixture; route the out-of-scope hostname case through ``bystander_url``.
- ``tests/test_squad_tools.py``: route the OA ``probe_hostnames`` and ``detect_takeover_candidates`` out-of-scope cases through ``bystander_url`` instead of ad-hoc ``malicious.invalid`` strings.

No production code touched. Stacks cleanly on top of #125.