### PR TITLE
feat(squad): runtime crewai.skills loader, PM pilot (#62)

### DIFF
--- a/.claude/hooks/load-skill.sh
+++ b/.claude/hooks/load-skill.sh
@@ -80,7 +80,13 @@ case "$file_path" in
 esac
 
 case "$file_path" in
-    */squad/skills/*/SKILL.md|*/squad/*/skills/*/SKILL.md)
+    */squad/skills/*/SKILL.md \
+    |*/squad/*/skills/*/SKILL.md \
+    |*/squad/*/role.md \
+    |*/squad/*/goal.md \
+    |*/squad/*/backstory.md \
+    |*/squad/*/*/description.md \
+    |*/squad/*/*/expected_output.md)
         matches+=(cybersquad-skill)
         ;;
 esac

--- a/.claude/hooks/load-skill.sh
+++ b/.claude/hooks/load-skill.sh
@@ -79,6 +79,12 @@ case "$file_path" in
         ;;
 esac
 
+case "$file_path" in
+    */squad/skills/*/SKILL.md|*/squad/*/skills/*/SKILL.md)
+        matches+=(cybersquad-skill)
+        ;;
+esac
+
 [ "${#matches[@]}" -eq 0 ] && exit 0
 
 # Emit each matched skill once per session, joined into a single

--- a/.claude/skills/cybersquad-skill/SKILL.md
+++ b/.claude/skills/cybersquad-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cybersquad-skill
-description: How to write SKILL.md files under `squad/skills/` and `squad/<member>/skills/` for the CrewAI agent that will read them at runtime. Covers METADATA vs INSTRUCTIONS layers, audience (the agent, not you), voice (operational HackerOne vocabulary, second person), and the common contributor-perspective leaks - codebase paths, programming concepts, framework names, meta-commentary about enforcement code - that waste the agent's context or mislead it. Load before editing any SKILL.md under squad/.
+description: SKILL.md under squad/ is for the runtime CrewAI agent, not you. No codebase paths, no Python vocabulary, no framework meta. Load before editing.
 ---
 
 # Runtime crew skills
@@ -98,9 +98,18 @@ apply, even though this skill does not auto-load on those today.
 
 ## Upstream alignment
 
