### PR TITLE
feat(pt,vr): wire Read Attack Plan typed-loader into PT and triage

### DIFF
--- a/squad/__init__.py
+++ b/squad/__init__.py
@@ -27,7 +27,11 @@ from typing import Any
 
 from crewai import Agent, Task
 
-from squad.workspace_tools import read_run_file_tool, read_run_filelist_tool
+from squad.workspace_tools import (
+    read_attack_plan_tool,
+    read_run_file_tool,
+    read_run_filelist_tool,
+)
 
 
 @dataclass(frozen=True)
@@ -84,6 +88,7 @@ __all__ = [
     "SquadMember",
     "build_agent",
     "build_task",
+    "read_attack_plan_tool",
     "read_run_filelist_tool",
     "read_run_file_tool",
 ]

--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -8,7 +8,12 @@ from typing import Protocol, cast
 from crewai.tools import tool
 
 from models import Endpoint, EndpointPage, ReconResult
-from squad import SquadMember, read_run_file_tool, read_run_filelist_tool
+from squad import (
+    SquadMember,
+    read_attack_plan_tool,
+    read_run_file_tool,
+    read_run_filelist_tool,
+)
 from tools import http
 from tools.cloud import (
     check_admin_panels,
@@ -1117,6 +1122,7 @@ MEMBER = SquadMember(
         recon_endpoints_tool,
         recon_open_ports_tool,
         save_findings_tool,
+        read_attack_plan_tool,
         read_run_filelist_tool,
         read_run_file_tool,
     ],

--- a/squad/penetration_tester/pentest/description.md
+++ b/squad/penetration_tester/pentest/description.md
@@ -4,6 +4,15 @@ plan as the primary guide for what to run. The OSINT briefing
 (further upstream in your context) gives you the wider surface for
 when the plan is exhausted or the recon needs cross-referencing.
 
+Start by calling **Read Attack Plan** to load the typed plan from
+`attack_plan.json`. It returns the deserialised plan so you work
+against the schema the VR wrote (one item per probe-target hypothesis,
+each carrying probe, target, expected_ceiling, rationale, and
+recon_evidence). Prefer this over reading the freeform briefing in
+your task context - the briefing is a summary, the typed plan is the
+source of truth. Work through the items in order; the briefing is for
+context, not for re-deriving what to run.
+
 The full inventory lives in `recon.json` in the run directory; the
 filename arrived in your context. recon.json is typically large -
 read focused slices through the recon query tools rather than

--- a/squad/vulnerability_researcher/__init__.py
+++ b/squad/vulnerability_researcher/__init__.py
@@ -16,7 +16,12 @@ from models.attack import (
     AttackPlanItem,
 )
 from models.h1 import Programme
-from squad import SquadMember, read_run_file_tool, read_run_filelist_tool
+from squad import (
+    SquadMember,
+    read_attack_plan_tool,
+    read_run_file_tool,
+    read_run_filelist_tool,
+)
 from tools import cwe_data, http, owasp_data
 from tools.h1_api import h1
 from tools.pentest import lookup_cve
@@ -114,7 +119,7 @@ def finalise_research_tool(
 ) -> str:
     """
     Persist the research-task attack plan to ``attack_plan.json`` for the
-    Penetration Tester (who reads it from task context) and for triage
+    Penetration Tester (who reads it via Read Attack Plan) and for triage
     re-load. ``items`` is a list of dicts, one per probe-target hypothesis,
     each with:
 
@@ -411,6 +416,7 @@ MEMBER = SquadMember(
         discard_finding_tool,
         finalise_triage_tool,
         # Workspace
+        read_attack_plan_tool,
         read_run_filelist_tool,
         read_run_file_tool,
     ],

--- a/squad/vulnerability_researcher/triage/description.md
+++ b/squad/vulnerability_researcher/triage/description.md
@@ -1,15 +1,15 @@
 Before you read findings, load the architectural surround. Call Read
-Run Filelist to see the run directory, then Read Run File on both
-`recon.json` (the OSINT Analyst's curated surface) and `attack_plan.json`
-(the typed attack plan you authored during the research pass). The PT's
-findings need recon evidence to triage well: to elevate a finding when
-recon shows the host runs a known-fragile stack, cluster duplicates
-that share a backend per recon, spot chains where recon evidence plus
-a PT finding compose into a critical, or suppress noise on hosts recon
-flagged as parked or as CDN landing-pages. The attack plan tells you
-which hypotheses you set the PT chasing, so you can recognise when a
-finding lands on a hypothesis and when one of your hypotheses has no
-finding to back it up.
+Run Filelist to see the run directory, then Read Run File on
+`recon.json` (the OSINT Analyst's curated surface) and **Read Attack
+Plan** to reload the typed attack plan you authored during the research
+pass. The PT's findings need recon evidence to triage well: to elevate
+a finding when recon shows the host runs a known-fragile stack, cluster
+duplicates that share a backend per recon, spot chains where recon
+evidence plus a PT finding compose into a critical, or suppress noise
+on hosts recon flagged as parked or as CDN landing-pages. The attack
+plan tells you which hypotheses you set the PT chasing, so you can
+recognise when a finding lands on a hypothesis and when one of your
+hypotheses has no finding to back it up.
 
 Then read the Penetration Tester's briefing from your task context.
 The raw findings live in `findings.json` in the run directory.

--- a/squad/workspace_tools.py
+++ b/squad/workspace_tools.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from crewai.tools import tool
 
 from tools import workspace
+from tools.research_tools import attack_plan_path, load_attack_plan
 
 
 @tool("List Run Files")
@@ -23,3 +24,20 @@ def read_run_file_tool(relative_path: str) -> dict:
     "recon.json") - the only kind of path this tool accepts. Returns
     {name, size_bytes, content}."""
     return workspace.read_run_file(relative_path)
+
+
+@tool("Read Attack Plan")
+def read_attack_plan_tool() -> dict:
+    """Load the Vulnerability Researcher's typed attack plan from
+    ``attack_plan.json`` in the current run directory.
+
+    Returns a dict with ``programme_handle``, ``drafted_at``, and ``items`` -
+    each item carrying ``probe``, ``target``, ``expected_ceiling``,
+    ``rationale``, and ``recon_evidence``. Use this in preference to Read
+    Run File on the same artefact: this tool deserialises the typed plan,
+    so the agent works against the schema the VR wrote rather than a raw
+    JSON blob.
+
+    Raises if no attack plan exists yet for the current run.
+    """
+    return load_attack_plan(attack_plan_path()).model_dump(mode="json")

--- a/squad/workspace_tools.py
+++ b/squad/workspace_tools.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from crewai.tools import tool
 
+from models.attack import AttackPlan
 from tools import workspace
 from tools.research_tools import attack_plan_path, load_attack_plan
 
@@ -27,17 +28,17 @@ def read_run_file_tool(relative_path: str) -> dict:
 
 
 @tool("Read Attack Plan")
-def read_attack_plan_tool() -> dict:
+def read_attack_plan_tool() -> AttackPlan:
     """Load the Vulnerability Researcher's typed attack plan from
     ``attack_plan.json`` in the current run directory.
 
-    Returns a dict with ``programme_handle``, ``drafted_at``, and ``items`` -
-    each item carrying ``probe``, ``target``, ``expected_ceiling``,
-    ``rationale``, and ``recon_evidence``. Use this in preference to Read
-    Run File on the same artefact: this tool deserialises the typed plan,
-    so the agent works against the schema the VR wrote rather than a raw
-    JSON blob.
+    Returns the typed ``AttackPlan`` with ``programme_handle``, ``drafted_at``,
+    and ``items`` - each item carrying ``probe``, ``target``,
+    ``expected_ceiling``, ``rationale``, and ``recon_evidence``. Use this in
+    preference to Read Run File on the same artefact: this tool deserialises
+    the typed plan, so the agent works against the schema the VR wrote rather
+    than a raw JSON blob.
 
     Raises if no attack plan exists yet for the current run.
     """
-    return load_attack_plan(attack_plan_path()).model_dump(mode="json")
+    return load_attack_plan(attack_plan_path())

--- a/tasks.py
+++ b/tasks.py
@@ -53,7 +53,7 @@ def build_tasks(agents: dict) -> list[Task]:
         "triage",
         VULNERABILITY_RESEARCHER,
         agents["vulnerability_researcher"],
-        context=[pentest, select],
+        context=[pentest, research, select],
         human_input=hi,
     )
 

