### PR TITLE
docs(skills): cybersquad-tool skill + suppression-as-signal framing

### DIFF
--- a/.claude/hooks/load-skill.sh
+++ b/.claude/hooks/load-skill.sh
@@ -2,13 +2,19 @@
 #
 # Claude Code PreToolUse hook for Write|Edit.
 #
-# Maps the target file path to a cybersquad skill and injects that skill's
-# SKILL.md content into the model context via hookSpecificOutput.additionalContext
-# - effectively auto-loading the relevant skill before each edit.
+# Maps the target file path to a stack of cybersquad skills and injects each
+# matched skill's SKILL.md content into the model context via
+# hookSpecificOutput.additionalContext - effectively auto-loading the relevant
+# skills before each edit.
+#
+# Stacking: a path may match more than one skill (e.g. a pentest probe wrapper
+# matches both the generic cybersquad-tool and the specialist
+# cybersquad-pentest-tool). Generic skills are matched first and specialists
+# layer on top, so the specialist appears later in the context window.
 #
 # Session-scoped sentinel: each skill is injected at most once per session, on
 # the first matching Edit/Write. Subsequent edits in the same session are silent
-# (the skill is already in context).
+# for skills that have already loaded.
 #
 # Wired via .claude/settings.json. Silently noops if jq is missing or the
 # expected stdin shape is absent - never blocks the edit.
@@ -33,47 +39,70 @@ skills_root="$repo_root/.claude/skills"
 state_dir="${TMPDIR:-/tmp}/cybersquad-skills-$session_id"
 mkdir -p "$state_dir"
 
-# Emit the skill content as additionalContext, once per session per skill.
-emit_skill() {
-    local skill_name="$1"
-    local sentinel="$state_dir/$skill_name"
-    [ -f "$sentinel" ] && exit 0  # already loaded this session
+# Build the matched-skill stack. Generic matchers come first; specialists
+# layer on top. Each branch is independent so a path can match more than one.
+matches=()
 
-    local skill_path="$skills_root/$skill_name/SKILL.md"
-    [ -f "$skill_path" ] || exit 0
-
-    touch "$sentinel"
-    local content
-    content=$(cat "$skill_path")
-
-    jq -n --arg skill "$skill_name" --arg content "$content" '
-        {
-            hookSpecificOutput: {
-                hookEventName: "PreToolUse",
-                additionalContext: ("Auto-loading skill \($skill) (matched on file path; this is its first edit this session).\n\n" + $content)
-            }
-        }
-    '
-    exit 0
-}
-
-# Most specific match wins (case statement evaluates top-down).
 case "$file_path" in
-    */tools/pentest/*|*/squad/penetration_tester/__init__.py)
-        emit_skill cybersquad-pentest-tool
-        ;;
-    */tests/features/*|*/tests/bdd/*)
-        emit_skill cybersquad-bdd
-        ;;
-    */tests/*)
-        emit_skill cybersquad-test-fixtures
-        ;;
-    */crew.py)
-        emit_skill cybersquad-agent-llm
-        ;;
     */squad/__init__.py|*/squad/workspace_tools.py|*/squad/*/__init__.py)
-        emit_skill cybersquad-tool
+        matches+=(cybersquad-tool)
         ;;
 esac
+
+case "$file_path" in
+    */tools/pentest/*|*/squad/penetration_tester/__init__.py)
+        matches+=(cybersquad-pentest-tool)
+        ;;
+esac
+
+case "$file_path" in
+    */tests/*)
+        matches+=(cybersquad-test-fixtures)
+        ;;
+esac
+
+case "$file_path" in
+    */tests/features/*|*/tests/bdd/*)
+        matches+=(cybersquad-bdd)
+        ;;
+esac
+
+case "$file_path" in
+    */crew.py)
+        matches+=(cybersquad-agent-llm)
+        ;;
+esac
+
+[ "${#matches[@]}" -eq 0 ] && exit 0
+
+# Emit each matched skill once per session, joined into a single
+# additionalContext blob in stack order (generic first, specialist on top).
+combined=""
+for skill_name in "${matches[@]}"; do
+    sentinel="$state_dir/$skill_name"
+    [ -f "$sentinel" ] && continue
+
+    skill_path="$skills_root/$skill_name/SKILL.md"
+    [ -f "$skill_path" ] || continue
+
+    touch "$sentinel"
+    content=$(cat "$skill_path")
+    header="Auto-loading skill $skill_name (matched on file path; this is its first edit this session)."
+    if [ -n "$combined" ]; then
+        combined="$combined"$'\n\n---\n\n'
+    fi
+    combined="${combined}${header}"$'\n\n'"${content}"
+done
+
+[ -z "$combined" ] && exit 0
+
+jq -n --arg content "$combined" '
+    {
+        hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            additionalContext: $content
+        }
+    }
+'
 
 exit 0

