### PR TITLE
chore(lint): add pylint with split-the-file rule family

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,12 +13,13 @@ python -m venv .venv
 .venv/bin/pip install -e ".[dev]"
 ```
 
-Then run the full CI stack locally, in this order. All five must pass before pushing - never "push and let CI tell me":
+Then run the full CI stack locally, in this order. All six must pass before pushing - never "push and let CI tell me":
 
 ```bash
 .venv/bin/ruff check .
 .venv/bin/ruff format --check .
 .venv/bin/mypy . --ignore-missing-imports
+.venv/bin/pylint squad tools config.py crew.py main.py models.py runtime.py tasks.py
 H1_API_USERNAME=ci-user H1_API_TOKEN=ci-token CYBERSQUAD_CONTACT_EMAIL=ci@example.invalid .venv/bin/pytest -m unit --cov --cov-report=term-missing
 .venv/bin/bandit -c pyproject.toml -r . -q
 ```
@@ -85,6 +86,16 @@ os.getenv("FOO", "/tmp/bar")  # nosec B108  # noqa: S108 - intentional dev defau
 # not acceptable
 result = something_dangerous()  # nosec
 ```
+
+### Pylint fails -> split the file you just touched
+
+Pylint is configured (in `pyproject.toml` under `[tool.pylint]`) with a narrow rule set whose purpose is one signal: *this code unit is getting monolithic, split it.* The enabled checks - `C0302` (too-many-lines), `R0915` (too-many-statements), `R0914` (too-many-locals), `R0912` (too-many-branches), `R0911` (too-many-return-statements), `R1702` (too-many-nested-blocks), `R0913`/`R0917` (too-many-arguments), `R0902` (too-many-instance-attributes), `R0904` (too-many-public-methods) - all fire when a file, function, or class has outgrown its single responsibility.
+
+If pylint fails on a file you edited, the default response is **split the file**, not suppress the rule. Pull the cohesive piece you can name into its own module; move the function family with a shared theme into its own file; extract the helper that the long function keeps reaching for. The 500-line module ceiling and pylint's default function/class thresholds are intentionally low - they fire early so the refactor is small.
+
+Suppression (`# pylint: disable=...`) is reserved for the rare case where the unit genuinely is one thing and the threshold is wrong for it. Same grammar as other linter suppressions: one-line comment explaining why, no bare disables.
+
+Existing files that already fail (`squad/penetration_tester/__init__.py`, `tools/report_tools.py`, `tools/triage_tools.py`, plus various functions across `tools/`) are tech debt visible in the pylint output. They get split when someone next edits them - not pre-emptively in unrelated PRs.
 
 ### FIXME and TODO grammar
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Then run the full CI stack locally, in this order. All six must pass before push
 .venv/bin/ruff check .
 .venv/bin/ruff format --check .
 .venv/bin/mypy . --ignore-missing-imports
-.venv/bin/pylint squad tools config.py crew.py main.py models.py runtime.py tasks.py
+.venv/bin/pylint .
 H1_API_USERNAME=ci-user H1_API_TOKEN=ci-token CYBERSQUAD_CONTACT_EMAIL=ci@example.invalid .venv/bin/pytest -m unit --cov --cov-report=term-missing
 .venv/bin/bandit -c pyproject.toml -r . -q
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,15 +87,9 @@ os.getenv("FOO", "/tmp/bar")  # nosec B108  # noqa: S108 - intentional dev defau
 result = something_dangerous()  # nosec
 ```
 
-### Pylint fails -> split the file you just touched
+### Pylint says split, not suppress
 
-Pylint is configured (in `pyproject.toml` under `[tool.pylint]`) with a narrow rule set whose purpose is one signal: *this code unit is getting monolithic, split it.* The enabled checks - `C0302` (too-many-lines), `R0915` (too-many-statements), `R0914` (too-many-locals), `R0912` (too-many-branches), `R0911` (too-many-return-statements), `R1702` (too-many-nested-blocks), `R0913`/`R0917` (too-many-arguments), `R0902` (too-many-instance-attributes), `R0904` (too-many-public-methods) - all fire when a file, function, or class has outgrown its single responsibility.
-
-If pylint fails on a file you edited, the default response is **split the file**, not suppress the rule. Pull the cohesive piece you can name into its own module; move the function family with a shared theme into its own file; extract the helper that the long function keeps reaching for. The 500-line module ceiling and pylint's default function/class thresholds are intentionally low - they fire early so the refactor is small.
-
-Suppression (`# pylint: disable=...`) is reserved for the rare case where the unit genuinely is one thing and the threshold is wrong for it. Same grammar as other linter suppressions: one-line comment explaining why, no bare disables.
-
-Existing files that already fail (`squad/penetration_tester/__init__.py`, `tools/report_tools.py`, `tools/triage_tools.py`, plus various functions across `tools/`) are tech debt visible in the pylint output. They get split when someone next edits them - not pre-emptively in unrelated PRs.
+Pylint is scoped (see `[tool.pylint]` in `pyproject.toml`) to the design rules that fire when a module, function, or class outgrows its single responsibility. When it fails on code you edited, split the unit - pull a cohesive piece into its own module, extract a helper. Suppression (`# pylint: disable=...`) is reserved for cases where the unit genuinely is one thing; same grammar as other suppressions, one-line comment explaining why.
 
 ### FIXME and TODO grammar
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,9 @@ disallow_untyped_defs = false
 # want pylint's other checks (similar-code, score, etc.) on top.
 
 [tool.pylint.main]
-ignore-paths = ["tests/.*", "\\.venv/.*"]
+recursive = true
+ignore = [".venv"]
+ignore-paths = ["tests/.*"]
 
 [tool.pylint."messages control"]
 disable = ["all"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dev = [
     # Linting & formatting
     "ruff>=0.4",
     "mypy>=1.10",
+    "pylint>=4.0",
     "types-requests>=2.32",
     "types-beautifulsoup4>=4.12",
 
@@ -126,6 +127,32 @@ disallow_any_generics = false
 [[tool.mypy.overrides]]
 module = "tests.*"
 disallow_untyped_defs = false
+
+# -- pylint --------------------------------------------------------------------
+# Scoped to the "this is getting monolithic, split it" rule family. Everything
+# else is off so the signal stays focused. Expand the enable list later if we
+# want pylint's other checks (similar-code, score, etc.) on top.
+
+[tool.pylint.main]
+ignore-paths = ["tests/.*", "\\.venv/.*"]
+
+[tool.pylint."messages control"]
+disable = ["all"]
+enable = [
+    "C0302",  # too-many-lines (module)
+    "R0911",  # too-many-return-statements
+    "R0912",  # too-many-branches
+    "R0913",  # too-many-arguments
+    "R0914",  # too-many-locals
+    "R0915",  # too-many-statements
+    "R0917",  # too-many-positional-arguments
+    "R0902",  # too-many-instance-attributes
+    "R0904",  # too-many-public-methods
+    "R1702",  # too-many-nested-blocks
+]
+
+[tool.pylint.format]
+max-module-lines = 500
 
 # -- bandit --------------------------------------------------------------------
 


### PR DESCRIPTION
Adds pylint as a dev dependency configured to enable only the design rules that signal "this code unit is getting monolithic": C0302, R0911-R0915, R0917, R0902, R0904, R1702. max-module-lines is set to 500. Tests are excluded.

Wired into the Before-you-commit stack and explained in CONTRIBUTING.md. Existing offenders (penetration_tester/__init__.py, report_tools.py, triage_tools.py, plus several functions in tools/) now fail loudly; they get split when next touched, per the rule documented in CONTRIBUTING.md.