--- a/tests/test_research_tools.py
+++ b/tests/test_research_tools.py
@@ -18,6 +18,7 @@ from models.attack import AttackPlan, AttackPlanFinalisationError
 from tools.research_tools import (
     attack_plan_path,
     finalise_research,
+    load_attack_plan,
     validate_attack_plan,
 )
 
@@ -129,3 +130,21 @@ class TestAttackPlanPath:
     def test_returns_attack_plan_json_under_run_dir(self, tmp_path, monkeypatch):
         monkeypatch.setattr("tools.research_tools.runtime.run_dir", lambda: tmp_path)
         assert attack_plan_path() == tmp_path / "attack_plan.json"
+
+
+# Loading
+
+
+class TestLoadAttackPlan:
+    def test_round_trips_a_persisted_plan(self, attack_plan, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.research_tools.runtime.run_dir", lambda: tmp_path)
+        path = finalise_research(attack_plan)
+        loaded = load_attack_plan(path)
+        assert isinstance(loaded, AttackPlan)
+        assert loaded.programme_handle == attack_plan.programme_handle
+        assert len(loaded.items) == len(attack_plan.items)
+        assert loaded.items[0].probe == attack_plan.items[0].probe
+
+    def test_raises_when_file_missing(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="attack plan not found"):
+            load_attack_plan(tmp_path / "attack_plan.json")

--- a/tests/test_squad_workspace_tools.py
+++ b/tests/test_squad_workspace_tools.py
@@ -43,16 +43,17 @@ class TestSharedWorkspaceTools:
                 read_run_file_tool.func("../etc/passwd")
 
     def test_read_attack_plan_tool_returns_typed_plan(self, attack_plan, tmp_path) -> None:
+        from models.attack import AttackPlan
         from squad import read_attack_plan_tool
 
         (tmp_path / "attack_plan.json").write_text(attack_plan.model_dump_json(), encoding="utf-8")
         with patch("tools.research_tools.runtime.run_dir", return_value=tmp_path):
             result = read_attack_plan_tool.func()
-        assert isinstance(result, dict)
-        assert result["programme_handle"] == attack_plan.programme_handle
-        assert len(result["items"]) == len(attack_plan.items)
-        assert result["items"][0]["probe"] == attack_plan.items[0].probe
-        assert result["items"][0]["expected_ceiling"] == attack_plan.items[0].expected_ceiling.value
+        assert isinstance(result, AttackPlan)
+        assert result.programme_handle == attack_plan.programme_handle
+        assert len(result.items) == len(attack_plan.items)
+        assert result.items[0].probe == attack_plan.items[0].probe
+        assert result.items[0].expected_ceiling == attack_plan.items[0].expected_ceiling
 
     def test_read_attack_plan_tool_raises_when_missing(self, tmp_path) -> None:
         from squad import read_attack_plan_tool

--- a/tests/test_squad_workspace_tools.py
+++ b/tests/test_squad_workspace_tools.py
@@ -41,3 +41,22 @@ class TestSharedWorkspaceTools:
         with patch("tools.workspace.runtime.run_dir", return_value=tmp_path):
             with pytest.raises(ValueError, match="must not contain '..'"):
                 read_run_file_tool.func("../etc/passwd")
+
+    def test_read_attack_plan_tool_returns_typed_plan(self, attack_plan, tmp_path) -> None:
+        from squad import read_attack_plan_tool
+
+        (tmp_path / "attack_plan.json").write_text(attack_plan.model_dump_json(), encoding="utf-8")
+        with patch("tools.research_tools.runtime.run_dir", return_value=tmp_path):
+            result = read_attack_plan_tool.func()
+        assert isinstance(result, dict)
+        assert result["programme_handle"] == attack_plan.programme_handle
+        assert len(result["items"]) == len(attack_plan.items)
+        assert result["items"][0]["probe"] == attack_plan.items[0].probe
+        assert result["items"][0]["expected_ceiling"] == attack_plan.items[0].expected_ceiling.value
+
+    def test_read_attack_plan_tool_raises_when_missing(self, tmp_path) -> None:
+        from squad import read_attack_plan_tool
+
+        with patch("tools.research_tools.runtime.run_dir", return_value=tmp_path):
+            with pytest.raises(FileNotFoundError, match="attack plan not found"):
+                read_attack_plan_tool.func()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -62,6 +62,21 @@ class TestSquadMemberRead:
             member.read("role")
 
 
+class TestAttackPlanWiring:
+    """The typed attack plan is the contract between VR research, PT, and VR
+    triage. Both consumers must expose Read Attack Plan."""
+
+    def test_penetration_tester_has_read_attack_plan_tool(self) -> None:
+        from squad import read_attack_plan_tool
+
+        assert read_attack_plan_tool in PENETRATION_TESTER.tools
+
+    def test_vulnerability_researcher_has_read_attack_plan_tool(self) -> None:
+        from squad import read_attack_plan_tool
+
+        assert read_attack_plan_tool in VULNERABILITY_RESEARCHER.tools
+
+
 class TestBuildTasks:
     def _agents(self) -> dict:
         roles = [
@@ -93,7 +108,7 @@ class TestBuildTasks:
         assert recon.context == [select]
         assert research.context == [recon, select]
         assert pentest.context == [research, recon, select]
-        assert triage.context == [pentest, select]
+        assert triage.context == [pentest, research, select]
         assert write.context == [triage, select]
         assert submit.context == [write]
 

--- a/tools/research_tools.py
+++ b/tools/research_tools.py
@@ -15,6 +15,9 @@ thinking; this module provides the supporting primitives:
 * ``finalise_research(plan)`` - validate, persist ``attack_plan.json`` for
   the Penetration Tester and re-read at triage time. Raises
   ``AttackPlanFinalisationError`` (from ``models.attack``) on hard errors.
+* ``load_attack_plan(path)`` - reverse direction. Deserialise
+  ``attack_plan.json`` into a typed ``AttackPlan`` so downstream agents
+  (PT, VR at triage) consume a Pydantic model rather than a raw blob.
 
 Mirrors the ``finalise_recon`` / ``finalise_triage`` pattern so the VR's
 research artefact is a first-class workspace file alongside ``recon.json``
@@ -134,8 +137,23 @@ def finalise_research(plan: AttackPlan) -> Path:
     return out_path
 
 
+def load_attack_plan(path: Path) -> AttackPlan:
+    """Deserialise ``attack_plan.json`` from ``path`` into a typed AttackPlan.
+
+    The reader half of the ``finalise_research`` contract: PT loads the plan
+    before running probes, and the VR re-loads it at triage time to map
+    findings back to the hypotheses that justified them. Raises
+    ``FileNotFoundError`` if the file is missing - the caller surfaces a
+    workflow error rather than silently reverting to a free-form briefing.
+    """
+    if not path.is_file():
+        raise FileNotFoundError(f"attack plan not found at {path}")
+    return AttackPlan.model_validate_json(path.read_text(encoding="utf-8"))
+
+
 __all__ = [
     "attack_plan_path",
     "finalise_research",
+    "load_attack_plan",
     "validate_attack_plan",
 ]


### PR DESCRIPTION
## Summary

Close the typed-contract loop opened by #137. The VR's research pass writes `attack_plan.json` (typed `AttackPlan`), but until now the only way for the Penetration Tester or the VR at triage to re-read it was `Read Run File` - a raw-bytes loader that hands back a string blob. Both consumers had to free-form parse the JSON, or rely on the freeform briefing in task context, which the VR's expected_output explicitly warns is a summary, not the source of truth.

- `tools/research_tools.py`: `load_attack_plan(path)` reader, symmetric with `finalise_research()`.
- `squad/workspace_tools.py`: new `Read Attack Plan` `@tool`, exposed via `squad/__init__.py` alongside the other shared workspace tools. Returns the deserialised plan (programme_handle, drafted_at, items[]).
- `squad/penetration_tester` + `squad/vulnerability_researcher`: tool added to `MEMBER.tools`. `pentest/description.md` and `triage/description.md` now instruct the typed loader as step 1.
- `tasks.py`: triage context grows from `[pentest, select]` to `[pentest, research, select]` so the CrewAI context graph matches the actual data flow (VR research output -> VR triage input).
- `finalise_research_tool` docstring: "reads it from task context" -> "reads it via Read Attack Plan".

## Out of scope (follow-ups)

- Deterministic ordering of `AttackPlan.items`. Today the order is whatever the VR LLM authored, with only a prompt-level nudge toward CRITICAL-first - worth either a sort-on-`expected_ceiling` in `finalise_research` or an explicit `priority` field.
- VR triage "gap detection" - flag attack-plan items that did not produce a finding so the PT loop can be tuned. The triage prompt now reloads the plan; using it for gap detection is its own follow-up.
- BDD coverage for the PT/VR prompt changes (#121). Held back deliberately - the user wants a clean E2E pipeline fire before backfilling BDD.

## Test plan

- [x] `ruff check .` - clean
- [x] `ruff format --check .` - clean
- [x] `mypy . --ignore-missing-imports` - clean (Success: no issues found in 136 source files)
- [x] `pylint .` - 9.86/10, unchanged from main (no new findings on touched code)
- [x] `pytest -m unit --cov` - 953 passed (was 947), 91.73% combined line+branch coverage, fail_under=90 satisfied
- [x] Branch coverage on `tools/research_tools.py` and `squad/workspace_tools.py` = 100%
- [x] `bandit -c pyproject.toml -r . -q` - clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01V65dr8HSs9p7uBQJ1q8q4a)_