--- a/.claude/hooks/load-skill.sh
+++ b/.claude/hooks/load-skill.sh
@@ -71,6 +71,9 @@ case "$file_path" in
     */crew.py)
         emit_skill cybersquad-agent-llm
         ;;
+    */squad/__init__.py|*/squad/workspace_tools.py|*/squad/*/__init__.py)
+        emit_skill cybersquad-tool
+        ;;
 esac
 
 exit 0

--- a/.claude/hooks/load-skill.sh
+++ b/.claude/hooks/load-skill.sh
@@ -73,6 +73,12 @@ case "$file_path" in
         ;;
 esac
 
+case "$file_path" in
+    */tasks.py)
+        matches+=(cybersquad-task)
+        ;;
+esac
+
 [ "${#matches[@]}" -eq 0 ] && exit 0
 
 # Emit each matched skill once per session, joined into a single

--- a/.claude/skills/cybersquad-agent-llm/SKILL.md
+++ b/.claude/skills/cybersquad-agent-llm/SKILL.md
@@ -39,3 +39,9 @@ If you change the default model in `config.py`, keep the `anthropic/` (or other 
 - Editing anything that imports `crewai.Agent`
 - Changing `config.llm.model`, `config.llm.temperature`, or `config.llm.max_tokens`
 - Writing a test that instantiates an `LLM` or `Agent`
+
+## Upstream alignment
+
+This skill is a narrow footgun overlay - the footgun is that `Agent(llm="bare-model-string")` silently drops `temperature` and `max_tokens`. The fix is mechanical.
+
+For general agent design (role-goal-backstory framework, when to use one vs many agents, `max_iter` / `max_rpm` tuning, `function_calling_llm` split for tool-call cost, code execution, planning configs with `reasoning_effort`, knowledge sources, agent guardrails), see [crewAIInc/skills `design-agent`](https://github.com/crewAIInc/skills/blob/main/skills/design-agent/SKILL.md). That is the canonical upstream best-practice; this skill complements it, does not replace it. If you are doing anything more than wiring the `LLM` instance, read upstream first.

--- a/.claude/skills/cybersquad-pentest-tool/SKILL.md
+++ b/.claude/skills/cybersquad-pentest-tool/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cybersquad-pentest-tool
-description: The attack-classification pattern every multi-variant pentest tool follows in cybersquad. Covers the StrEnum variant enum, the `check_X` function filter parameter, the squad @tool wrapper, and the OWASP Top 10 classification decorator. Load before creating or editing files under tools/pentest/ or squad/penetration_tester/__init__.py.
+description: The attack-classification pattern every multi-variant pentest probe follows in cybersquad. StrEnum variants, `check_X` filter parameter, `@pentest_tool` wrapper with OWASP categorisation. Builds on cybersquad-tool. Load before editing any pentest probe.
 ---
 
 # cybersquad pentest tool conventions
@@ -82,8 +82,8 @@ In `squad/penetration_tester/__init__.py`, use `@pentest_tool` (not bare `@tool`
 def ssrf_probe_tool(
     endpoints_json: str,
     payloads: list[SsrfPayload] | None = None,
-) -> list[dict]:
-    return [f.model_dump() for f in check_ssrf(_parse_endpoints(endpoints_json), payloads)]
+) -> list[RawFinding]:
+    return list(check_ssrf(_parse_endpoints(endpoints_json), payloads))
 ```
 
 4. Document each variant in the docstring so the agent knows when to pick a subset. Include what the variant targets, when it is useful, and the request-cost implication of narrowing.

--- a/.claude/skills/cybersquad-task/SKILL.md
+++ b/.claude/skills/cybersquad-task/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: cybersquad-task
+description: Construct CrewAI tasks via build_task(). Prose lives in description.md / expected_output.md. Inter-agent structured handoff uses workspace files, not output_pydantic. Load before editing tasks.py.
+---
+
+# cybersquad task conventions
+
+## Construction: build_task() - never bare `Task(...)`
+
+`squad/__init__.py` defines `build_task(task_name, member, agent, context=[...], human_input=hi)`. It reads the per-task `description.md` and `expected_output.md` from the agent's directory, wires the agent, and centralises `human_input` gating via `config.human_input`.
+
+Writing `Task(...)` directly puts prose in Python strings and bypasses the toggle. Use the helper.
+
+## Prose lives in markdown, not Python strings
+
+```
+squad/<member>/
+    role.md
+    goal.md
+    backstory.md
+    <task_name>/description.md
+    <task_name>/expected_output.md
+```
+
+Multi-task agents (Vulnerability Researcher has `research/` and `triage/`) get one subdirectory per task. `SquadMember.read()` is the only loader; missing files raise at build time.
+
+This separation is deliberate: prompt iteration is a markdown edit, wiring is a Python edit, and neither blocks the other.
+
+## Inter-agent structured handoff: workspace files, not `output_pydantic`
+
+When data flows between agents (recon -> attack plan -> findings -> verified -> reports), use the workspace-file pair pattern:
+
+- Producer agent calls a typed `@tool` like `Finalise Research(plan: AttackPlan)` that validates and writes `attack_plan.json` to the run directory; returns the bare filename.
+- The *task's* textual output is freeform briefing prose plus that filename.
+- Consumer agent calls a typed `@tool` like `Read Attack Plan -> AttackPlan` to deserialise the artefact.
+
+DO NOT use `output_pydantic=SomeModel` on tasks for inter-agent flow. Three reasons:
+
+1. **Size.** ReconResult is ~115KB / ~30K tokens on real targets. `output_pydantic` puts the full JSON in every downstream `context=`, which torches the LLM window.
+2. **Prose-coercion cost.** `output_pydantic` constrains the agent to JSON-only output. Agents naturally want to produce "Here is my reasoning, then the JSON" and JSON parsing breaks on the prose. Suppressing the prose reliably takes non-trivial prompt engineering.
+3. **Both-and.** Workspace files let the task's textual output be reasoning-narrative (which the next agent uses to orient) AND the typed artefact be the structured contract (which downstream code consumes). `output_pydantic` collapses these into one.
+
+For the tool-side conventions (writer/reader pair, return types, where shared tools live), load `cybersquad-tool`.
+
+## When `output_pydantic` is acceptable
+
+`output_pydantic` earns its keep when:
+
+- The output is consumed by *orchestration code*, not by another agent in the chain (rare in cybersquad).
+- The structure is small enough that the size argument does not apply AND you have a reason to want JSON over prose in the next agent's context.
+
+If unsure, default to workspace files. The pair pattern earns its keep.
+
+## `context=` chain
+
+`context=[prior_task, ...]` lists upstream tasks whose outputs become this task's context. CrewAI's `aggregate_raw_outputs_from_tasks` joins each prior task's `output.raw` with dividers - there is no automatic structured passing.
+
+Use `context=` explicitly even in sequential pipelines. It makes the data-flow graph readable and enables non-linear deps. Example - the Vulnerability Researcher's triage task reads from BOTH `pentest` AND its own earlier `research` task:
+
+```python
+triage = build_task(
+    "triage", VULNERABILITY_RESEARCHER, agents["vulnerability_researcher"],
+    context=[pentest, research, select],
+    human_input=hi,
+)
+```
+
+## `human_input` toggle
+
+Always pass `human_input=hi` where `hi = config.human_input` (set via the `CYBERSQUAD_HUMAN_INPUT` env var). Never hardcode `True` or `False` - the toggle exists so production runs can be unattended while interactive runs gate at each step.
+
+## Upstream alignment
+
+CrewAI's [crewAIInc/skills `design-task`](https://github.com/crewAIInc/skills/blob/main/skills/design-task/SKILL.md) is the canonical upstream best-practice for task design. Its strong recommendation is `output_pydantic` for structured handoff between tasks. Cybersquad deliberately diverges on that one point - see the "workspace files" section above. The rest of upstream `design-task` (single-purpose tasks, specific `expected_output`, function/LLM guardrails, conditional tasks, async, callbacks) we follow without exception.

--- a/.claude/skills/cybersquad-tool/SKILL.md
+++ b/.claude/skills/cybersquad-tool/SKILL.md
@@ -84,6 +84,12 @@ Today `SquadMember.tools` is typed `list[Any]` because the local `_PentestTool` 
 
 ## Canonical examples
 
-- `squad/workspace_tools.py` `read_attack_plan_tool` - the typed-reader pattern (returns `AttackPlan`).
-- `squad/penetration_tester/__init__.py` `recon_endpoints_tool` - returns `EndpointPage`, the existing typed wrapper to mirror when retyping a `list[dict]` probe.
-- `tools/research_tools.py` `finalise_research` + `load_attack_plan` - the writer / reader pair as a unit.
+Cross-agent intent matters: this skill applies to every agent's `@tool` wrappers, not just the pentester's. The codebase is mid-migration (#139) so exemplary typed returns are still sparse - one canonical pydantic-return example today, plus the workspace-handle string family.
+
+- `squad/penetration_tester/__init__.py` `recon_endpoints_tool` returns `EndpointPage` - the only `@tool` in the codebase today that follows the pydantic-return rule end-to-end. The wrapper lives on PT but it reads OSINT's recon output, so the pattern is cross-agent.
+- The workspace-handle string family demonstrates the `str` exception (writer returns the filename, next agent passes it to a typed reader):
+  - `Finalise Recon` (`squad/osint_analyst/__init__.py`) -> `"recon.json"`
+  - `Finalise Research` (`squad/vulnerability_researcher/__init__.py`) -> `"attack_plan.json"`
+  - `Finalise Triage` (`squad/vulnerability_researcher/__init__.py`) -> `"verified.json"`
+  - `Finalise Reports` (`squad/technical_author/__init__.py`) -> the reports manifest filename
+- `squad/workspace_tools.py` `read_attack_plan_tool` is on the #139 backlog - it should return `AttackPlan` but currently returns a `dict` shape. Cite it as the *target* of the typed-reader pattern, not the example to mirror today.

--- a/.claude/skills/cybersquad-tool/SKILL.md
+++ b/.claude/skills/cybersquad-tool/SKILL.md
@@ -63,7 +63,7 @@ Any file an agent writes for the next agent to read needs both halves of the con
 | `finalise_research(plan)` -> `attack_plan.json` | `read_attack_plan_tool` -> `AttackPlan` |
 | `finalise_triage(...)` -> `verified.json` | (Technical Author's typed reader) |
 
-The reader returns the typed model; downstream agents work against the schema, not raw bytes. A writer landing without a typed reader is the bug PR #138 fixed - do not repeat it.
+The reader returns the typed model; downstream agents work against the schema, not raw bytes. A writer landing without a typed reader is the gap PR #138 addresses - do not repeat it.
 
 ## Where tools live
 

--- a/.claude/skills/cybersquad-tool/SKILL.md
+++ b/.claude/skills/cybersquad-tool/SKILL.md
@@ -96,9 +96,29 @@ Cross-agent intent matters: this skill applies to every agent's `@tool` wrappers
 
 ## Upstream alignment
 
-CrewAI's [crewAIInc/skills](https://github.com/crewAIInc/skills) repository publishes three skills today: `getting-started`, `design-agent`, `design-task`. None of them cover `@tool` conventions at the project level; the closest upstream document is [`design-agent/references/custom-tools.md`](https://github.com/crewAIInc/skills/blob/main/skills/design-agent/references/custom-tools.md), which covers `@tool` vs `BaseTool` decoration mechanics. This skill is a project layer on top of those mechanics, not a replacement.
+CrewAI's [crewAIInc/skills](https://github.com/crewAIInc/skills) repository publishes three skills today: `getting-started`, `design-agent`, `design-task`. None covers tool conventions at the project level; the closest upstream document is [`design-agent/references/custom-tools.md`](https://github.com/crewAIInc/skills/blob/main/skills/design-agent/references/custom-tools.md), which covers `@tool` vs `BaseTool` mechanics.
 
-Two relationship points to know:
+This skill *deliberately diverges* from upstream in two places. Being honest about that matters more than pretending compatibility.
 
-- **"Return pydantic" vs upstream "return strings".** Upstream advises tool functions return strings because the LLM sees text. CrewAI serialises any return value to JSON for the LLM, so a pydantic-model return delivers the same text to the LLM *and* preserves the schema at the Python level (downstream code calling `tool.func(...)` directly gets a typed model; `mypy` can verify wiring; the contract test in #139 has something to introspect). Returning `dict` keeps the LLM side and strips the Python side.
-- **`@tool` vs `BaseTool`.** This skill assumes `@tool` because that is what cybersquad uses today. If you reach for `BaseTool` (when you need `args_schema`, async via `_arun`, or per-tool state), defer to the upstream reference for mechanics - the pydantic-return rule still applies.
+### Divergence 1: structured returns from tools (chosen)
+
+Upstream's architectural take is that structured data belongs on the *task* (`output_pydantic` / `output_json`), and tools just return text-fodder for the LLM's reasoning. We put pydantic on tools because:
+
+- The #139 contract test needs introspectable return annotations to enforce the rule.
+- Tests call `tool.func(...)` directly and want a typed return.
+- `mypy` verifies cross-tool wiring (e.g. that `read_attack_plan_tool` actually returns what `Finalise Research` wrote).
+- Probe tools return small, structured `RawFinding` lists - flattening them to text loses the structure agents reason over.
+
+Wire-format equivalence: CrewAI serialises any return value to JSON-text for the LLM, so the agent sees the same text upstream wants *and* we get the Python-side discipline upstream does not.
+
+### Divergence 2: inter-agent handoff via workspace files (forced)
+
+Upstream's task model expects the next task to receive the previous task's structured output via `context=`. Cybersquad uses workspace files instead: a typed `finalise_X` writes the artefact, the task's textual output is the filename, the next agent uses a typed `load_X` reader.
+
+This divergence is forced, not chosen. ReconResult artefacts are routinely ~115KB / ~30K tokens (Cloudflare runs); threading every downstream `context=` through that would torch the LLM window. Workspace files + typed slicers (`Recon Endpoints`, `Recon Open Ports`, `Recon Subdomains`) let agents pull narrow views on demand without loading the whole artefact.
+
+The hybrid we have not adopted yet: small inter-task briefings (e.g. VR's freeform paragraph for PT) could move to `output_pydantic=AttackBriefing` while the large typed artefact stays in the workspace. Worth its own conversation; not in scope for this skill.
+
+### When to revisit
+
+If you find yourself wanting to relax either rule - "this tool's return is small, can it be a string?", "this task's handoff is small, can it use `output_pydantic`?" - re-derive from first principles rather than appealing to the rule. The divergences are intentional but not load-bearing forever.

--- a/.claude/skills/cybersquad-tool/SKILL.md
+++ b/.claude/skills/cybersquad-tool/SKILL.md
@@ -111,13 +111,17 @@ Upstream's architectural take is that structured data belongs on the *task* (`ou
 
 Wire-format equivalence: CrewAI serialises any return value to JSON-text for the LLM, so the agent sees the same text upstream wants *and* we get the Python-side discipline upstream does not.
 
-### Divergence 2: inter-agent handoff via workspace files (forced)
+### Divergence 2: inter-agent handoff via workspace files
 
-Upstream's task model expects the next task to receive the previous task's structured output via `context=`. Cybersquad uses workspace files instead: a typed `finalise_X` writes the artefact, the task's textual output is the filename, the next agent uses a typed `load_X` reader.
+A CrewAI task emits exactly one thing - the agent's text response, parked at `task.output.raw`. `output_pydantic` and `output_json` do not add a second channel; they constrain that text to JSON-shape and parse it for orchestration code. The next agent in the pipeline still receives raw text in its context (CrewAI's `aggregate_raw_outputs_from_tasks` joins `output.raw` from prior tasks with dividers), whether that text is freeform Markdown or schema-shaped JSON.
 
-This divergence is forced, not chosen. ReconResult artefacts are routinely ~115KB / ~30K tokens (Cloudflare runs); threading every downstream `context=` through that would torch the LLM window. Workspace files + typed slicers (`Recon Endpoints`, `Recon Open Ports`, `Recon Subdomains`) let agents pull narrow views on demand without loading the whole artefact.
+Two reasons we use workspace files for inter-agent structured data instead of `output_pydantic`:
 
-The hybrid we have not adopted yet: small inter-task briefings (e.g. VR's freeform paragraph for PT) could move to `output_pydantic=AttackBriefing` while the large typed artefact stays in the workspace. Worth its own conversation; not in scope for this skill.
+1. **Size (forced).** ReconResult artefacts run ~115KB / ~30K tokens on real targets. `output_pydantic=ReconResult` would put that JSON in every downstream `context=` and torch the LLM window. Workspace files + typed slicers (`Recon Endpoints`, `Recon Open Ports`, `Recon Subdomains`) let agents pull narrow views on demand.
+
+2. **The both-and (chosen).** With workspace files, the task's textual output is reasoning-narrative (a freeform briefing the next agent uses to orient) *and* the typed artefact is produced separately by a `Finalise X` tool call. We get narrative reasoning AND schema-enforced structure. `output_pydantic` collapses these into one - the agent must produce JSON-only output, and any reasoning prose it would naturally produce has to be suppressed via non-trivial prompt engineering. Many CrewAI users hit "agent said 'here is my analysis: { ... }' and the JSON parser broke."
+
+The pair pattern (typed `finalise_X` writer + typed `load_X` reader) is the wedge that makes this work. The task-side conventions live in the `cybersquad-task` skill.
 
 ### When to revisit
 

--- a/.claude/skills/cybersquad-tool/SKILL.md
+++ b/.claude/skills/cybersquad-tool/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cybersquad-tool
-description: Universal rules for every CrewAI `@tool`-wrapped function in cybersquad. Covers the pydantic return-shape rule, typed parameters, the workspace writer/reader pair, and where shared tools live. Load before editing any `@tool` wrapper - `squad/*/__init__.py`, `squad/workspace_tools.py`, or `squad/__init__.py`. Pentest probes layer the `cybersquad-pentest-tool` skill on top of this one.
+description: Universal rules for every CrewAI `@tool`-wrapped function in cybersquad. Pydantic return shape, typed parameters, writer/reader workspace pair. Load before editing any `@tool` wrapper.
 ---
 
 # cybersquad @tool conventions

--- a/.claude/skills/cybersquad-tool/SKILL.md
+++ b/.claude/skills/cybersquad-tool/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: cybersquad-tool
+description: Universal rules for every CrewAI `@tool`-wrapped function in cybersquad. Covers the pydantic return-shape rule, typed parameters, the workspace writer/reader pair, and where shared tools live. Load before editing any `@tool` wrapper - `squad/*/__init__.py`, `squad/workspace_tools.py`, or `squad/__init__.py`. Pentest probes layer the `cybersquad-pentest-tool` skill on top of this one.
+---
+
+# cybersquad @tool conventions
+
+Every CrewAI `@tool`-wrapped function the agents see follows these rules. They are universal; `cybersquad-pentest-tool` is a specialisation that adds OWASP + StrEnum + `@pentest_tool` on top of this baseline. If you are touching a pentest probe wrapper, load both.
+
+## Return a pydantic model, or `list[<Model>]`
+
+```python
+# correct - the agent sees a schema
+@tool("Read Attack Plan")
+def read_attack_plan_tool() -> AttackPlan:
+    return load_attack_plan(attack_plan_path())
+
+@tool("Reflected XSS Probe")
+def xss_probe_tool(endpoints_json: str) -> list[RawFinding]:
+    return list(check_reflected_xss(_parse_endpoints(endpoints_json)))
+```
+
+```python
+# wrong - the agent sees a JSON-shaped dict and has to reconstitute the schema
+# from the docstring
+@tool("Reflected XSS Probe")
+def xss_probe_tool(endpoints_json: str) -> list[dict]:
+    return [f.model_dump() for f in check_reflected_xss(...)]
+```
+
+Never `dict`, `list[dict]`, or bare `list` (no inner type). CrewAI serialises pydantic models to JSON on its own; calling `.model_dump()` in the wrapper just strips the schema. If the underlying helper does not have a typed return yet, add the model before wiring the `@tool` - the model is the contract.
+
+### The one exception: workspace-handle strings
+
+`finalise_X` / `save_X` tools return the bare filename of the artifact they wrote (`"findings.json"`, `"attack_plan.json"`, `"verified.json"`). That `str` return is intentional - the filename is a handle the next agent passes to a typed reader. Document it in the docstring; do not invent a `WorkspaceHandle` wrapper model.
+
+## Type the parameters too
+
+```python
+# correct
+@pentest_tool("SSRF Probe", check_fn=check_ssrf)
+def ssrf_probe_tool(
+    endpoints_json: str,
+    payloads: list[SsrfPayload] | None = None,
+) -> list[RawFinding]:
+    ...
+```
+
+```python
+# wrong - the agent has no idea what strings are valid
+def ssrf_probe_tool(endpoints_json: str, payloads: list[str] | None = None) -> ...:
+```
+
+The `endpoints_json: str` pattern exists because CrewAI's tool-call protocol cannot pass arbitrary pydantic objects in - the wrapper takes the JSON-encoded form and unmarshals via `_parse_endpoints`. That is the only acceptable use of a bare `str` parameter for structured data; everywhere else, use the typed shape.
+
+## Workspace artifacts: writer and reader ship together
+
+Any file an agent writes for the next agent to read needs both halves of the contract in the same PR:
+
+| Writer | Reader |
+|---|---|
+| `finalise_recon(recon)` -> `recon.json` | `Recon Endpoints` / `Recon Open Ports` / `Recon Subdomains` slicers |
+| `finalise_research(plan)` -> `attack_plan.json` | `read_attack_plan_tool` -> `AttackPlan` |
+| `finalise_triage(...)` -> `verified.json` | (Technical Author's typed reader) |
+
+The reader returns the typed model; downstream agents work against the schema, not raw bytes. A writer landing without a typed reader is the bug PR #138 fixed - do not repeat it.
+
+## Where tools live
+
+- **Per-agent**: `squad/<agent>/__init__.py`. Each `@tool` is added to that agent's `MEMBER.tools` list.
+- **Shared between agents**: `squad/workspace_tools.py`. Re-export through `squad/__init__.py` (`__all__` and the explicit re-export) so consumers `from squad import read_attack_plan_tool`, not from the deeper path.
+
+## The `SquadMember.tools` registry
+
+Today `SquadMember.tools` is typed `list[Any]` because the local `_PentestTool` / `_ResearchBriefTool` Protocols do not share a base. That is being tightened in a follow-up (define a `CrewAITool` Protocol once, retype the registry). When that lands, the contract test that walks `MEMBER.tools` and asserts return-type annotations will be the mechanical enforcement of this skill - skill stays in AI context, test stays in CI.
+
+## Anti-patterns to catch
+
+- `[f.model_dump() for f in check_X(...)]` in any wrapper body - drop the comprehension, just `return list(check_X(...))`.
+- Return annotation of `dict` for a structured payload that has a pydantic shape already.
+- Bare `list` (no inner type) as a return annotation - either it is `list[str]` for a flat handle list, or it is `list[<Model>]` for structured rows.
+- New workspace writer with no typed reader.
+- `from squad.workspace_tools import ...` in a consumer instead of `from squad import ...` - the re-export exists so the import path stays stable when shared tools move.
+
+## Canonical examples
+
+- `squad/workspace_tools.py` `read_attack_plan_tool` - the typed-reader pattern (returns `AttackPlan`).
+- `squad/penetration_tester/__init__.py` `recon_endpoints_tool` - returns `EndpointPage`, the existing typed wrapper to mirror when retyping a `list[dict]` probe.
+- `tools/research_tools.py` `finalise_research` + `load_attack_plan` - the writer / reader pair as a unit.

--- a/.claude/skills/cybersquad-tool/SKILL.md
+++ b/.claude/skills/cybersquad-tool/SKILL.md
@@ -93,3 +93,12 @@ Cross-agent intent matters: this skill applies to every agent's `@tool` wrappers
   - `Finalise Triage` (`squad/vulnerability_researcher/__init__.py`) -> `"verified.json"`
   - `Finalise Reports` (`squad/technical_author/__init__.py`) -> the reports manifest filename
 - `squad/workspace_tools.py` `read_attack_plan_tool` is on the #139 backlog - it should return `AttackPlan` but currently returns a `dict` shape. Cite it as the *target* of the typed-reader pattern, not the example to mirror today.
+
+## Upstream alignment
+
+CrewAI's [crewAIInc/skills](https://github.com/crewAIInc/skills) repository publishes three skills today: `getting-started`, `design-agent`, `design-task`. None of them cover `@tool` conventions at the project level; the closest upstream document is [`design-agent/references/custom-tools.md`](https://github.com/crewAIInc/skills/blob/main/skills/design-agent/references/custom-tools.md), which covers `@tool` vs `BaseTool` decoration mechanics. This skill is a project layer on top of those mechanics, not a replacement.
+
+Two relationship points to know:
+
+- **"Return pydantic" vs upstream "return strings".** Upstream advises tool functions return strings because the LLM sees text. CrewAI serialises any return value to JSON for the LLM, so a pydantic-model return delivers the same text to the LLM *and* preserves the schema at the Python level (downstream code calling `tool.func(...)` directly gets a typed model; `mypy` can verify wiring; the contract test in #139 has something to introspect). Returning `dict` keeps the LLM side and strips the Python side.
+- **`@tool` vs `BaseTool`.** This skill assumes `@tool` because that is what cybersquad uses today. If you reach for `BaseTool` (when you need `args_schema`, async via `_arun`, or per-tool state), defer to the upstream reference for mechanics - the pydantic-return rule still applies.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,8 @@ os.getenv("FOO", "/tmp/bar")  # nosec B108  # noqa: S108 - intentional dev defau
 result = something_dangerous()  # nosec
 ```
 
+The flip side: when you encounter a suppression in unfamiliar code, the suppressions are the codebase telling you where the load-bearing assumptions live. The one-line `why` is the original author handing you context the type system or scanner could not encode - read it before you change anything that depends on it.
+
 ### Pylint says split, not suppress
 
 Pylint is scoped (see `[tool.pylint]` in `pyproject.toml`) to the design rules that fire when a module, function, or class outgrows its single responsibility. When it fails on code you edited, split the unit - pull a cohesive piece into its own module, extract a helper. Suppression (`# pylint: disable=...`) is reserved for cases where the unit genuinely is one thing; same grammar as other suppressions, one-line comment explaining why.


### PR DESCRIPTION
## Summary

Adds the parent skill that lays universal rules for every CrewAI `@tool`-wrapped function in cybersquad. `cybersquad-pentest-tool` becomes a specialisation that layers OWASP + StrEnum + `@pentest_tool` on top of this baseline.

- `.claude/skills/cybersquad-tool/SKILL.md` - new skill covering the pydantic return-shape rule, typed parameters, the workspace writer/reader pair (the contract PR #138 addresses), and where shared tools live. Anti-patterns include `[f.model_dump() for f in ...]` in any wrapper body, `dict`/`list[dict]`/bare-`list` return annotations, and new workspace writers without a typed reader.
- `.claude/hooks/load-skill.sh` - new matcher entry fires on `squad/__init__.py`, `squad/workspace_tools.py`, `squad/*/__init__.py`, and (latest commit) `*/tasks.py`. Pentest paths still match `cybersquad-pentest-tool` because they are listed first in the case statement (most-specific-wins).
- `.claude/skills/cybersquad-task/SKILL.md` - new skill covering `build_task()`, prose in `description.md` / `expected_output.md`, inter-agent structured handoff via workspace files (not `output_pydantic`), `human_input` threading through `config.human_input`, and `context=` as the explicit data-flow graph.
- `CONTRIBUTING.md` - adds the reader-side framing to the "Linter and SAST findings are engineering signal" section: when you encounter a suppression in unfamiliar code, the suppressions are the codebase telling you where the load-bearing assumptions live.

## Out of scope (tracked separately)

The migration this skill makes visible - 72 dict-shaped `@tool` returns + 1 bare `list` return - is tracked in #139. That issue also flags the prerequisite work (define `CrewAITool` Protocol, retype `SquadMember.tools: list[CrewAITool]`, add the contract test that walks every `MEMBER.tools` and asserts return-type annotations).

## Test plan

- [x] `bash -n .claude/hooks/load-skill.sh` - syntax clean
- [x] Hook matcher fires correctly: pentest paths emit `cybersquad-pentest-tool`, `squad/workspace_tools.py` emits `cybersquad-tool`, `squad/__init__.py` emits `cybersquad-tool`, `crew.py` still emits `cybersquad-agent-llm`, `*/tasks.py` emits `cybersquad-task`
- [x] All touched files are ASCII-only
- [x] `pytest -m unit` - 947 passed (no test changes, sanity check that nothing broke)