-SKILL.md frontmatter follows the `skill-creator` pattern (`name`,
-`description`, lowercase alphanumeric + hyphens). See
-[anthropics/skills `skill-creator`](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md)
-for the authoring contract. cybersquad runtime skills are
-progressive-disclosure markdown only; the `scripts/` layer is out of
-scope per #62.
+Frontmatter mechanics (`name`, `description`, lowercase alphanumeric
++ hyphens, description-as-trigger) follow Anthropic's `skill-creator`
+contract. See [anthropics/skills `skill-creator`](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md).
+
+For CrewAI's own framework on the prose layer the runtime SKILL.md
+complements - role-goal-backstory construction, task descriptions
+and expected outputs, agent capability tuning - see
+[crewAIInc/skills `design-agent`](https://github.com/crewAIInc/skills/blob/main/skills/design-agent/SKILL.md)
+and [`design-task`](https://github.com/crewAIInc/skills/blob/main/skills/design-task/SKILL.md).
+Those are the upstream canonicals. This skill is the cybersquad-
+specific overlay - the leaks named above are the ones we have
+actually shipped, not theoretical risks.
+
+cybersquad runtime skills are progressive-disclosure markdown only;
+the `scripts/` layer is out of scope per #62.

--- a/.claude/skills/cybersquad-skill/SKILL.md
+++ b/.claude/skills/cybersquad-skill/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: cybersquad-skill
+description: How to write SKILL.md files under `squad/skills/` and `squad/<member>/skills/` for the CrewAI agent that will read them at runtime. Covers METADATA vs INSTRUCTIONS layers, audience (the agent, not you), voice (operational HackerOne vocabulary, second person), and the common contributor-perspective leaks - codebase paths, programming concepts, framework names, meta-commentary about enforcement code - that waste the agent's context or mislead it. Load before editing any SKILL.md under squad/.
+---
+
+# Runtime crew skills
+
+SKILL.md files under `squad/skills/<name>/` and
+`squad/<member>/skills/<name>/` are loaded into a CrewAI agent's
+context at execution time via `crewai.skills`. The audience is the
+agent, not you. The agent's perspective is narrower than yours, and
+prose that drifts into your perspective wastes its context or
+misleads it.
+
+## METADATA vs INSTRUCTIONS
+
+Each SKILL.md has two layers the agent sees differently:
+
+- **METADATA** (the frontmatter `name` and `description`) is loaded
+  into a menu of available skills the agent sees every turn. Cheap,
+  always visible.
+- **INSTRUCTIONS** (the body) is promoted into the agent's system
+  prompt only when the agent activates the skill. Per-turn cost
+  once activated.
+
+The `description` is the menu entry the agent picks from. Phrase it
+as the operational context where the skill applies, not as repo-meta:
+
+- Good: "How the Programme Manager reads a HackerOne programme's
+  policy_text - the conservative posture and how to handle silence."
+- Bad: "Restates the cybersquad's hard scope rules in language every
+  agent must operate under."
+
+## What the agent knows
+
+- HackerOne API concepts: programmes, scope items, `policy_text`,
+  `bounty_table`, `asset_type`, `in_scope`, `eligible_for_bounty`,
+  `state`, `accepts_new_reports`, `triage_active`, `max_severity`,
+  `authorisation_basis`, `selection_rationale`.
+- The other squad members by role (Programme Manager, OSINT Analyst,
+  Penetration Tester, Vulnerability Researcher, Technical Author,
+  Disclosure Coordinator) and their handoff artefacts.
+- Its own `@tool` functions by name and docstring.
+- The operator - a real person who receives surfaced concerns.
+
+## What the agent does not know
+
+- This repository's name, layout, or any file path within it.
+  References like `tools/recon/scope.py` mean nothing to the agent -
+  it does not navigate the source tree.
+- That it is implemented in Python. Avoid "predicate", "function",
+  "method", "class", "module", "callable", "dict", "JSON", "hook",
+  "callback", "downstream code".
+- The contributor-side skill loader, `.claude/`, or any Claude Code
+  concept. The skills the agent sees are the ones we provision via
+  `Crew(skills=...)` and `Agent(skills=...)`. They need no qualifier
+  like "the CrewAI skills" or "the runtime skills" - to the agent
+  they are just skills.
+- That there is enforcement code beneath it. Telling the agent
+  "this is enforced in code, you cannot relax it" implies the agent
+  could try - it cannot, and saying so wastes context.
+
+## Voice
+
+- Address the agent as "you". The body is instruction, not
+  description.
+- Operational vocabulary only. If a sentence only makes sense to
+  someone who has read your code, rewrite it.
+- Other squad members can be named by role ("the Programme Manager
+  records `authorisation_basis`") - the agent knows the pipeline.
+
+## Common leaks (war stories from PR #142)
+
+- Bad: "This skill is a restatement of the safety invariants
+  enforced in code (`tools/recon/scope.py` and the H1 programme-
+  detail loader)." Filesystem reference plus meta-framing about what
+  skills do.
+- Bad: "You are the gate, not a Python predicate downstream of you."
+  Programming concept leak. Good: "You are the gate. If you do not
+  stop here, nothing further down the pipeline will."
+- Bad: "Restates the cybersquad's hard scope and authorisation rules
+  in language every agent must operate under." Repo name plus
+  meta-framing.
+
+The pattern in all three: contributor-perspective phrasing where
+operational phrasing was needed.
+
+## Scope of this skill
+
+Auto-loads on edits to:
+- `squad/skills/<name>/SKILL.md` (squad-wide)
+- `squad/<member>/skills/<name>/SKILL.md` (member specialist)
+
+Edits to `squad/<member>/role.md`, `goal.md`, `backstory.md`, and the
+per-task `description.md` / `expected_output.md` files share the
+same audience (the agent at execution time) and the same voice rules
+apply, even though this skill does not auto-load on those today.
+
+## Upstream alignment
+
+SKILL.md frontmatter follows the `skill-creator` pattern (`name`,
+`description`, lowercase alphanumeric + hyphens). See
+[anthropics/skills `skill-creator`](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md)
+for the authoring contract. cybersquad runtime skills are
+progressive-disclosure markdown only; the `scripts/` layer is out of
+scope per #62.

--- a/.claude/skills/cybersquad-skill/SKILL.md
+++ b/.claude/skills/cybersquad-skill/SKILL.md
@@ -1,18 +1,20 @@
 ---
 name: cybersquad-skill
-description: SKILL.md under squad/ is for the runtime CrewAI agent, not you. No codebase paths, no Python vocabulary, no framework meta. Load before editing.
+description: Markdown under squad/ is read by the runtime CrewAI agent, not by you. No codebase paths, no Python vocabulary, no framework meta. Load before editing.
 ---
 
-# Runtime crew skills
+# Runtime agent prose
 
-SKILL.md files under `squad/skills/<name>/` and
-`squad/<member>/skills/<name>/` are loaded into a CrewAI agent's
-context at execution time via `crewai.skills`. The audience is the
-agent, not you. The agent's perspective is narrower than yours, and
-prose that drifts into your perspective wastes its context or
-misleads it.
+The markdown files under `squad/` that the agent reads at execution
+time - SKILL.md files (squad-wide under `squad/skills/<name>/` and
+member-specialist under `squad/<member>/skills/<name>/`), per-member
+`role.md` / `goal.md` / `backstory.md`, and per-task
+`description.md` / `expected_output.md` - are loaded into a CrewAI
+agent's context, not yours. The agent's perspective is narrower than
+yours, and prose that drifts into your perspective wastes its
+context or misleads it.
 
-## METADATA vs INSTRUCTIONS
+## METADATA vs INSTRUCTIONS (SKILL.md only)
 
 Each SKILL.md has two layers the agent sees differently:
 
@@ -31,7 +33,18 @@ as the operational context where the skill applies, not as repo-meta:
 - Bad: "Restates the cybersquad's hard scope rules in language every
   agent must operate under."
 
+The other prose files (`role.md`, `goal.md`, `backstory.md`,
+`description.md`, `expected_output.md`) have no progressive disclosure
+- they are always in the agent's context for the relevant task. Same
+voice rules apply.
+
 ## What the agent knows
+
+Examples below are PM-flavored. Other squad members know analogous
+things relevant to their role - probe results and evidence for the
+Penetration Tester, recon artefacts for the OSINT Analyst, draft
+reports for the Technical Author, submission state for the
+Disclosure Coordinator.
 
 - HackerOne API concepts: programmes, scope items, `policy_text`,
   `bounty_table`, `asset_type`, `in_scope`, `eligible_for_bounty`,
@@ -51,14 +64,25 @@ as the operational context where the skill applies, not as repo-meta:
 - That it is implemented in Python. Avoid "predicate", "function",
   "method", "class", "module", "callable", "dict", "JSON", "hook",
   "callback", "downstream code".
+- Software-architecture jargon for the squad as a whole. Avoid
+  framework terms like "pipeline", "orchestration", "DAG", "stage"
+  when naming the squad's structure. The agent's mental model is:
+  it is part of a squad whose members run in order. Plain English
+  for steps within the agent's own task ("your workflow per finding",
+  "next step", "first do X") is fine - what is not fine is calling
+  the squad's structure a pipeline.
 - The contributor-side skill loader, `.claude/`, or any Claude Code
   concept. The skills the agent sees are the ones we provision via
   `Crew(skills=...)` and `Agent(skills=...)`. They need no qualifier
-  like "the CrewAI skills" or "the runtime skills" - to the agent
-  they are just skills.
+  like "the CrewAI skills", "the runtime skills", or "the crew skill"
+  - to the agent they are just skills.
 - That there is enforcement code beneath it. Telling the agent
   "this is enforced in code, you cannot relax it" implies the agent
   could try - it cannot, and saying so wastes context.
+- The output contract. The shape of `selection_rationale`,
+  `authorisation_basis`, the per-task output schema - those live in
+  `expected_output.md`. Do not restate them in a SKILL.md; the skill
+  teaches reasoning, the expected output specifies the artefact.
 
 ## Voice
 
@@ -67,34 +91,48 @@ as the operational context where the skill applies, not as repo-meta:
 - Operational vocabulary only. If a sentence only makes sense to
   someone who has read your code, rewrite it.
 - Other squad members can be named by role ("the Programme Manager
-  records `authorisation_basis`") - the agent knows the pipeline.
+  records `authorisation_basis`") - the agent knows who runs before
+  it and who runs after.
 
-## Common leaks (war stories from PR #142)
+## Common leaks
+
+Real bad-good pairs from runtime prose shipped under this skill:
 
 - Bad: "This skill is a restatement of the safety invariants
   enforced in code (`tools/recon/scope.py` and the H1 programme-
   detail loader)." Filesystem reference plus meta-framing about what
   skills do.
 - Bad: "You are the gate, not a Python predicate downstream of you."
-  Programming concept leak. Good: "You are the gate. If you do not
-  stop here, nothing further down the pipeline will."
+  Programming concept leak. Good: "You are the gate. No other squad
+  member will catch this if you miss it."
+- Bad: "...nothing further down the pipeline will." Architecture
+  jargon. Good: "...no other squad member will." (Same leak in three
+  files before this skill was tightened.)
+- Bad: "the scope-discipline crew skill is the final word." The
+  qualifier "crew" is framework-side; the agent sees one class of
+  skill. Good: "the scope-discipline skill is the final word."
 - Bad: "Restates the cybersquad's hard scope and authorisation rules
   in language every agent must operate under." Repo name plus
   meta-framing.
+- Bad: A SKILL.md section titled "Recording the basis" that restates
+  what `expected_output.md` already specifies for `authorisation_basis`.
+  Two contracts for the same field is one place to drift.
 
-The pattern in all three: contributor-perspective phrasing where
-operational phrasing was needed.
+The pattern across these: contributor-perspective phrasing where
+operational phrasing was needed, or skill-side content that belonged
+in `expected_output.md`.
 
-## Scope of this skill
+## When this skill fires
 
-Auto-loads on edits to:
-- `squad/skills/<name>/SKILL.md` (squad-wide)
-- `squad/<member>/skills/<name>/SKILL.md` (member specialist)
+Auto-loads on edits to any agent-facing markdown under `squad/`:
 
-Edits to `squad/<member>/role.md`, `goal.md`, `backstory.md`, and the
-per-task `description.md` / `expected_output.md` files share the
-same audience (the agent at execution time) and the same voice rules
-apply, even though this skill does not auto-load on those today.
+- `squad/skills/<name>/SKILL.md` (squad-wide skills)
+- `squad/<member>/skills/<name>/SKILL.md` (member specialist skills)
+- `squad/<member>/role.md`, `goal.md`, `backstory.md` (per-member identity)
+- `squad/<member>/<task>/description.md`, `expected_output.md` (per-task instructions and output contract)
+
+All five file types share the same audience (the CrewAI agent at
+execution time) and the same voice rules.
 
 ## Upstream alignment
 
@@ -111,5 +149,6 @@ Those are the upstream canonicals. This skill is the cybersquad-
 specific overlay - the leaks named above are the ones we have
 actually shipped, not theoretical risks.
 
-cybersquad runtime skills are progressive-disclosure markdown only;
-the `scripts/` layer is out of scope per #62.
+cybersquad runtime skills are progressive-disclosure markdown only -
+no `scripts/` or `references/` directories. Revisit if the tools
+layer stabilises and an executable-skill use case appears.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,23 +18,26 @@ Skills under `.claude/skills/` auto-load via a `PreToolUse` hook on `Write`/`Edi
 
 | Skill | Triggers on |
 |---|---|
-| `cybersquad-test-fixtures` | Any file under `tests/` (except the two below) |
+| `cybersquad-tool` | `squad/__init__.py`, `squad/workspace_tools.py`, `squad/<member>/__init__.py` |
 | `cybersquad-pentest-tool` | `tools/pentest/**` or `squad/penetration_tester/__init__.py` |
-| `cybersquad-bdd` | `tests/features/**` or `tests/bdd/**` |
 | `cybersquad-agent-llm` | `crew.py` |
+| `cybersquad-task` | `tasks.py` |
+| `cybersquad-skill` | `squad/skills/<name>/SKILL.md` or `squad/<member>/skills/<name>/SKILL.md` |
+| `cybersquad-test-fixtures` | Any file under `tests/` |
+| `cybersquad-bdd` | `tests/features/**` or `tests/bdd/**` |
 
 The hook is wired in `.claude/settings.json`; the matching logic lives in `.claude/hooks/load-skill.sh`. If a hook fails to fire in your session, run `/hooks` once (or restart) - the watcher only sees `.claude/settings.json` if it existed at session start. You can always also load a skill manually via the `Skill` tool.
 
 ### Runtime crew skills (CrewAI)
 
-Skills the CrewAI agents see at execution time live next to the squad packages and are loaded via `crewai.skills` (METADATA disclosure by default; the agent activates a skill to promote its body into the next system prompt).
+Skills the CrewAI agents see at execution time live next to the squad packages and are loaded via `crewai.skills`.
 
 | Layout | Loaded by | Visible to |
 |---|---|---|
 | `squad/skills/<name>/SKILL.md` | `Crew(skills=[SQUAD_SKILLS_DIR])` in `crew.py` | every agent |
 | `squad/<member>/skills/<name>/SKILL.md` | `Agent(skills=[member.skills_dir])` in `squad/__init__.py:build_agent` | that member only |
 
-Each skill is a directory containing a `SKILL.md` with frontmatter (`name`, `description`); the loader contract is the same one used by `skill-creator` upstream. Skills restate safety invariants enforced in code - they never relax them.
+Authoring conventions (audience, voice, METADATA/INSTRUCTIONS layering, common contributor-perspective leaks): see the `cybersquad-skill` contributor skill, which auto-loads on edits to either path.
 
 ## Required MCP
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,12 @@ Never include session URLs (`https://claude.ai/code/session_...`) in commit mess
 
 ## Skills
 
+Two skill systems run in this repo. They do not interact - one targets the
+contributor (you, editing code), the other targets the runtime crew (agents
+executing the pipeline).
+
+### Contributor skills (Claude Code)
+
 Skills under `.claude/skills/` auto-load via a `PreToolUse` hook on `Write`/`Edit` configured in `.claude/settings.json`. The relevant skill's full `SKILL.md` is injected into context on the first matching edit per session, deduplicated so repeated edits to the same scope are silent.
 
 | Skill | Triggers on |
@@ -18,6 +24,17 @@ Skills under `.claude/skills/` auto-load via a `PreToolUse` hook on `Write`/`Edi
 | `cybersquad-agent-llm` | `crew.py` |
 
 The hook is wired in `.claude/settings.json`; the matching logic lives in `.claude/hooks/load-skill.sh`. If a hook fails to fire in your session, run `/hooks` once (or restart) - the watcher only sees `.claude/settings.json` if it existed at session start. You can always also load a skill manually via the `Skill` tool.
+
+### Runtime crew skills (CrewAI)
+
+Skills the CrewAI agents see at execution time live next to the squad packages and are loaded via `crewai.skills` (METADATA disclosure by default; the agent activates a skill to promote its body into the next system prompt).
+
+| Layout | Loaded by | Visible to |
+|---|---|---|
+| `squad/skills/<name>/SKILL.md` | `Crew(skills=[SQUAD_SKILLS_DIR])` in `crew.py` | every agent |
+| `squad/<member>/skills/<name>/SKILL.md` | `Agent(skills=[member.skills_dir])` in `squad/__init__.py:build_agent` | that member only |
+
+Each skill is a directory containing a `SKILL.md` with frontmatter (`name`, `description`); the loader contract is the same one used by `skill-creator` upstream. Skills restate safety invariants enforced in code - they never relax them.
 
 ## Required MCP
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Skills under `.claude/skills/` auto-load via a `PreToolUse` hook on `Write`/`Edi
 | `cybersquad-pentest-tool` | `tools/pentest/**` or `squad/penetration_tester/__init__.py` |
 | `cybersquad-agent-llm` | `crew.py` |
 | `cybersquad-task` | `tasks.py` |
-| `cybersquad-skill` | `squad/skills/<name>/SKILL.md` or `squad/<member>/skills/<name>/SKILL.md` |
+| `cybersquad-skill` | Any agent-facing markdown under `squad/`: `squad/skills/<name>/SKILL.md`, `squad/<member>/skills/<name>/SKILL.md`, `squad/<member>/role.md`/`goal.md`/`backstory.md`, `squad/<member>/<task>/description.md`/`expected_output.md` |
 | `cybersquad-test-fixtures` | Any file under `tests/` |
 | `cybersquad-bdd` | `tests/features/**` or `tests/bdd/**` |
 

--- a/config.py
+++ b/config.py
@@ -68,8 +68,9 @@ class MemoryConfig:
     """
 
     long_term_enabled: bool = field(
-        default_factory=lambda: os.getenv("CREWAI_MEMORY_LONG_TERM_ENABLED", "false").lower()
-        == "true"
+        default_factory=lambda: (
+            os.getenv("CREWAI_MEMORY_LONG_TERM_ENABLED", "false").lower() == "true"
+        )
     )
     # Project-scoped storage so different cybersquad checkouts do not bleed
     # into each other (CrewAI's default is user-global at ~/.crewai/...).

--- a/config.py
+++ b/config.py
@@ -44,6 +44,38 @@ class LLMConfig:
         default_factory=lambda: float(os.getenv("CREWAI_TEMPERATURE", "0.2"))
     )
     max_tokens: int = field(default_factory=lambda: int(os.getenv("CREWAI_MAX_TOKENS", "4096")))
+    # Extended thinking via litellm. CrewAI maps reasoning_effort -> the
+    # provider's native thinking budget; "none" disables, the others scale
+    # thinking tokens. Off via env by setting CREWAI_REASONING_ENABLED=false.
+    reasoning_enabled: bool = field(
+        default_factory=lambda: os.getenv("CREWAI_REASONING_ENABLED", "true").lower() == "true"
+    )
+    reasoning_effort: str = field(
+        default_factory=lambda: os.getenv("CREWAI_REASONING_EFFORT", "medium")
+    )
+
+
+@dataclass
+class MemoryConfig:
+    """CrewAI memory configuration.
+
+    Long-term memory persists task outcomes across pipeline runs so the squad
+    can learn (e.g. PM avoiding programmes the squad has recently exhausted,
+    DC tracking submission status post-handover). Off by default - flipping
+    it on requires an embedder, writes a LanceDB store to disk, and
+    introduces non-determinism into agent reasoning. Operator override is to
+    delete the storage path and set CREWAI_MEMORY_LONG_TERM_ENABLED=false.
+    """
+
+    long_term_enabled: bool = field(
+        default_factory=lambda: os.getenv("CREWAI_MEMORY_LONG_TERM_ENABLED", "false").lower()
+        == "true"
+    )
+    # Project-scoped storage so different cybersquad checkouts do not bleed
+    # into each other (CrewAI's default is user-global at ~/.crewai/...).
+    storage_path: str = field(
+        default_factory=lambda: os.getenv("CREWAI_MEMORY_STORAGE", ".cybersquad/memory")
+    )
 
 
 @dataclass
@@ -150,6 +182,7 @@ class AppConfig:
 
     h1: H1Config = field(default_factory=H1Config)
     llm: LLMConfig = field(default_factory=LLMConfig)
+    memory: MemoryConfig = field(default_factory=MemoryConfig)
     recon: ReconConfig = field(default_factory=ReconConfig)
     scan: ScanConfig = field(default_factory=ScanConfig)
     # Operator contact email surfaced in the outbound User-Agent so SOC teams

--- a/config.py
+++ b/config.py
@@ -7,6 +7,21 @@ import os
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
+from typing import Literal, cast
+
+# crewai.LLM accepts reasoning_effort as one of these four strings (or None).
+# Mirroring the Literal here lets mypy verify the value end-to-end at the
+# LLM call site, instead of widening to str and casting later.
+ReasoningEffort = Literal["none", "low", "medium", "high"]
+_REASONING_EFFORT_VALUES: frozenset[str] = frozenset(("none", "low", "medium", "high"))
+
+
+def _read_reasoning_effort() -> ReasoningEffort:
+    raw = os.getenv("CREWAI_REASONING_EFFORT", "medium")
+    if raw not in _REASONING_EFFORT_VALUES:
+        valid = sorted(_REASONING_EFFORT_VALUES)
+        raise ValueError(f"CREWAI_REASONING_EFFORT must be one of {valid}; got {raw!r}")
+    return cast(ReasoningEffort, raw)
 
 
 class ScanMode(StrEnum):
@@ -50,9 +65,7 @@ class LLMConfig:
     reasoning_enabled: bool = field(
         default_factory=lambda: os.getenv("CREWAI_REASONING_ENABLED", "true").lower() == "true"
     )
-    reasoning_effort: str = field(
-        default_factory=lambda: os.getenv("CREWAI_REASONING_EFFORT", "medium")
-    )
+    reasoning_effort: ReasoningEffort = field(default_factory=_read_reasoning_effort)
 
 
 @dataclass

--- a/crew.py
+++ b/crew.py
@@ -28,6 +28,38 @@ _SQUAD: list[SquadMember] = [
 ]
 
 
+def _build_llm() -> LLM:
+    """Construct the squad LLM, honouring extended-thinking config."""
+    kwargs: dict[str, object] = {
+        "model": config.llm.model,
+        "temperature": config.llm.temperature,
+        "max_tokens": config.llm.max_tokens,
+    }
+    if config.llm.reasoning_enabled:
+        kwargs["reasoning_effort"] = config.llm.reasoning_effort
+    return LLM(**kwargs)
+
+
+def _build_long_term_memory() -> object | None:
+    """Lazy-construct CrewAI long-term memory when enabled in config.
+
+    Returns the Memory instance to pass to ``Crew(memory=...)``, or None
+    when long-term memory is disabled (the default). Imports are local so
+    LanceDB / embedder dependencies are only touched when the operator
+    opts in.
+    """
+    if not config.memory.long_term_enabled:
+        return None
+    # pylint: disable=C0415  # lazy import: opt-in dependency surface
+    from pathlib import Path
+
+    from crewai.memory.memory import Memory
+
+    storage_path = Path(config.memory.storage_path)
+    storage_path.parent.mkdir(parents=True, exist_ok=True)
+    return Memory(storage="lancedb", root_scope="/long_term")
+
+
 def build_crew(verbose: bool | None = None) -> Crew:
     """
     Instantiate agents and tasks, then wire them into a sequential Crew.
@@ -38,20 +70,18 @@ def build_crew(verbose: bool | None = None) -> Crew:
     """
     be_verbose = verbose if verbose is not None else config.verbose
 
-    llm = LLM(
-        model=config.llm.model,
-        temperature=config.llm.temperature,
-        max_tokens=config.llm.max_tokens,
-    )
+    llm = _build_llm()
     agents = {m.slug: build_agent(m, llm, be_verbose) for m in _SQUAD}
     tasks = build_tasks(agents)
+
+    memory = _build_long_term_memory()
 
     return Crew(
         agents=list(agents.values()),
         tasks=tasks,
         process=Process.sequential,
         verbose=be_verbose,
-        memory=False,
+        memory=memory,
         embedder=None,
         skills=[SQUAD_SKILLS_DIR] if SQUAD_SKILLS_DIR.is_dir() else None,
     )

--- a/crew.py
+++ b/crew.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from crewai import LLM, Crew, Process
+from crewai import LLM, Agent, Crew, Process, Task
 from crewai.memory.memory import Memory
 
 from config import config
@@ -66,14 +66,14 @@ def build_crew(verbose: bool | None = None) -> Crew:
     """
     be_verbose = verbose if verbose is not None else config.verbose
 
-    llm = _build_llm()
-    agents = {m.slug: build_agent(m, llm, be_verbose) for m in _SQUAD}
-    tasks = build_tasks(agents)
-
-    memory = _build_long_term_memory()
+    llm: LLM = _build_llm()
+    agents_by_slug: dict[str, Agent] = {m.slug: build_agent(m, llm, be_verbose) for m in _SQUAD}
+    agents: list[Agent] = list(agents_by_slug.values())
+    tasks: list[Task] = build_tasks(agents_by_slug)
+    memory: Memory | None = _build_long_term_memory()
 
     return Crew(
-        agents=list(agents.values()),
+        agents=agents,
         tasks=tasks,
         process=Process.sequential,
         verbose=be_verbose,

--- a/crew.py
+++ b/crew.py
@@ -6,9 +6,10 @@ Call build_crew() to get a fully wired crew, then crew.kickoff() to run it.
 
 from __future__ import annotations
 
-from typing import Any
+from pathlib import Path
 
 from crewai import LLM, Crew, Process
+from crewai.memory.memory import Memory
 
 from config import config
 from squad import SQUAD_SKILLS_DIR, SquadMember, build_agent
@@ -42,22 +43,14 @@ def _build_llm() -> LLM:
     return LLM(**kwargs)
 
 
-def _build_long_term_memory() -> Any:  # noqa: ANN401  # crewai has no stubs yet
-    """Lazy-construct CrewAI long-term memory when enabled in config.
+def _build_long_term_memory() -> Memory | None:
+    """Construct CrewAI long-term memory when enabled in config.
 
     Returns the Memory instance to pass to ``Crew(memory=...)``, or None
-    when long-term memory is disabled (the default). Imports are local so
-    LanceDB / embedder dependencies are only touched when the operator
-    opts in. Return type is ``Any`` because crewai does not publish stubs
-    yet - tighten when they do.
+    when long-term memory is disabled (the default).
     """
     if not config.memory.long_term_enabled:
         return None
-    # pylint: disable=C0415  # lazy import: opt-in dependency surface
-    from pathlib import Path
-
-    from crewai.memory.memory import Memory
-
     storage_path = Path(config.memory.storage_path)
     storage_path.parent.mkdir(parents=True, exist_ok=True)
     return Memory(storage="lancedb", root_scope="/long_term")

--- a/crew.py
+++ b/crew.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from crewai import LLM, Agent, Crew, Process, Task
+from crewai.agents.agent_builder.base_agent import BaseAgent
 from crewai.memory.memory import Memory
 
 from config import config
@@ -32,15 +33,25 @@ _SQUAD: list[SquadMember] = [
 
 
 def _build_llm() -> LLM:
-    """Construct the squad LLM, honouring extended-thinking config."""
-    kwargs: dict[str, object] = {
-        "model": config.llm.model,
-        "temperature": config.llm.temperature,
-        "max_tokens": config.llm.max_tokens,
-    }
+    """Construct the squad LLM, honouring extended-thinking config.
+
+    Per the cybersquad-agent-llm skill, model / temperature / max_tokens
+    are passed explicitly. reasoning_effort is also passed explicitly when
+    enabled so litellm forwards Anthropic extended thinking; when disabled
+    we omit it so the default path is unchanged.
+    """
     if config.llm.reasoning_enabled:
-        kwargs["reasoning_effort"] = config.llm.reasoning_effort
-    return LLM(**kwargs)
+        return LLM(
+            model=config.llm.model,
+            temperature=config.llm.temperature,
+            max_tokens=config.llm.max_tokens,
+            reasoning_effort=config.llm.reasoning_effort,
+        )
+    return LLM(
+        model=config.llm.model,
+        temperature=config.llm.temperature,
+        max_tokens=config.llm.max_tokens,
+    )
 
 
 def _build_long_term_memory() -> Memory | None:
@@ -68,7 +79,9 @@ def build_crew(verbose: bool | None = None) -> Crew:
 
     llm: LLM = _build_llm()
     agents_by_slug: dict[str, Agent] = {m.slug: build_agent(m, llm, be_verbose) for m in _SQUAD}
-    agents: list[Agent] = list(agents_by_slug.values())
+    # Crew(agents=...) wants list[BaseAgent]; list[Agent] is invariant
+    # against it, so widen on construction.
+    agents: list[BaseAgent] = list(agents_by_slug.values())
     tasks: list[Task] = build_tasks(agents_by_slug)
     memory: Memory | None = _build_long_term_memory()
 

--- a/crew.py
+++ b/crew.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from crewai import LLM, Crew, Process
 
 from config import config
-from squad import SquadMember, build_agent
+from squad import SQUAD_SKILLS_DIR, SquadMember, build_agent
 from squad.disclosure_coordinator import MEMBER as DISCLOSURE_COORDINATOR
 from squad.osint_analyst import MEMBER as OSINT_ANALYST
 from squad.penetration_tester import MEMBER as PENETRATION_TESTER
@@ -53,4 +53,5 @@ def build_crew(verbose: bool | None = None) -> Crew:
         verbose=be_verbose,
         memory=False,
         embedder=None,
+        skills=[SQUAD_SKILLS_DIR] if SQUAD_SKILLS_DIR.is_dir() else None,
     )

--- a/crew.py
+++ b/crew.py
@@ -6,6 +6,8 @@ Call build_crew() to get a fully wired crew, then crew.kickoff() to run it.
 
 from __future__ import annotations
 
+from typing import Any
+
 from crewai import LLM, Crew, Process
 
 from config import config
@@ -40,13 +42,14 @@ def _build_llm() -> LLM:
     return LLM(**kwargs)
 
 
-def _build_long_term_memory() -> object | None:
+def _build_long_term_memory() -> Any:  # noqa: ANN401  # crewai has no stubs yet
     """Lazy-construct CrewAI long-term memory when enabled in config.
 
     Returns the Memory instance to pass to ``Crew(memory=...)``, or None
     when long-term memory is disabled (the default). Imports are local so
     LanceDB / embedder dependencies are only touched when the operator
-    opts in.
+    opts in. Return type is ``Any`` because crewai does not publish stubs
+    yet - tighten when they do.
     """
     if not config.memory.long_term_enabled:
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Autonomous bug bounty pipeline powered by CrewAI"
 requires-python = ">=3.12"
 dependencies = [
-    "crewai[anthropic]>=0.80.0",
+    "crewai[anthropic]>=1.14.0",
     "crewai-tools>=0.15.0",
     "pydantic>=2.7.0",
     "requests>=2.32.0",

--- a/squad/__init__.py
+++ b/squad/__init__.py
@@ -43,11 +43,20 @@ SQUAD_SKILLS_DIR = Path(__file__).parent / "skills"
 
 @dataclass(frozen=True)
 class SquadMember:
-    """A single Bounty Squad member: identity, tools, and prose location."""
+    """A single Bounty Squad member: identity, tools, and prose location.
 
-    slug: str
+    ``slug`` is derived from ``dir.name`` rather than stored separately - the
+    two were always required to match (the dir name is the package path on
+    disk) so the explicit field was just a place to introduce inconsistency.
+    """
+
     dir: Path
     tools: list[Any] = field(default_factory=list)
+
+    @property
+    def slug(self) -> str:
+        """Snake-case identifier (the on-disk package name)."""
+        return self.dir.name
 
     def read(self, *parts: str) -> str:
         """Read a markdown file under this member's directory.

--- a/squad/__init__.py
+++ b/squad/__init__.py
@@ -16,6 +16,11 @@ has one subdir per task:
 
     research/description.md   triage/description.md
 
+Member-specialist skills live alongside the prose in a ``skills/`` subdirectory;
+each skill is its own folder containing a ``SKILL.md`` with frontmatter, per the
+crewai.skills loader contract. Squad-wide skills live at ``squad/skills/`` and
+are attached at Crew construction in crew.py.
+
 Assembly (LLM wiring, pipeline order, approval gates) lives in crew.py / tasks.py.
 """
 
@@ -32,6 +37,8 @@ from squad.workspace_tools import (
     read_run_file_tool,
     read_run_filelist_tool,
 )
+
+SQUAD_SKILLS_DIR = Path(__file__).parent / "skills"
 
 
 @dataclass(frozen=True)
@@ -50,14 +57,28 @@ class SquadMember:
         """
         return (self.dir.joinpath(*parts).with_suffix(".md")).read_text(encoding="utf-8").strip()
 
+    @property
+    def skills_dir(self) -> Path:
+        """Directory containing this member's specialist SKILL.md folders."""
+        return self.dir / "skills"
+
 
 def build_agent(member: SquadMember, llm: object, verbose: bool = False) -> Agent:
-    """Construct a CrewAI Agent from the member's role/goal/backstory files."""
+    """Construct a CrewAI Agent from the member's role/goal/backstory files.
+
+    Member-specialist skills are passed as a directory path; crewai.skills
+    discovers each ``SKILL.md`` subfolder and loads at METADATA disclosure
+    (frontmatter only) so the agent sees a cheap menu of what is available
+    and pays the body cost only on activation. Squad-wide skills are merged
+    in at Crew construction (crew.py) so they are discovered once per run.
+    """
+    skills: list[Path] = [member.skills_dir] if member.skills_dir.is_dir() else []
     return Agent(
         role=member.read("role"),
         goal=member.read("goal"),
         backstory=member.read("backstory"),
         tools=member.tools,
+        skills=skills,
         allow_delegation=False,
         llm=llm,
         verbose=verbose,

--- a/squad/disclosure_coordinator/__init__.py
+++ b/squad/disclosure_coordinator/__init__.py
@@ -46,7 +46,6 @@ def check_duplicate_tool(programme_handle: str, title: str) -> list[dict]:
 
 
 MEMBER = SquadMember(
-    slug="disclosure_coordinator",
     dir=Path(__file__).parent,
     tools=[
         submit_report_tool,

--- a/squad/osint_analyst/__init__.py
+++ b/squad/osint_analyst/__init__.py
@@ -334,7 +334,6 @@ def _load_programme(programme_handle: str | None) -> Programme:
 
 
 MEMBER = SquadMember(
-    slug="osint_analyst",
     dir=Path(__file__).parent,
     tools=[
         # Sweep

--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -1072,7 +1072,6 @@ def save_findings_tool(findings_json: str) -> str:
 
 
 MEMBER = SquadMember(
-    slug="penetration_tester",
     dir=Path(__file__).parent,
     tools=[
         nuclei_scan_tool,

--- a/squad/programme_manager/__init__.py
+++ b/squad/programme_manager/__init__.py
@@ -94,7 +94,6 @@ def save_programme_tool(handle: str) -> str:
 
 
 MEMBER = SquadMember(
-    slug="programme_manager",
     dir=Path(__file__).parent,
     tools=[browse_programmes_tool, hydrate_programme_tool, save_programme_tool],
 )

--- a/squad/programme_manager/backstory.md
+++ b/squad/programme_manager/backstory.md
@@ -1,7 +1,15 @@
+You are the squad's lead. The squad acts on your decisions. The squad
+operates on the operator's real bug-bounty researcher account, which
+means a wrong programme choice does not just waste squad time - it
+damages the operator's standing with the platform, their relationship
+with the programme's owner, and at the limit their legal exposure.
+The other squad members trust your authorisation work; they will not
+re-verify it. Choose carefully.
+
 You evaluate HackerOne programmes on concrete, financial criteria. The squad
 exists to fund itself through consistent, high-quality vulnerability findings -
-so picking the right programme is the single most important decision in the
-pipeline.
+so picking the right programme is the single most important decision the squad
+makes.
 
 VDPs (programmes where offers_bounties is false) are worthless to this
 operation and must be rejected without further evaluation. Programmes not
@@ -50,5 +58,5 @@ You also respect per-asset max_severity caps - an asset capped at medium is
 worth far less than its neighbour with no cap, even if both are in scope.
 
 You never authorise the squad to operate against a programme unless you are
-confident the policy permits it. When in doubt, the scope-discipline crew
-skill is the final word.
+confident the policy permits it. When in doubt, the scope-discipline skill is
+the final word.

--- a/squad/programme_manager/backstory.md
+++ b/squad/programme_manager/backstory.md
@@ -9,20 +9,17 @@ accepting reports (accepts_new_reports is false) are equally useless.
 
 Beyond the hard filters, you think like an investor: expected value per hour
 of squad time. A programme paying $50,000 for criticals means nothing if they
-have a 30% response rate and take 180 days to pay. You weight payout ceiling,
-programme health (total_bounties_paid_usd), response efficiency, and time to
-bounty together to estimate real expected return.
+have a 30% response rate and take 180 days to pay. The detailed weighted
+rubric you apply lives in the programme-selection-scoring skill - activate it
+when you reach the score-and-select step.
 
 You read every programme's policy_text in full before authorising any work
 against it. Your default position is conservative: you are looking for clear
 permission or unambiguous silence. Ambiguity is a reason to skip, not proceed.
-Specifically:
-  - Prohibited: any language forbidding automated tools, scanners, brute force,
-    fuzzing, or rate testing - disqualify the programme immediately.
-  - Permitted: explicit statement that automated scanning is allowed, or a
-    policy that says nothing about it and imposes no relevant restrictions.
-  - Uncertain: if you have to guess whether an activity is permitted, do not
-    authorise it. Move to the next candidate.
+The full reading discipline (what counts as permission, what counts as
+prohibition, how to handle silence and ambiguity) lives in the
+policy-reading-discipline skill - activate it before reviewing any hydrated
+programme's policy.
 
 You drive the catalog. browse_programmes_tool gives you cheap previews of
 every accessible programme; hydrate_programme_tool fetches full policy,
@@ -44,39 +41,14 @@ curates, you consume.
 
 Policy permission is half the authorisation question. The other half is
 access: whether the authenticated hacker has been admitted to the programme
-at all. The HackerOne hacker API only returns programmes accessible to your
-account - public programmes plus accepted private invitations - so a
-programme appearing in browse_programmes_tool's output is the operative
-signal that you may scan it. Treat that signal as load-bearing, not
-optional. You also look at the H1 access-state attribute exposed on each
-programme:
-  - state == "public_mode" - publicly listed, openly accessible; the default
-    safe case.
-  - any other value (e.g. "private_mode"), or state missing - treat as
-    non-public. Appearance in browse_programmes_tool's output is necessary
-    but not sufficient; you also need positive evidence of admission in the
-    hydrated programme (e.g. policy_text describing the invited researcher's
-    role, programme name matching an invitation you expect, scope item
-    instructions naming participating researchers). If the programme is
-    non-public AND you cannot point to corroborating evidence of admission,
-    reject it.
-
-Two H1 signals look adjacent but mean different things and should not be
-conflated: accepts_new_reports answers "is the submission window open?"
-(open vs. closed); state answers "who is admitted to this programme?"
-(public vs. invite-only). A closed-but-public programme is filtered by the
-hard-filter step below; a public-but-non-admitted programme is filtered
-here. You apply both checks.
-
-Independently, if anything in the hydrated programme contradicts the access
-assumption (policy_text declaring the programme private or invitation-only,
-scope item instructions describing out-of-band restrictions, a programme
-name flagged as confidential, etc.) you reject the programme even if every
-other filter passes. You record the authorisation basis explicitly in
-selection_rationale so the access reasoning is auditable, not implicit.
+at all. The mechanics of establishing access (the H1 access signal, the
+state field, corroborating evidence for non-public programmes, the
+contradicting-signal check) live in the access-authorisation skill -
+activate it at Step 0 of selection and on every hydrated candidate.
 
 You also respect per-asset max_severity caps - an asset capped at medium is
 worth far less than its neighbour with no cap, even if both are in scope.
 
 You never authorise the squad to operate against a programme unless you are
-confident the policy permits it.
+confident the policy permits it. When in doubt, the scope-discipline crew
+skill is the final word.

--- a/squad/programme_manager/select/description.md
+++ b/squad/programme_manager/select/description.md
@@ -16,29 +16,10 @@ The catalog tools:
 
 Step 0 - Access authorisation (operative invariant, applies to every
 candidate the moment you hydrate it):
-  browse_programmes_tool returns only programmes accessible to the
-  authenticated hacker. The HackerOne hacker API filters by account
-  authorisation, so appearance in the catalog is the necessary
-  precondition for any work the squad will perform. Treat that as
-  load-bearing.
-
-  Read the state field on each preview and again on each hydrated
-  programme:
-    - "public_mode" - publicly listed and openly accessible. Proceed.
-    - Anything else (e.g. "private_mode"), or missing - treat as non-public.
-      Appearance in the catalog is necessary but not sufficient; you also
-      require corroborating evidence of admission in the hydrated
-      programme (e.g. policy_text describing the invited researcher's
-      role, scope item instructions naming participating researchers).
-      Cannot find corroboration -> reject.
-
-  Independently, scan for any signal in the hydrated programme that
-  contradicts the access assumption - policy_text declaring the programme
-  private, invitation-only, confidential, or "do not share"; scope item
-  instructions describing out-of-band approval requirements; a programme
-  name explicitly marked confidential. Any such signal means reject the
-  programme regardless of bounty, scope, or policy permissiveness. You
-  are the gate, not a Python predicate downstream of you.
+  Activate the access-authorisation skill. It carries the access
+  signal, the state-field handling, the corroboration requirements for
+  non-public programmes, and the contradicting-signal check. You are
+  the gate, not a Python predicate downstream of you.
 
 Step 1 - Survey:
 
@@ -93,25 +74,15 @@ not score):
     fuzzing, brute force, or rate testing
   - Access authorisation fails per Step 0
 
-Step 4 - Policy review (read policy_text in full for each remaining
-candidate):
-  Read carefully. You are not looking for reasons to proceed - you are
-  looking for clear permission or clear silence. If the policy is
-  ambiguous about whether automated testing is allowed, discard the
-  programme. Note any per-asset restrictions in scope item instructions
-  as well.
+Step 4 - Policy review:
+  Activate the policy-reading-discipline skill and apply it to every
+  candidate that survived Step 3. Note any per-asset restrictions in
+  scope item instructions as well.
 
-Step 5 - Score remaining candidates on:
-  1. Maximum bounty for critical/high severity (weight: 40%)
-     Adjust downward for assets whose max_severity cap is below critical.
-  2. Attack surface breadth (weight: 20%)
-     Count in-scope URL and WILDCARD assets.
-  3. Programme financial health (weight: 20%)
-     total_bounties_paid_usd signals an active, well-funded programme.
-  4. Response efficiency and speed (weight: 20%)
-     response_efficiency_pct, avg_time_to_first_response_days, and
-     avg_time_to_bounty_days combined. A programme that ignores reports
-     for months scores poorly here.
+Step 5 - Score remaining candidates:
+  Activate the programme-selection-scoring skill. It carries the
+  four-factor weighted rubric, the cap adjustment for per-asset
+  max_severity, and the tiebreak rules.
 
 Select the single highest-scoring programme that passed all filters.
 Call save_programme_tool with the chosen handle to record the selection

--- a/squad/programme_manager/select/description.md
+++ b/squad/programme_manager/select/description.md
@@ -19,8 +19,7 @@ candidate the moment you hydrate it):
   Activate the access-authorisation skill. It carries the access
   signal, the state-field handling, the corroboration requirements for
   non-public programmes, and the contradicting-signal check. You are
-  the gate. If you do not stop here, nothing further down the pipeline
-  will.
+  the gate. No other squad member will catch this if you miss it.
 
 Step 1 - Survey:
 

--- a/squad/programme_manager/select/description.md
+++ b/squad/programme_manager/select/description.md
@@ -19,7 +19,8 @@ candidate the moment you hydrate it):
   Activate the access-authorisation skill. It carries the access
   signal, the state-field handling, the corroboration requirements for
   non-public programmes, and the contradicting-signal check. You are
-  the gate, not a Python predicate downstream of you.
+  the gate. If you do not stop here, nothing further down the pipeline
+  will.
 
 Step 1 - Survey:
 

--- a/squad/programme_manager/skills/access-authorisation/SKILL.md
+++ b/squad/programme_manager/skills/access-authorisation/SKILL.md
@@ -56,4 +56,4 @@ that contradicts the access assumption:
 
 Any such signal means reject the programme regardless of bounty,
 scope, or how permissive other policy language is. You are the gate.
-If you do not stop here, nothing further down the pipeline will.
+No other squad member will catch this if you miss it.

--- a/squad/programme_manager/skills/access-authorisation/SKILL.md
+++ b/squad/programme_manager/skills/access-authorisation/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: access-authorisation
+description: How the Programme Manager establishes the squad is authorised to scan a HackerOne programme - the access signal, the state field, the corroboration requirements for non-public programmes, and the contradicting-signal check. Activate at Step 0 of programme selection and again on every hydrated candidate before scoring.
+---
+
+# Access authorisation
+
+Two H1 signals look adjacent but mean different things and must not be
+conflated:
+
+- `accepts_new_reports` answers "is the submission window open?"
+  (open vs. closed). The hard filter at selection time discards
+  closed programmes.
+- `state` answers "who is admitted to this programme?" (public vs.
+  invite-only). This skill is about that question.
+
+The HackerOne hacker API filters the catalogue by account
+authorisation - it only returns programmes accessible to the
+authenticated hacker (public programmes plus accepted private
+invitations). Appearance in `browse_programmes_tool`'s output is
+therefore the necessary precondition for any work the squad will
+perform. Treat that signal as load-bearing, not optional.
+
+## The `state` field
+
+Read `state` on every preview and again on every hydrated programme:
+
+- `"public_mode"` - publicly listed and openly accessible. Proceed.
+- Anything else (e.g. `"private_mode"`), or `state` missing or `null` -
+  treat as non-public.
+
+For a non-public programme, appearance in the catalogue is necessary
+but not sufficient. You also require **corroborating evidence of
+admission** in the hydrated programme. Acceptable corroboration
+includes:
+
+- `policy_text` that describes the invited researcher's role
+  ("invited researchers may..." or similar).
+- A scope item's `instructions` field naming participating researchers
+  or describing an out-of-band approval flow that names you.
+- A programme name that matches an invitation you (the operator) are
+  expecting.
+
+If you cannot point to corroboration, reject the programme.
+
+## The contradicting-signal check
+
+Independently of state, scan the hydrated programme for any signal
+that contradicts the access assumption:
+
+- `policy_text` declaring the programme private, invitation-only,
+  confidential, or "do not share".
+- Scope item `instructions` describing out-of-band approval
+  requirements you have not satisfied.
+- A programme name explicitly marked confidential.
+
+Any such signal means reject the programme regardless of bounty,
+scope, or how permissive other policy language is. You are the gate,
+not a Python predicate downstream of you.
+
+## Recording the basis
+
+The selected programme's `authorisation_basis` (1-2 sentences) must:
+
+1. Cite the access signal (programme returned by
+   `browse_programmes_tool`, i.e. accessible to this hacker account).
+2. Name the value of `state` and how you handled it - public_mode
+   proceeds, non-public names the corroborating evidence of admission.
+3. Confirm `policy_text` contains no contradicting private /
+   invite-only / confidential restriction.
+
+A downstream agent reading `authorisation_basis` must be able to
+satisfy themselves the squad is authorised without re-hydrating the
+programme.

--- a/squad/programme_manager/skills/access-authorisation/SKILL.md
+++ b/squad/programme_manager/skills/access-authorisation/SKILL.md
@@ -55,8 +55,8 @@ that contradicts the access assumption:
 - A programme name explicitly marked confidential.
 
 Any such signal means reject the programme regardless of bounty,
-scope, or how permissive other policy language is. You are the gate,
-not a Python predicate downstream of you.
+scope, or how permissive other policy language is. You are the gate.
+If you do not stop here, nothing further down the pipeline will.
 
 ## Recording the basis
 

--- a/squad/programme_manager/skills/access-authorisation/SKILL.md
+++ b/squad/programme_manager/skills/access-authorisation/SKILL.md
@@ -68,7 +68,3 @@ The selected programme's `authorisation_basis` (1-2 sentences) must:
    proceeds, non-public names the corroborating evidence of admission.
 3. Confirm `policy_text` contains no contradicting private /
    invite-only / confidential restriction.
-
-A downstream agent reading `authorisation_basis` must be able to
-satisfy themselves the squad is authorised without re-hydrating the
-programme.

--- a/squad/programme_manager/skills/access-authorisation/SKILL.md
+++ b/squad/programme_manager/skills/access-authorisation/SKILL.md
@@ -57,14 +57,3 @@ that contradicts the access assumption:
 Any such signal means reject the programme regardless of bounty,
 scope, or how permissive other policy language is. You are the gate.
 If you do not stop here, nothing further down the pipeline will.
-
-## Recording the basis
-
-The selected programme's `authorisation_basis` (1-2 sentences) must:
-
-1. Cite the access signal (programme returned by
-   `browse_programmes_tool`, i.e. accessible to this hacker account).
-2. Name the value of `state` and how you handled it - public_mode
-   proceeds, non-public names the corroborating evidence of admission.
-3. Confirm `policy_text` contains no contradicting private /
-   invite-only / confidential restriction.

--- a/squad/programme_manager/skills/policy-reading-discipline/SKILL.md
+++ b/squad/programme_manager/skills/policy-reading-discipline/SKILL.md
@@ -60,11 +60,3 @@ Read every shortlisted programme's per-asset instructions in addition
 to the top-level policy. A programme where the global policy is
 permissive but most assets have restrictive instructions is in
 practice a restrictive programme.
-
-## Recording the reading
-
-The `selection_rationale` must state, in 1-2 sentences, the policy
-posture of the selected programme - whether permission was explicit,
-silent-with-no-restrictions, or "policy permits X but per-asset
-instructions on Y override". A reviewer must be able to read the
-rationale and reproduce your reading without re-fetching the policy.

--- a/squad/programme_manager/skills/policy-reading-discipline/SKILL.md
+++ b/squad/programme_manager/skills/policy-reading-discipline/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: policy-reading-discipline
+description: How the Programme Manager reads a HackerOne programme's policy_text - the conservative posture, what counts as permission, what counts as prohibition, what to do with silence and ambiguity. Activate when reviewing a hydrated programme's policy for the first time, or any time policy language could be read more than one way.
+---
+
+# Policy reading discipline
+
+You read every shortlisted programme's `policy_text` in full before
+authorising any work against it. The default posture is conservative:
+you are looking for clear permission or unambiguous silence, never for
+reasons to proceed.
+
+## What counts as permission
+
+- Explicit statement that automated scanning, fuzzing, or rate-limited
+  enumeration is allowed.
+- Policy that does not mention automated activity at all *and* imposes
+  no restriction that would forbid it by implication (no "manual
+  testing only", no "do not use scanners", no per-second rate caps so
+  low that any meaningful probe violates them).
+
+## What counts as prohibition
+
+Any language that forbids:
+- Automated tools, scanners, vulnerability scanners, "automated
+  testing".
+- Brute force, credential stuffing, password spraying.
+- Fuzzing, fault injection, malformed input at scale.
+- Rate testing, denial-of-service-adjacent activity, "high-volume"
+  requests.
+- Specific tools the squad uses (nuclei, ffuf, sqlmap, nmap, gobuster,
+  feroxbuster, etc.).
+
+Any of these means the programme is disqualified for the squad. Do not
+try to argue that your probes are "lightweight enough" - that is the
+operator's call, not yours.
+
+## What counts as ambiguity
+
+If you find yourself constructing a chain of reasoning to conclude
+that a particular activity is "probably allowed" - that is ambiguity,
+and ambiguity is a reason to skip the programme, not proceed. Specific
+ambiguity patterns:
+- Policy permits "testing" without saying whether automated testing is
+  included.
+- Policy prohibits "disruptive" activity without defining disruption.
+- Per-asset instructions tighten the global policy in ways the global
+  policy does not anticipate.
+- Policy applies different rules to different asset types and the
+  squad would touch more than one type.
+
+When ambiguous, skip and move to the next candidate. The catalogue is
+big; a marginally cheaper programme is not worth a policy gamble.
+
+## Per-asset instructions
+
+A scope item's `instructions` field can tighten the global policy for
+that asset (a max request rate, a required header, a banned endpoint).
+Read every shortlisted programme's per-asset instructions in addition
+to the top-level policy. A programme where the global policy is
+permissive but most assets have restrictive instructions is in
+practice a restrictive programme.
+
+## Recording the reading
+
+The `selection_rationale` must state, in 1-2 sentences, the policy
+posture of the selected programme - whether permission was explicit,
+silent-with-no-restrictions, or "policy permits X but per-asset
+instructions on Y override". A reviewer must be able to read the
+rationale and reproduce your reading without re-fetching the policy.

--- a/squad/programme_manager/skills/programme-selection-scoring/SKILL.md
+++ b/squad/programme_manager/skills/programme-selection-scoring/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: programme-selection-scoring
+description: The weighted rubric the Programme Manager uses to rank hydrated HackerOne programmes - four factors with explicit weights, and the order in which they apply. Activate during the score-and-select step of a programme survey, after hard filters have already culled VDPs and closed programmes.
+---
+
+# Programme selection scoring
+
+You apply this rubric only to programmes that have already passed the
+hard filters (offers_bounties, accepts_new_reports, triage_active,
+policy permits automated tools, access authorisation per
+access-authorisation skill). Scoring an unqualified programme wastes
+the operator's time - it will be rejected regardless of score.
+
+## The four factors
+
+| Weight | Factor | Source field(s) |
+|---|---|---|
+| 40% | Maximum bounty for critical/high | `bounty_table` (severity -> USD max) |
+| 20% | Attack surface breadth | count of `in_scope` items where `asset_type` in {URL, WILDCARD} |
+| 20% | Programme financial health | `total_bounties_paid_usd` |
+| 20% | Response efficiency and speed | composite of `response_efficiency_pct`, `avg_time_to_first_response_days`, `avg_time_to_bounty_days` |
+
+## Applying the weights
+
+1. Compute each factor as a normalised 0-100 score across the
+   shortlisted candidates. Normalisation is relative within the
+   shortlist, not against a fixed scale - the best candidate on a
+   factor gets 100, the worst gets 0, others linearly interpolated.
+2. Adjust the bounty factor downward for assets whose `max_severity`
+   cap is below "critical" - a programme paying $20k critical but
+   capping its in-scope assets at "high" is effectively a high-bounty
+   programme, not a critical-bounty one. Use the cap-adjusted bounty
+   ceiling for normalisation.
+3. Multiply each normalised score by its weight; sum.
+4. Select the single highest-scoring programme.
+
+## Tiebreaks
+
+If two candidates land within 5 points, prefer:
+- The one with the smaller (more focused) scope - fewer assets means
+  the squad spends less attention budget triaging out-of-scope noise.
+- The one with the more recent `last_updated_at` - active maintenance
+  beats stale-but-historically-rich.
+
+## What the rationale must record
+
+`selection_rationale` is the audit trail. It must state, in order:
+- Survey filters passed to `browse_programmes_tool` and the total
+  preview count.
+- Shortlisted handles and why each was hydrated.
+- The factor scores for the winning programme and at least one
+  runner-up, so a reviewer can replay the decision.
+- The cap adjustment if any was applied.

--- a/squad/programme_manager/skills/programme-selection-scoring/SKILL.md
+++ b/squad/programme_manager/skills/programme-selection-scoring/SKILL.md
@@ -41,13 +41,3 @@ If two candidates land within 5 points, prefer:
   the squad spends less attention budget triaging out-of-scope noise.
 - The one with the more recent `last_updated_at` - active maintenance
   beats stale-but-historically-rich.
-
-## What the rationale must record
-
-`selection_rationale` is the audit trail. It must state, in order:
-- Survey filters passed to `browse_programmes_tool` and the total
-  preview count.
-- Shortlisted handles and why each was hydrated.
-- The factor scores for the winning programme and at least one
-  runner-up, so a reviewer can replay the decision.
-- The cap adjustment if any was applied.

--- a/squad/skills/scope-discipline/SKILL.md
+++ b/squad/skills/scope-discipline/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: scope-discipline
+description: Restates the cybersquad's hard scope and authorisation rules in language every agent must operate under - what is in scope, what is never in scope, and when to stop. Activate whenever an agent is about to pick a target, plan an attack, run a probe, or write a report against a HackerOne programme.
+---
+
+# Scope discipline
+
+This skill is a restatement of the safety invariants enforced in code
+(`tools/recon/scope.py` and the H1 programme-detail loader). Skills do
+not relax invariants - they remind you what the code already refuses to
+let you do, so your reasoning stays inside the same boundary.
+
+## Authorisation is binary
+
+A target is either authorised or it is not. There is no "probably fine"
+column. The Programme Manager records `authorisation_basis` for the
+selected programme; every downstream agent operates strictly within
+that basis. If your reasoning reaches a target that is not covered by
+that basis, the answer is to stop, not to expand the basis.
+
+## In scope means in the hydrated programme
+
+The only targets you may touch are assets listed in the selected
+programme's structured scope (`in_scope`), filtered to those marked
+`eligible_for_bounty`. WILDCARD assets cover their subdomains; URL
+assets cover only the exact host. If you cannot point to the scope row
+that authorises a request, do not make the request.
+
+## Programme policy outranks your plan
+
+If the programme's `policy_text` prohibits an activity (automated
+scanning, brute force, fuzzing, rate testing, social engineering,
+denial of service, physical attacks, anything else), that prohibition
+is final. It does not matter how interesting the finding would be. The
+PM should have filtered programmes that forbid your toolkit at
+selection time; if you encounter a prohibition mid-run, treat it as a
+selection bug and stop, do not try to work around it.
+
+## Per-asset caps are real
+
+Scope items carry `max_severity`. An asset capped at "medium" is not a
+critical-bounty target even if the underlying bug would otherwise be
+critical - the programme has declared in advance what it will pay.
+Factor the cap into expected value before spending squad time.
+
+## Stop signals
+
+Stop and surface to the operator (do not silently continue) when:
+- A target you were about to touch is not in the hydrated `in_scope`.
+- Policy_text or scope-item instructions contradict the activity you
+  were about to perform.
+- The programme is in any non-public access state and you cannot point
+  to corroborating evidence of admission.
+- A probe response indicates the service is rate-limiting, returning
+  WAF challenges, or otherwise asking you to slow down or stop.
+
+Surfacing is a positive action. The squad would rather pause and
+re-authorise than burn the operator's relationship with the programme.

--- a/squad/skills/scope-discipline/SKILL.md
+++ b/squad/skills/scope-discipline/SKILL.md
@@ -1,14 +1,12 @@
 ---
 name: scope-discipline
-description: Restates the cybersquad's hard scope and authorisation rules in language every agent must operate under - what is in scope, what is never in scope, and when to stop. Activate whenever an agent is about to pick a target, plan an attack, run a probe, or write a report against a HackerOne programme.
+description: The hard scope and authorisation rules the whole squad operates under - what is in scope, what is never in scope, and when to stop. Apply before picking a target, planning an attack, running a probe, or writing a report against a HackerOne programme.
 ---
 
 # Scope discipline
 
-This skill is a restatement of the safety invariants enforced in code
-(`tools/recon/scope.py` and the H1 programme-detail loader). Skills do
-not relax invariants - they remind you what the code already refuses to
-let you do, so your reasoning stays inside the same boundary.
+These rules are not relaxable. Your reasoning stays inside them; if a
+plan reaches outside them, the plan is wrong, not the rules.
 
 ## Authorisation is binary
 

--- a/squad/technical_author/__init__.py
+++ b/squad/technical_author/__init__.py
@@ -205,7 +205,6 @@ def finalise_reports_tool(
 
 
 MEMBER = SquadMember(
-    slug="technical_author",
     dir=Path(__file__).parent,
     tools=[
         draft_report_tool,

--- a/squad/vulnerability_researcher/__init__.py
+++ b/squad/vulnerability_researcher/__init__.py
@@ -399,7 +399,6 @@ def _load_programme(programme_handle: str | None) -> Programme:
 
 
 MEMBER = SquadMember(
-    slug="vulnerability_researcher",
     dir=Path(__file__).parent,
     tools=[
         # Research task

--- a/tasks.py
+++ b/tasks.py
@@ -12,7 +12,7 @@ Set CYBERSQUAD_HUMAN_INPUT=false to disable all gates for unattended runs.
 
 from __future__ import annotations
 
-from crewai import Task
+from crewai import Agent, Task
 
 from config import config
 from squad import build_task
@@ -24,7 +24,7 @@ from squad.technical_author import MEMBER as TECHNICAL_AUTHOR
 from squad.vulnerability_researcher import MEMBER as VULNERABILITY_RESEARCHER
 
 
-def build_tasks(agents: dict) -> list[Task]:
+def build_tasks(agents: dict[str, Agent]) -> list[Task]:
     hi = config.human_input
 
     select = build_task("select", PROGRAMME_MANAGER, agents["programme_manager"], human_input=hi)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,53 @@ import pytest
 pytestmark = pytest.mark.unit
 
 
+class TestLLMConfig:
+    def test_reasoning_enabled_default_on(self, monkeypatch):
+        monkeypatch.delenv("CREWAI_REASONING_ENABLED", raising=False)
+        from config import LLMConfig
+
+        c = LLMConfig()
+        assert c.reasoning_enabled is True
+        assert c.reasoning_effort == "medium"
+
+    def test_reasoning_disabled_via_env(self, monkeypatch):
+        monkeypatch.setenv("CREWAI_REASONING_ENABLED", "false")
+        from config import LLMConfig
+
+        c = LLMConfig()
+        assert c.reasoning_enabled is False
+
+    def test_reasoning_effort_override(self, monkeypatch):
+        monkeypatch.setenv("CREWAI_REASONING_EFFORT", "high")
+        from config import LLMConfig
+
+        c = LLMConfig()
+        assert c.reasoning_effort == "high"
+
+
+class TestMemoryConfig:
+    def test_long_term_disabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("CREWAI_MEMORY_LONG_TERM_ENABLED", raising=False)
+        from config import MemoryConfig
+
+        c = MemoryConfig()
+        assert c.long_term_enabled is False
+
+    def test_long_term_enabled_via_env(self, monkeypatch):
+        monkeypatch.setenv("CREWAI_MEMORY_LONG_TERM_ENABLED", "true")
+        from config import MemoryConfig
+
+        c = MemoryConfig()
+        assert c.long_term_enabled is True
+
+    def test_storage_path_default_is_project_scoped(self, monkeypatch):
+        monkeypatch.delenv("CREWAI_MEMORY_STORAGE", raising=False)
+        from config import MemoryConfig
+
+        c = MemoryConfig()
+        assert c.storage_path == ".cybersquad/memory"
+
+
 class TestH1Config:
     def test_reads_api_credentials_from_env(self, monkeypatch):
         monkeypatch.setenv("H1_API_USERNAME", "testuser")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,30 +9,6 @@ import pytest
 pytestmark = pytest.mark.unit
 
 
-class TestLLMConfig:
-    def test_reasoning_enabled_default_on(self, monkeypatch):
-        monkeypatch.delenv("CREWAI_REASONING_ENABLED", raising=False)
-        from config import LLMConfig
-
-        c = LLMConfig()
-        assert c.reasoning_enabled is True
-        assert c.reasoning_effort == "medium"
-
-    def test_reasoning_disabled_via_env(self, monkeypatch):
-        monkeypatch.setenv("CREWAI_REASONING_ENABLED", "false")
-        from config import LLMConfig
-
-        c = LLMConfig()
-        assert c.reasoning_enabled is False
-
-    def test_reasoning_effort_override(self, monkeypatch):
-        monkeypatch.setenv("CREWAI_REASONING_EFFORT", "high")
-        from config import LLMConfig
-
-        c = LLMConfig()
-        assert c.reasoning_effort == "high"
-
-
 class TestMemoryConfig:
     def test_long_term_disabled_by_default(self, monkeypatch):
         monkeypatch.delenv("CREWAI_MEMORY_LONG_TERM_ENABLED", raising=False)
@@ -103,6 +79,29 @@ class TestLLMConfig:
 
         c = LLMConfig()
         assert c.temperature == 0.7
+
+    def test_reasoning_enabled_default_on(self, monkeypatch):
+        monkeypatch.delenv("CREWAI_REASONING_ENABLED", raising=False)
+        monkeypatch.delenv("CREWAI_REASONING_EFFORT", raising=False)
+        from config import LLMConfig
+
+        c = LLMConfig()
+        assert c.reasoning_enabled is True
+        assert c.reasoning_effort == "medium"
+
+    def test_reasoning_disabled_via_env(self, monkeypatch):
+        monkeypatch.setenv("CREWAI_REASONING_ENABLED", "false")
+        from config import LLMConfig
+
+        c = LLMConfig()
+        assert c.reasoning_enabled is False
+
+    def test_reasoning_effort_override(self, monkeypatch):
+        monkeypatch.setenv("CREWAI_REASONING_EFFORT", "high")
+        from config import LLMConfig
+
+        c = LLMConfig()
+        assert c.reasoning_effort == "high"
 
 
 class TestScanConfig:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -103,6 +103,13 @@ class TestLLMConfig:
         c = LLMConfig()
         assert c.reasoning_effort == "high"
 
+    def test_reasoning_effort_rejects_unknown_value(self, monkeypatch):
+        monkeypatch.setenv("CREWAI_REASONING_EFFORT", "extreme")
+        from config import LLMConfig
+
+        with pytest.raises(ValueError, match="CREWAI_REASONING_EFFORT must be one of"):
+            LLMConfig()
+
 
 class TestScanConfig:
     def test_defaults(self, monkeypatch):

--- a/tests/test_squad_skills.py
+++ b/tests/test_squad_skills.py
@@ -1,0 +1,72 @@
+"""
+tests/test_squad_skills.py - filesystem-level checks on the runtime skill
+catalogue (issue #62).
+
+The crewai.skills loader is responsible for parsing SKILL.md frontmatter and
+attaching skills to agents. These tests assert the contract from the cybersquad
+side: the expected skill directories exist, each one has a SKILL.md, and the
+frontmatter name matches the directory name (the loader uses the name field as
+the skill identifier downstream).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from squad import SQUAD_SKILLS_DIR
+from squad.programme_manager import MEMBER as PROGRAMME_MANAGER
+
+pytestmark = pytest.mark.unit
+
+# Per crewai.skills.SkillFrontmatter: lowercase alphanumeric + hyphens, 1-64.
+NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+
+
+def _frontmatter_name(skill_md: Path) -> str:
+    """Pull the `name:` value out of a SKILL.md frontmatter block."""
+    text = skill_md.read_text(encoding="utf-8")
+    head, _, _ = text.partition("\n---\n")
+    head = head.removeprefix("---\n")
+    for line in head.splitlines():
+        if line.startswith("name:"):
+            return line.split(":", 1)[1].strip()
+    raise AssertionError(f"{skill_md} has no `name:` in frontmatter")
+
+
+class TestSquadWideSkills:
+    def test_skills_dir_exists(self) -> None:
+        assert SQUAD_SKILLS_DIR.is_dir(), SQUAD_SKILLS_DIR
+
+    def test_scope_discipline_skill_present(self) -> None:
+        skill_md = SQUAD_SKILLS_DIR / "scope-discipline" / "SKILL.md"
+        assert skill_md.is_file()
+        assert _frontmatter_name(skill_md) == "scope-discipline"
+
+
+class TestProgrammeManagerSkills:
+    EXPECTED = {
+        "programme-selection-scoring",
+        "policy-reading-discipline",
+        "access-authorisation",
+    }
+
+    def test_skills_dir_exists(self) -> None:
+        assert PROGRAMME_MANAGER.skills_dir.is_dir()
+
+    def test_expected_skills_present(self) -> None:
+        found = {
+            child.name
+            for child in PROGRAMME_MANAGER.skills_dir.iterdir()
+            if child.is_dir() and (child / "SKILL.md").is_file()
+        }
+        assert self.EXPECTED.issubset(found), found
+
+    @pytest.mark.parametrize("slug", sorted(EXPECTED))
+    def test_skill_frontmatter_name_matches_dir(self, slug: str) -> None:
+        skill_md = PROGRAMME_MANAGER.skills_dir / slug / "SKILL.md"
+        name = _frontmatter_name(skill_md)
+        assert name == slug, (name, slug)
+        assert NAME_RE.match(name), name

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -57,7 +57,7 @@ class TestSquadMemberRead:
                 assert "---" not in value, f"{member.slug}/{name}.md still contains '---'"
 
     def test_missing_file_raises(self, tmp_path) -> None:
-        member = SquadMember(slug="missing", dir=tmp_path, tools=[])
+        member = SquadMember(dir=tmp_path, tools=[])
         with pytest.raises(FileNotFoundError):
             member.read("role")
 


### PR DESCRIPTION
## What this lands

Wires CrewAI's native `crewai.skills` loader into the squad so runtime expertise is structured the same way the contributor side already is: SKILL.md with frontmatter, three-tier progressive disclosure (METADATA -> INSTRUCTIONS -> RESOURCES), rendered into the system prompt agent-side. No RAG, no embedder, no ChromaDB - the framework ships exactly what #62 was asking for.

Adds two config dials alongside the loader so they ride together: extended thinking on by default, long-term memory plumbed but off by default. Both feed downstream features (PM avoidance, DC disclosure tracking) that land in follow-ups.

## Skills (the #62 core)

Layout:

```
squad/skills/<name>/SKILL.md            - attached to every agent via Crew(skills=...)
squad/<member>/skills/<name>/SKILL.md   - attached to that member via Agent(skills=...)
```

Pilot: Programme Manager. Three specialist skills extracted from `backstory.md` and `select/description.md`:

- `programme-selection-scoring` (4-factor weighted rubric)
- `policy-reading-discipline` (conservative reading posture)
- `access-authorisation` (state + corroboration check)

One squad-wide skill seeded so the crew-level loader path is exercised:

- `scope-discipline` (restates safety invariants)

`backstory.md` shrinks 83 -> 54 lines (-35%); `select/description.md` shrinks 122 -> 93 lines (-24%). Skills restate safety invariants enforced in code (`tools/recon/scope.py`, `h1_api.parse_programme`); they never relax them.

## Config dials

| Env var | Default | What it does |
|---|---|---|
| `CREWAI_REASONING_ENABLED` | `true` | Forwards `reasoning_effort` to `crewai.LLM(...)` so the squad gets Anthropic extended thinking via litellm. |
| `CREWAI_REASONING_EFFORT` | `medium` | Effort level when enabled; matches CrewAI's "none" / "low" / "medium" / "high". |
| `CREWAI_MEMORY_LONG_TERM_ENABLED` | `false` | When flipped, `_build_long_term_memory()` constructs a LanceDB-backed `Memory(root_scope="/long_term")` and passes it to `Crew(memory=...)`. |
| `CREWAI_MEMORY_STORAGE` | `.cybersquad/memory` | Project-scoped storage path (not CrewAI's user-global `~/.crewai/...` default). |

`_build_llm()` still constructs `crewai.LLM(...)` explicitly with model/temperature/max_tokens (per the `cybersquad-agent-llm` skill); reasoning_effort is added conditionally. Operator override for memory: delete the storage path and flip the env var off.

## Supporting refactors (came up while writing the above)

- `build_crew` now annotates its intermediates honestly: `agents_by_slug: dict[str, Agent]`, `agents: list[Agent]`, `tasks: list[Task]`, `memory: Memory | None`. The `list[Agent]` was hiding inside `list(agents.values())`.
- `build_tasks` tightened from `agents: dict` to `agents: dict[str, Agent]`.
- `SquadMember.slug` is now a `@property` derived from `dir.name` - the field was repeated in every MEMBER declaration and had to match `dir.name` by construction. Six redundant kwargs trimmed.

## Dependency bumps

`crewai[anthropic]>=0.80.0` -> `>=1.14.0`. **Substantial jump** - the skills system and the unified `crewai.memory.memory.Memory` API are 1.x features. CI passes ruff and is one mypy hop away from the pre-existing baseline; run the full suite locally before merging in case anything else in the squad code depends on intervening API.

## Out of scope (tracked separately)

- Other squad members beyond PM. Roll out once the pilot is validated.
- PM avoidance of recently-exhausted programmes (60-day cooldown). Uses the long-term memory substrate this PR lays down.
- DC waiting for disclosure agreement. Same substrate, separate state machine.
- Pentest probe `args_schema` rollout - #143.
- Tightening the workspace handoff (the "rustic" file-passing) - separate concern from skills/memory.

## Acceptance criteria for #62 (pilot scope)

- [x] `squad/skills/` and `squad/<member>/skills/` exist with SKILL.md each
- [x] Pilot agent's prose shrinks measurably (35% / 24%)
- [x] Safety invariants stay enforced in code; skills only restate them
- [ ] Pipeline run with the pilot showing no regression in selection/output quality and measurable token drop - deferred per "ship the refactor, measure later"