### PR TITLE
refactor(squad): typed pydantic returns for every @tool wrapper (#139)

### DIFF
--- a/.claude/skills/cybersquad-pentest-tool/SKILL.md
+++ b/.claude/skills/cybersquad-pentest-tool/SKILL.md
@@ -80,10 +80,10 @@ In `squad/penetration_tester/__init__.py`, use `@pentest_tool` (not bare `@tool`
 ```python
 @pentest_tool("SSRF Probe", check_fn=check_ssrf)
 def ssrf_probe_tool(
-    endpoints_json: str,
+    endpoints: list[Endpoint],
     payloads: list[SsrfPayload] | None = None,
 ) -> list[RawFinding]:
-    return list(check_ssrf(_parse_endpoints(endpoints_json), payloads))
+    return list(check_ssrf(_parse_endpoints(endpoints), payloads))
 ```
 
 4. Document each variant in the docstring so the agent knows when to pick a subset. Include what the variant targets, when it is useful, and the request-cost implication of narrowing.

--- a/.claude/skills/cybersquad-tool/SKILL.md
+++ b/.claude/skills/cybersquad-tool/SKILL.md
@@ -16,8 +16,8 @@ def read_attack_plan_tool() -> AttackPlan:
     return load_attack_plan(attack_plan_path())
 
 @tool("Reflected XSS Probe")
-def xss_probe_tool(endpoints_json: str) -> list[RawFinding]:
-    return list(check_reflected_xss(_parse_endpoints(endpoints_json)))
+def xss_probe_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
+    return list(check_reflected_xss(_parse_endpoints(endpoints)))
 ```
 
 ```python
@@ -40,7 +40,7 @@ Never `dict`, `list[dict]`, or bare `list` (no inner type). CrewAI serialises py
 # correct
 @pentest_tool("SSRF Probe", check_fn=check_ssrf)
 def ssrf_probe_tool(
-    endpoints_json: str,
+    endpoints: list[Endpoint],
     payloads: list[SsrfPayload] | None = None,
 ) -> list[RawFinding]:
     ...
@@ -48,10 +48,10 @@ def ssrf_probe_tool(
 
 ```python
 # wrong - the agent has no idea what strings are valid
-def ssrf_probe_tool(endpoints_json: str, payloads: list[str] | None = None) -> ...:
+def ssrf_probe_tool(endpoints: list[Endpoint], payloads: list[str] | None = None) -> ...:
 ```
 
-The `endpoints_json: str` pattern exists because CrewAI's tool-call protocol cannot pass arbitrary pydantic objects in - the wrapper takes the JSON-encoded form and unmarshals via `_parse_endpoints`. That is the only acceptable use of a bare `str` parameter for structured data; everywhere else, use the typed shape.
+The legacy `endpoints_json: str` pattern was retired in #139 once CrewAI's args-schema validation grew up enough to accept `list[<Model>]` directly. Today the LLM-side wire format is still JSON, but `args_schema.model_validate(kwargs).model_dump()` happens inside CrewAI before the function is called, so the wrapper just receives `list[dict]` and re-validates via `_parse_endpoints`. The agent sees a typed Endpoint schema instead of "pass a JSON string" - never reintroduce the JSON-string parameter for structured data.
 
 ## Workspace artifacts: writer and reader ship together
 
@@ -72,7 +72,7 @@ The reader returns the typed model; downstream agents work against the schema, n
 
 ## The `SquadMember.tools` registry
 
-Today `SquadMember.tools` is typed `list[Any]` because the local `_PentestTool` / `_ResearchBriefTool` Protocols do not share a base. That is being tightened in a follow-up (define a `CrewAITool` Protocol once, retype the registry). When that lands, the contract test that walks `MEMBER.tools` and asserts return-type annotations will be the mechanical enforcement of this skill - skill stays in AI context, test stays in CI.
+`SquadMember.tools` is typed `list[CrewAITool]` (the `CrewAITool` Protocol in `squad/__init__.py`). The local `_PentestTool` / `_ResearchBriefTool` Protocols inherit from it, so the registry is properly typed end-to-end. The contract test in `tests/test_squad_tool_contracts.py` walks every `MEMBER.tools` entry and asserts return-type annotations - skill stays in AI context, test stays in CI.
 
 ## Anti-patterns to catch
 

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -165,6 +165,89 @@ class ReconResult(BaseModel):
     completed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
 
+# Workspace artefacts (shared @tool wrapper return shapes)
+
+
+class RunFile(BaseModel):
+    """One file in the per-run shared workspace."""
+
+    name: str  # path relative to the run directory
+    size_bytes: int
+
+
+class RunFileContent(BaseModel):
+    """The full contents of one run-directory file."""
+
+    name: str
+    size_bytes: int
+    content: str
+
+
+# Recon-derived tool return shapes
+
+
+class OpenPortsMap(BaseModel):
+    """The recon-derived port map keyed by host.
+
+    Lives as its own model rather than ``dict[str, list[int]]`` so the
+    Penetration Tester sees a documented shape it can pattern-match on
+    when deciding which port-specific probes to run.
+    """
+
+    hosts: dict[str, list[int]] = Field(default_factory=dict)
+
+
+class LlmEndpoint(BaseModel):
+    """An endpoint flagged as LLM-backed by ``detect_llm_endpoints``.
+
+    A thin wrapper over ``Endpoint`` so the OSINT Analyst tool surface
+    carries the LLM-detection intent at the type level (the field set is
+    identical, but the model name marks the contract).
+    """
+
+    url: str
+    status_code: int | None = None
+    technologies: list[str] = Field(default_factory=list)
+    parameters: list[str] = Field(default_factory=list)
+
+
+# Triage / report / OSINT tool return shapes
+#
+# These wrap a workspace path plus the validation report produced by the
+# underlying tool. Keeping the path and the validation grouped on the same
+# model means the agent does not have to guess which keys to read on a
+# bare dict.
+
+
+class RawFindingSummary(BaseModel):
+    """Compact summary of one raw finding, returned by List Raw Findings."""
+
+    index: int
+    title: str
+    vuln_class: str
+    target: str
+    severity_hint: Severity
+    evidence_bytes: int
+
+
+class ProgrammeReportSummary(BaseModel):
+    """Compact summary of one HackerOne report listed against a programme."""
+
+    report_id: str | None = None
+    title: str | None = None
+    severity: str | None = None
+    state: str | None = None
+
+
+class CveEntry(BaseModel):
+    """One NVD CVE record, returned by NVD CVE Lookup."""
+
+    id: str
+    cvss_score: float | None = None
+    cvss_vector: str | None = None
+    description: str = ""
+
+
 # Operational metrics (emitted after every pipeline run)
 
 

--- a/squad/__init__.py
+++ b/squad/__init__.py
@@ -30,7 +30,7 @@ import functools
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import Protocol, TypeVar, runtime_checkable
 
 from crewai import Agent, Task
 from crewai.tools import tool
@@ -45,6 +45,32 @@ from squad.workspace_tools import (
 R = TypeVar("R")
 
 SQUAD_SKILLS_DIR = Path(__file__).parent / "skills"
+
+
+@runtime_checkable
+class CrewAITool(Protocol):
+    """The shape every ``MEMBER.tools`` entry conforms to.
+
+    The decorators in use - the bare ``@tool``, ``@pentest_tool``,
+    ``@research_brief_tool``, ``@cached_tool`` - all produce CrewAI ``Tool``
+    instances that carry ``name``, ``description``, and ``func``. This
+    Protocol is the single shared surface those decorators expose, so the
+    registry can be ``list[CrewAITool]`` rather than ``list[Any]`` and the
+    contract test in ``tests/test_squad_tool_contracts.py`` has a typed
+    handle to walk.
+
+    ``func`` is declared via ``@property`` (rather than as a plain class
+    attribute) so the Protocol is satisfied by CrewAI's ``Tool`` model -
+    its ``func`` field is typed ``Callable[P, R | Awaitable[R]]`` for the
+    concrete wrapped function and would otherwise fail Protocol variance
+    against ``Callable[..., object]``.
+    """
+
+    name: str
+    description: str
+
+    @property
+    def func(self) -> Callable[..., object]: ...
 
 
 def cached_tool(name: str) -> Callable[[Callable[..., R]], Tool[..., R]]:
@@ -78,7 +104,7 @@ class SquadMember:
     """
 
     dir: Path
-    tools: list[Any] = field(default_factory=list)
+    tools: list[CrewAITool] = field(default_factory=list)
 
     @property
     def slug(self) -> str:
@@ -142,6 +168,7 @@ def build_task(
 
 
 __all__ = [
+    "CrewAITool",
     "SquadMember",
     "build_agent",
     "build_task",

--- a/squad/__init__.py
+++ b/squad/__init__.py
@@ -26,23 +26,18 @@ Assembly (LLM wiring, pipeline order, approval gates) lives in crew.py / tasks.p
 
 from __future__ import annotations
 
-import functools
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Protocol, TypeVar, runtime_checkable
+from typing import Protocol, runtime_checkable
 
 from crewai import Agent, Task
-from crewai.tools import tool
-from crewai.tools.base_tool import Tool
 
 from squad.workspace_tools import (
     read_attack_plan_tool,
     read_run_file_tool,
     read_run_filelist_tool,
 )
-
-R = TypeVar("R")
 
 SQUAD_SKILLS_DIR = Path(__file__).parent / "skills"
 
@@ -52,12 +47,11 @@ class CrewAITool(Protocol):
     """The shape every ``MEMBER.tools`` entry conforms to.
 
     The decorators in use - the bare ``@tool``, ``@pentest_tool``,
-    ``@research_brief_tool``, ``@cached_tool`` - all produce CrewAI ``Tool``
-    instances that carry ``name``, ``description``, and ``func``. This
-    Protocol is the single shared surface those decorators expose, so the
-    registry can be ``list[CrewAITool]`` rather than ``list[Any]`` and the
-    contract test in ``tests/test_squad_tool_contracts.py`` has a typed
-    handle to walk.
+    ``@research_brief_tool`` - all produce CrewAI ``Tool`` instances that
+    carry ``name``, ``description``, and ``func``. This Protocol is the
+    single shared surface those decorators expose, so the registry can be
+    ``list[CrewAITool]`` rather than ``list[Any]`` and the contract test in
+    ``tests/test_squad_tool_contracts.py`` has a typed handle to walk.
 
     ``func`` is declared via ``@property`` (rather than as a plain class
     attribute) so the Protocol is satisfied by CrewAI's ``Tool`` model -
@@ -71,27 +65,6 @@ class CrewAITool(Protocol):
 
     @property
     def func(self) -> Callable[..., object]: ...
-
-
-def cached_tool(name: str) -> Callable[[Callable[..., R]], Tool[..., R]]:
-    """Drop-in replacement for ``@tool`` for deterministic data lookups.
-
-    Wraps the underlying function in ``functools.cache`` so repeated calls
-    with the same arguments skip recomputation, then registers it as a
-    CrewAI tool. Use this for pure functions whose return depends only on
-    their arguments and never mutates state (the CWE / OWASP cheat-sheet
-    lookups are the canonical case). Do not apply to tools that hit the
-    network, read or write the workspace, or otherwise depend on time-
-    varying state - those would silently return stale results.
-
-    The cache lives on the Tool's ``.func`` attribute and can be cleared
-    via ``tool_obj.func.cache_clear()``.
-    """
-
-    def decorator(fn: Callable[..., R]) -> Tool[..., R]:
-        return tool(name)(functools.cache(fn))
-
-    return decorator
 
 
 @dataclass(frozen=True)
@@ -172,7 +145,6 @@ __all__ = [
     "SquadMember",
     "build_agent",
     "build_task",
-    "cached_tool",
     "read_attack_plan_tool",
     "read_run_filelist_tool",
     "read_run_file_tool",

--- a/squad/__init__.py
+++ b/squad/__init__.py
@@ -26,11 +26,15 @@ Assembly (LLM wiring, pipeline order, approval gates) lives in crew.py / tasks.p
 
 from __future__ import annotations
 
+import functools
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 from crewai import Agent, Task
+from crewai.tools import tool
+from crewai.tools.base_tool import Tool
 
 from squad.workspace_tools import (
     read_attack_plan_tool,
@@ -38,7 +42,30 @@ from squad.workspace_tools import (
     read_run_filelist_tool,
 )
 
+R = TypeVar("R")
+
 SQUAD_SKILLS_DIR = Path(__file__).parent / "skills"
+
+
+def cached_tool(name: str) -> Callable[[Callable[..., R]], Tool[..., R]]:
+    """Drop-in replacement for ``@tool`` for deterministic data lookups.
+
+    Wraps the underlying function in ``functools.cache`` so repeated calls
+    with the same arguments skip recomputation, then registers it as a
+    CrewAI tool. Use this for pure functions whose return depends only on
+    their arguments and never mutates state (the CWE / OWASP cheat-sheet
+    lookups are the canonical case). Do not apply to tools that hit the
+    network, read or write the workspace, or otherwise depend on time-
+    varying state - those would silently return stale results.
+
+    The cache lives on the Tool's ``.func`` attribute and can be cleared
+    via ``tool_obj.func.cache_clear()``.
+    """
+
+    def decorator(fn: Callable[..., R]) -> Tool[..., R]:
+        return tool(name)(functools.cache(fn))
+
+    return decorator
 
 
 @dataclass(frozen=True)
@@ -118,6 +145,7 @@ __all__ = [
     "SquadMember",
     "build_agent",
     "build_task",
+    "cached_tool",
     "read_attack_plan_tool",
     "read_run_filelist_tool",
     "read_run_file_tool",

--- a/squad/disclosure_coordinator/__init__.py
+++ b/squad/disclosure_coordinator/__init__.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 from crewai.tools import tool
 
+from models import ProgrammeReportSummary
+from models.h1 import DisclosureReport, SubmissionResult
 from squad import SquadMember, read_run_file_tool, read_run_filelist_tool
 from tools import http
 from tools.h1_api import h1
@@ -13,19 +15,16 @@ from tools.report_tools import save_report
 
 
 @tool("Submit Report")
-def submit_report_tool(report_json: str) -> dict:
+def submit_report_tool(report_json: str) -> SubmissionResult:
     """Submit a serialised DisclosureReport to HackerOne."""
-    from models.h1 import DisclosureReport
-
     report = DisclosureReport.model_validate_json(report_json)
     http.set_programme(report.programme_handle)
     save_report(report)
-    result = h1.submit_report(report)
-    return result.model_dump()
+    return h1.submit_report(report)
 
 
 @tool("Check H1 Duplicate")
-def check_duplicate_tool(programme_handle: str, title: str) -> list[dict]:
+def check_duplicate_tool(programme_handle: str, title: str) -> list[ProgrammeReportSummary]:
     """
     Last-chance duplicate check before submission. Lists recent reports on this
     programme whose titles resemble the given title. A match means another
@@ -35,11 +34,11 @@ def check_duplicate_tool(programme_handle: str, title: str) -> list[dict]:
     reports = h1.list_reports(programme_handle, page_size=25)
     title_lower = title.lower()
     return [
-        {
-            "report_id": r.get("id"),
-            "title": r.get("attributes", {}).get("title"),
-            "state": r.get("attributes", {}).get("state"),
-        }
+        ProgrammeReportSummary(
+            report_id=r.get("id"),
+            title=r.get("attributes", {}).get("title"),
+            state=r.get("attributes", {}).get("state"),
+        )
         for r in reports
         if title_lower[:30] in (r.get("attributes", {}).get("title") or "").lower()
     ]

--- a/squad/osint_analyst/__init__.py
+++ b/squad/osint_analyst/__init__.py
@@ -18,7 +18,7 @@ from models import (
     OpenPortsMap,
 )
 from models.h1 import Programme
-from squad import SquadMember, cached_tool, read_run_file_tool, read_run_filelist_tool
+from squad import SquadMember, read_run_file_tool, read_run_filelist_tool
 from tools import http
 from tools.cwe_data import CWEEntry
 from tools.cwe_data import lookup as cwe_lookup
@@ -214,7 +214,7 @@ def detect_takeover_candidates_tool(
     return list(detect_takeover_candidates(in_scope))
 
 
-@cached_tool("Lookup CWE")
+@tool("Lookup CWE")
 def lookup_cwe_tool(query: str) -> list[CWEEntry]:
     """
     Find Common Weakness Enumeration entries that match a query - useful
@@ -226,7 +226,7 @@ def lookup_cwe_tool(query: str) -> list[CWEEntry]:
     return list(cwe_lookup(query))
 
 
-@cached_tool("Lookup OWASP Guidance")
+@tool("Lookup OWASP Guidance")
 def lookup_owasp_tool(query: str) -> list[OWASPEntry]:
     """
     Find OWASP Cheat Sheet entries for a vuln class or topic - hint for

--- a/squad/osint_analyst/__init__.py
+++ b/squad/osint_analyst/__init__.py
@@ -8,11 +8,23 @@ from pathlib import Path
 from crewai.tools import tool
 
 import runtime
-from models import Endpoint, HostInsight, HostPriority, HostRole
+from models import (
+    Endpoint,
+    EndpointPage,
+    HostInsight,
+    HostPriority,
+    HostRole,
+    LlmEndpoint,
+    OpenPortsMap,
+)
 from models.h1 import Programme
-from squad import SquadMember, read_run_file_tool, read_run_filelist_tool
-from tools import cwe_data, http, owasp_data
+from squad import SquadMember, cached_tool, read_run_file_tool, read_run_filelist_tool
+from tools import http
+from tools.cwe_data import CWEEntry
+from tools.cwe_data import lookup as cwe_lookup
 from tools.h1_api import h1
+from tools.owasp_data import OWASPEntry
+from tools.owasp_data import lookup as owasp_lookup
 from tools.recon import (
     cert_transparency,
     detect_llm_endpoints,
@@ -21,9 +33,11 @@ from tools.recon import (
     run_recon,
 )
 from tools.recon import probe_endpoints as probe_endpoints_impl
+from tools.recon.dnsx import TakeoverCandidate
 from tools.recon.query import recon_endpoints, recon_open_ports, recon_subdomains
 from tools.recon.scope import filter_in_scope as filter_in_scope_impl
 from tools.recon_insights import (
+    HostAnnotation,
     ReconFinalisationError,
     finalise_recon,
     save_insight,
@@ -64,7 +78,9 @@ def run_initial_sweep_tool(programme_handle: str) -> str:
 
 
 @tool("Recon Subdomains")
-def recon_subdomains_tool(sweep_path: str = "sweep.json", host_filter: str | None = None) -> list:
+def recon_subdomains_tool(
+    sweep_path: str = "sweep.json", host_filter: str | None = None
+) -> list[str]:
     """
     Return the in-scope subdomains in the OA's draft sweep. ``host_filter`` is
     a case-insensitive substring (e.g. "api" returns every subdomain
@@ -82,7 +98,7 @@ def recon_endpoints_tool(
     host_contains: str | None = None,
     offset: int = 0,
     limit: int = 50,
-) -> dict:
+) -> EndpointPage:
     """
     Return a paginated slice of endpoints from the sweep matching the given
     filters (conjunctive). ``tech`` matches case-insensitively as a
@@ -97,18 +113,18 @@ def recon_endpoints_tool(
         host_contains=host_contains,
         offset=offset,
         limit=limit,
-    ).model_dump(mode="json")
+    )
 
 
 @tool("Recon Open Ports")
-def recon_open_ports_tool(sweep_path: str = "sweep.json", host: str | None = None) -> dict:
+def recon_open_ports_tool(sweep_path: str = "sweep.json", host: str | None = None) -> OpenPortsMap:
     """
     Return the open-port map per host from the sweep. Passing a ``host``
     restricts the result to that single host. Use to surface non-HTTP
     services (Redis 6379, Elasticsearch 9200, Mongo 27017, etc.) that an
     annotation should call out.
     """
-    return recon_open_ports(sweep_path, host=host)
+    return OpenPortsMap(hosts=recon_open_ports(sweep_path, host=host))
 
 
 @tool("Certificate Transparency Lookup")
@@ -132,7 +148,7 @@ def historical_urls_tool(domain: str) -> list[str]:
 
 
 @tool("LLM Endpoint Detection")
-def llm_detection_tool(endpoints_json: str) -> list[dict]:
+def llm_detection_tool(endpoints_json: str) -> list[LlmEndpoint]:
     """
     Scan a set of live endpoints for signals that they are backed by an LLM
     or AI assistant (URL path heuristics, OpenAI-format response keys,
@@ -142,11 +158,11 @@ def llm_detection_tool(endpoints_json: str) -> list[dict]:
     Tester at prompt-injection probes.
     """
     endpoints = [Endpoint.model_validate(e) for e in json.loads(endpoints_json)]
-    return [ep.model_dump() for ep in detect_llm_endpoints(endpoints)]
+    return [LlmEndpoint.model_validate(ep.model_dump()) for ep in detect_llm_endpoints(endpoints)]
 
 
 @tool("Probe Hostnames")
-def probe_hostnames_tool(hostnames: list[str], programme_handle: str) -> list[dict]:
+def probe_hostnames_tool(hostnames: list[str], programme_handle: str) -> list[Endpoint]:
     """
     Re-probe a list of hostnames with httpx to confirm liveness, capture
     status codes, and fingerprint technologies. Use this on hostnames
@@ -156,8 +172,8 @@ def probe_hostnames_tool(hostnames: list[str], programme_handle: str) -> list[di
     The hostnames are filtered against the programme's structured scope
     before any HTTP traffic is generated; out-of-scope hostnames are
     dropped silently (we never probe outside scope, even for fingerprinting).
-    Returns ``[{url, status_code, technologies, parameters}]``. Net-new
-    endpoints can then be annotated with Annotate Host.
+    Returns a list of Endpoint with {url, status_code, technologies,
+    parameters}. Net-new endpoints can then be annotated with Annotate Host.
     """
     if not hostnames:
         return []
@@ -165,20 +181,21 @@ def probe_hostnames_tool(hostnames: list[str], programme_handle: str) -> list[di
     in_scope = filter_in_scope_impl([h.strip().lower() for h in hostnames if h.strip()], programme)
     if not in_scope:
         return []
-    eps = probe_endpoints_impl(in_scope)
-    return [ep.model_dump(mode="json") for ep in eps]
+    return list(probe_endpoints_impl(in_scope))
 
 
 @tool("Detect Takeover Candidates")
-def detect_takeover_candidates_tool(hostnames: list[str], programme_handle: str) -> list[dict]:
+def detect_takeover_candidates_tool(
+    hostnames: list[str], programme_handle: str
+) -> list[TakeoverCandidate]:
     """
     Resolve each hostname via dnsx and flag subdomain-takeover candidates.
 
     A candidate is flagged when the host's CNAME points to a known-vulnerable
     provider (AWS S3, Heroku, GitHub Pages, Azure, Vercel, Netlify, ...) or
     when the CNAME chain dangles (CNAME exists but resolves to no A records).
-    Returns ``[{hostname, cname, reason, service}]`` where ``reason`` is one
-    of ``cname_to_vulnerable_provider`` or ``dangling_cname``.
+    Returns a list of TakeoverCandidate where ``reason`` is one of
+    ``cname_to_vulnerable_provider`` or ``dangling_cname``.
 
     Each candidate is exactly that - a candidate. Follow up by annotating
     the host HIGH priority with a note pointing the Penetration Tester at
@@ -194,12 +211,11 @@ def detect_takeover_candidates_tool(hostnames: list[str], programme_handle: str)
     in_scope = filter_in_scope_impl([h.strip().lower() for h in hostnames if h.strip()], programme)
     if not in_scope:
         return []
-    candidates = detect_takeover_candidates(in_scope)
-    return [c.model_dump(mode="json") for c in candidates]
+    return list(detect_takeover_candidates(in_scope))
 
 
-@tool("Lookup CWE")
-def lookup_cwe_tool(query: str) -> list[dict]:
+@cached_tool("Lookup CWE")
+def lookup_cwe_tool(query: str) -> list[CWEEntry]:
     """
     Find Common Weakness Enumeration entries that match a query - useful
     when annotating a host whose detected tech has a well-known weakness
@@ -207,36 +223,17 @@ def lookup_cwe_tool(query: str) -> list[dict]:
     Returns each match's cwe_id, name, short description, and the matching
     OWASP cheat-sheet topic.
     """
-    entries = cwe_data.lookup(query)
-    return [
-        {
-            "cwe_id": e.cwe_id,
-            "name": e.name,
-            "description": e.description,
-            "url": e.url,
-            "owasp_topic": e.owasp_topic,
-        }
-        for e in entries
-    ]
+    return list(cwe_lookup(query))
 
 
-@tool("Lookup OWASP Guidance")
-def lookup_owasp_tool(query: str) -> list[dict]:
+@cached_tool("Lookup OWASP Guidance")
+def lookup_owasp_tool(query: str) -> list[OWASPEntry]:
     """
     Find OWASP Cheat Sheet entries for a vuln class or topic - hint for
     the downstream VR's attack-plan reasoning. Returns each match's title,
     key_principles, and the canonical cheatsheetseries.owasp.org URL.
     """
-    entries = owasp_data.lookup(query)
-    return [
-        {
-            "topic": e.topic,
-            "title": e.title,
-            "url": e.url,
-            "key_principles": e.key_principles,
-        }
-        for e in entries
-    ]
+    return list(owasp_lookup(query))
 
 
 @tool("Annotate Host")
@@ -248,7 +245,7 @@ def annotate_host_tool(
     detected_tech: list[str] | None = None,
     sweep_path: str = "sweep.json",
     programme_handle: str | None = None,
-) -> dict:
+) -> HostAnnotation:
     """
     Author one HostInsight for a single hostname and run the quality gate.
 
@@ -265,8 +262,9 @@ def annotate_host_tool(
         "Spring Boot"); the warning fires when the sweep saw tech that the
         annotation drops
 
-    Returns ``{"path": "host_insights/HOST.json", "validation": {ok, issues}}``.
-    Re-run with the issues addressed when validation.ok is false.
+    Returns a HostAnnotation with the relative insight path and an
+    InsightValidationReport. Re-run with the issues addressed when
+    validation.ok is false.
     """
     sweep = load_sweep_impl(sweep_path)
     programme = _load_programme(programme_handle)
@@ -279,11 +277,10 @@ def annotate_host_tool(
         detected_tech=[t.strip() for t in (detected_tech or []) if t.strip()],
     )
     path = save_insight(insight)
-    report = validate_insight(insight, sweep, programme)
-    return {
-        "path": str(path.relative_to(path.parents[1])),
-        "validation": report.model_dump(),
-    }
+    return HostAnnotation(
+        path=str(path.relative_to(path.parents[1])),
+        validation=validate_insight(insight, sweep, programme),
+    )
 
 
 @tool("Uncovered Hosts")

--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -7,8 +7,9 @@ from typing import Protocol, cast
 
 from crewai.tools import tool
 
-from models import Endpoint, EndpointPage, ReconResult
+from models import Endpoint, EndpointPage, OpenPortsMap, RawFinding, ReconResult
 from squad import (
+    CrewAITool,
     SquadMember,
     read_attack_plan_tool,
     read_run_file_tool,
@@ -64,15 +65,18 @@ from tools.pentest.xss import check_reflected_xss
 from tools.pentest.xxe import XxePayload, check_xxe
 from tools.recon.query import recon_endpoints, recon_open_ports, recon_subdomains
 
-_PentestFn = Callable[..., list[dict]]
+_PentestFn = Callable[..., list[RawFinding]]
 
 
-class _PentestTool(Protocol):
-    """Runtime shape of a CrewAI @tool: callable that also exposes .func."""
+class _PentestTool(CrewAITool, Protocol):
+    """Runtime shape of a CrewAI @tool: callable that also exposes .func.
 
-    func: _PentestFn
+    Inherits ``name`` / ``description`` / ``func`` from ``CrewAITool`` and
+    adds the call signature so callers (and the pentest factory) keep the
+    ``list[RawFinding]`` return type that the squad contract test enforces.
+    """
 
-    def __call__(self, *args: object, **kwargs: object) -> list[dict]: ...
+    def __call__(self, *args: object, **kwargs: object) -> list[RawFinding]: ...
 
 
 def pentest_tool(name: str, *, check_fn: object = None) -> Callable[[_PentestFn], _PentestTool]:
@@ -112,12 +116,12 @@ def _recon_from_path(recon_path: str) -> ReconResult:
 
 
 @pentest_tool("Nuclei Scan", check_fn=run_nuclei)
-def nuclei_scan_tool(endpoints_json: str, tech_tags_json: str = "[]") -> list[dict]:
+def nuclei_scan_tool(endpoints_json: str, tech_tags_json: str = "[]") -> list[RawFinding]:
     """
     Run nuclei against a specific set of endpoints, optionally filtered by template tags.
 
     endpoints_json: JSON array of endpoint objects to scan. Extract from ReconResult:
-      select live endpoints (status_code < 500), serialise with model_dump().
+      select live endpoints (status_code < 500), serialise to JSON.
       Example: '[{"url": "https://example.com/", "status_code": 200,
         "technologies": ["WordPress"]}]'
 
@@ -129,15 +133,15 @@ def nuclei_scan_tool(endpoints_json: str, tech_tags_json: str = "[]") -> list[di
 
     Prefer narrow tag lists when you have technology intel - running all templates
     against every endpoint is slow and noisy.
-    Returns raw findings as dicts.
+
     """
     endpoints = _parse_endpoints(endpoints_json)
     tech_tags: list[str] = json.loads(tech_tags_json)
-    return [f.model_dump() for f in run_nuclei(endpoints, tech_tags=tech_tags or None)]
+    return list(run_nuclei(endpoints, tech_tags=tech_tags or None))
 
 
 @pentest_tool("SQLMap Injection Scan", check_fn=run_sqlmap)
-def sqlmap_tool(endpoints_json: str) -> list[dict]:
+def sqlmap_tool(endpoints_json: str) -> list[RawFinding]:
     """
     Run sqlmap against specific parameterised endpoints.
 
@@ -149,13 +153,13 @@ def sqlmap_tool(endpoints_json: str) -> list[dict]:
 
     Do not pass all endpoints blindly - sqlmap is slow and loud. Pass only the
     endpoints where injection is plausible based on the recon context.
-    Returns raw findings as dicts.
+
     """
-    return [f.model_dump() for f in run_sqlmap(_parse_endpoints(endpoints_json))]
+    return list(run_sqlmap(_parse_endpoints(endpoints_json)))
 
 
 @pentest_tool("Cookie Security Check", check_fn=check_cookies)
-def cookie_check_tool(recon_path: str) -> list[dict]:
+def cookie_check_tool(recon_path: str) -> list[RawFinding]:
     """
     Inspect Set-Cookie attributes across the recon surface for: missing
     Secure on HTTPS cookies, missing HttpOnly on session-shaped cookies,
@@ -167,26 +171,26 @@ def cookie_check_tool(recon_path: str) -> list[dict]:
     Run this broadly - one request per distinct host, findings deduped per
     (host, cookie name, check class). Especially useful on login, dashboard,
     and authenticated API endpoints where Set-Cookie is most likely.
-    Pass the path to the recon.json file in the run directory. Returns raw findings as dicts.
+    Pass the path to the recon.json file in the run directory.
     """
     recon = _recon_from_path(recon_path)
-    return [f.model_dump() for f in check_cookies(recon.endpoints)]
+    return list(check_cookies(recon.endpoints))
 
 
 @pentest_tool("CORS Misconfiguration Check", check_fn=check_cors_misconfiguration)
-def cors_check_tool(recon_path: str) -> list[dict]:
+def cors_check_tool(recon_path: str) -> list[RawFinding]:
     """
     Check all live endpoints for CORS misconfigurations: origin reflection,
     null origin acceptance, and overly permissive Access-Control-Allow-Origin headers.
     Relevant wherever the target exposes an API or serves authenticated content.
-    Pass the path to the recon.json file in the run directory. Returns raw findings as dicts.
+    Pass the path to the recon.json file in the run directory.
     """
     recon = _recon_from_path(recon_path)
-    return [f.model_dump() for f in check_cors_misconfiguration(recon.endpoints)]
+    return list(check_cors_misconfiguration(recon.endpoints))
 
 
 @pentest_tool("CSRF Detection", check_fn=check_csrf)
-def csrf_check_tool(recon_path: str) -> list[dict]:
+def csrf_check_tool(recon_path: str) -> list[RawFinding]:
     """
     Detect CSRF vulnerabilities across HTML endpoints in the recon surface.
 
@@ -209,17 +213,17 @@ def csrf_check_tool(recon_path: str) -> list[dict]:
 
     Run broadly against all HTML-serving endpoints; especially relevant on
     login, registration, account management, and any state-changing form.
-    Pass the path to the recon.json file in the run directory. Returns raw findings as dicts.
+    Pass the path to the recon.json file in the run directory.
     """
     recon = _recon_from_path(recon_path)
-    return [f.model_dump() for f in check_csrf(recon.endpoints)]
+    return list(check_csrf(recon.endpoints))
 
 
 @pentest_tool("SSRF Probe", check_fn=check_ssrf)
 def ssrf_probe_tool(
     endpoints_json: str,
     payloads: list[SsrfPayload] | None = None,
-) -> list[dict]:
+) -> list[RawFinding]:
     """
     Inject cloud metadata (169.254.169.254) and loopback (127.0.0.1) payloads
     into URL parameters to detect Server-Side Request Forgery.
@@ -233,38 +237,38 @@ def ssrf_probe_tool(
       null to try all. Useful for stealth or when the cloud provider is known
       (e.g. just "aws-imds" for an AWS-hosted target).
 
-    Returns raw findings as dicts.
+
     """
-    return [f.model_dump() for f in check_ssrf(_parse_endpoints(endpoints_json), payloads)]
+    return list(check_ssrf(_parse_endpoints(endpoints_json), payloads))
 
 
 @pentest_tool("Header Injection Check", check_fn=check_header_injection)
-def header_injection_tool(recon_path: str) -> list[dict]:
+def header_injection_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for CRLF injection via X-Forwarded-For and similar headers.
     Relevant on all endpoints - run this broadly.
-    Pass the path to the recon.json file in the run directory. Returns raw findings as dicts.
+    Pass the path to the recon.json file in the run directory.
     """
     recon = _recon_from_path(recon_path)
-    return [f.model_dump() for f in check_header_injection(recon.endpoints)]
+    return list(check_header_injection(recon.endpoints))
 
 
 @pentest_tool("Host Header Attack Check", check_fn=check_host_headers)
-def host_header_tool(recon_path: str) -> list[dict]:
+def host_header_tool(recon_path: str) -> list[RawFinding]:
     """
     Test for Host header reflection (cache poisoning, password-reset poisoning)
     and X-Original-URL / X-Rewrite-URL overrides that may bypass access controls.
-    Pass the path to the recon.json file in the run directory. Returns raw findings as dicts.
+    Pass the path to the recon.json file in the run directory.
     """
     recon = _recon_from_path(recon_path)
-    return [f.model_dump() for f in check_host_headers(recon.endpoints)]
+    return list(check_host_headers(recon.endpoints))
 
 
 @pentest_tool("Header XSS Probe", check_fn=check_header_xss)
 def header_xss_tool(
     endpoints_json: str,
     header_names: list[XSSHeader] | None = None,
-) -> list[dict]:
+) -> list[RawFinding]:
     """
     Inject an angle-bracket canary into request headers and check whether the
     response body contains the canary verbatim (unencoded).
@@ -289,30 +293,28 @@ def header_xss_tool(
       (e.g. error pages that echo the User-Agent, analytics that log Referer).
       Example: ["User-Agent", "Referer"]
 
-    Returns raw findings as dicts.
+
     """
-    return [
-        f.model_dump() for f in check_header_xss(_parse_endpoints(endpoints_json), header_names)
-    ]
+    return list(check_header_xss(_parse_endpoints(endpoints_json), header_names))
 
 
 @pentest_tool("JS Source Map Scan", check_fn=check_js_source_maps)
-def source_maps_tool(recon_path: str) -> list[dict]:
+def source_maps_tool(recon_path: str) -> list[RawFinding]:
     """
     Discover exposed .js.map source map files and scan reconstructed source for
     secrets and internal paths. Use when the recon surface includes HTML pages
     that load JavaScript bundles (React, Angular, Vue, etc.).
-    Pass the path to the recon.json file in the run directory. Returns raw findings as dicts.
+    Pass the path to the recon.json file in the run directory.
     """
     recon = _recon_from_path(recon_path)
-    return [f.model_dump() for f in check_js_source_maps(recon.endpoints)]
+    return list(check_js_source_maps(recon.endpoints))
 
 
 @pentest_tool("Path Traversal Probe", check_fn=check_path_traversal)
 def path_traversal_tool(
     endpoints_json: str,
     payloads: list[PathTraversalPayload] | None = None,
-) -> list[dict]:
+) -> list[RawFinding]:
     """
     Inject directory-traversal payloads (plain, URL-encoded, double-encoded,
     backslash for Windows, null-byte truncation) into URL parameters and look
@@ -336,15 +338,13 @@ def path_traversal_tool(
     Read-only sentinel paths only; no writes, no destructive payloads. A
     confirmed match returns severity HIGH - traversal that yields /etc/passwd
     or win.ini almost always implies a file-read primitive worth escalating.
-    Returns raw findings as dicts.
+
     """
-    return [
-        f.model_dump() for f in check_path_traversal(_parse_endpoints(endpoints_json), payloads)
-    ]
+    return list(check_path_traversal(_parse_endpoints(endpoints_json), payloads))
 
 
 @pentest_tool("HTTP Parameter Pollution Probe", check_fn=check_hpp)
-def hpp_probe_tool(endpoints_json: str) -> list[dict]:
+def hpp_probe_tool(endpoints_json: str) -> list[RawFinding]:
     """
     Detect HTTP Parameter Pollution by sending a baseline request
     (`?param=1`) and a polluted request (`?param=1&param=2`) and comparing
@@ -366,16 +366,16 @@ def hpp_probe_tool(endpoints_json: str) -> list[dict]:
     further exploitation rather than a vuln in itself. The VR should
     escalate when the divergence can be chained with another finding
     (SQLi filter bypass, access-control override, cache poisoning).
-    Returns raw findings as dicts.
+
     """
-    return [f.model_dump() for f in check_hpp(_parse_endpoints(endpoints_json))]
+    return list(check_hpp(_parse_endpoints(endpoints_json)))
 
 
 @pentest_tool("Server-Side Template Injection Probe", check_fn=check_ssti)
 def ssti_probe_tool(
     endpoints_json: str,
     payloads: list[SstiPayload] | None = None,
-) -> list[dict]:
+) -> list[RawFinding]:
     """
     Inject template-language expressions (Jinja2/Twig/Liquid, Mako/FreeMarker,
     ERB/EJS, Ruby interpolation) into URL parameters and look for the evaluated
@@ -399,16 +399,16 @@ def ssti_probe_tool(
     SSTI confirmed at the canary-arithmetic level is HIGH; the VR should
     escalate to CRITICAL when manual follow-up demonstrates RCE primitives
     (sandbox escape, attribute traversal, OS command execution).
-    Returns raw findings as dicts.
+
     """
-    return [f.model_dump() for f in check_ssti(_parse_endpoints(endpoints_json), payloads)]
+    return list(check_ssti(_parse_endpoints(endpoints_json), payloads))
 
 
 @pentest_tool("Open Redirect Probe", check_fn=check_open_redirect)
 def open_redirect_tool(
     endpoints_json: str,
     payloads: list[OpenRedirectPayload] | None = None,
-) -> list[dict]:
+) -> list[RawFinding]:
     """
     Inject external URL payloads (https, protocol-relative, backslash, userinfo)
     into URL parameters and check whether the response Location, Refresh header,
@@ -428,13 +428,13 @@ def open_redirect_tool(
 
     Open redirect on its own is typically MEDIUM, but it escalates on OAuth
     redirect_uri and SSO callback endpoints (token theft) - flag those for VR.
-    Returns raw findings as dicts.
+
     """
-    return [f.model_dump() for f in check_open_redirect(_parse_endpoints(endpoints_json), payloads)]
+    return list(check_open_redirect(_parse_endpoints(endpoints_json), payloads))
 
 
 @pentest_tool("Reflected XSS Probe", check_fn=check_reflected_xss)
-def xss_probe_tool(endpoints_json: str) -> list[dict]:
+def xss_probe_tool(endpoints_json: str) -> list[RawFinding]:
     """
     Inject an angle-bracket canary into URL parameters and check for unescaped
     reflection in the response body.
@@ -444,24 +444,24 @@ def xss_probe_tool(endpoints_json: str) -> list[dict]:
       back into a page rather than returning JSON or a redirect).
       Example: '[{"url": "https://example.com/search", "parameters": ["q"]}]'
 
-    Returns raw findings as dicts.
+
     """
-    return [f.model_dump() for f in check_reflected_xss(_parse_endpoints(endpoints_json))]
+    return list(check_reflected_xss(_parse_endpoints(endpoints_json)))
 
 
 @pentest_tool("Subresource Integrity Check", check_fn=check_sri)
-def sri_check_tool(recon_path: str) -> list[dict]:
+def sri_check_tool(recon_path: str) -> list[RawFinding]:
     """
     Scan HTML pages for cross-origin <script> and <link> tags missing an
     integrity= attribute. Run broadly against all HTML-serving endpoints.
-    Pass the path to the recon.json file in the run directory. Returns raw findings as dicts.
+    Pass the path to the recon.json file in the run directory.
     """
     recon = _recon_from_path(recon_path)
-    return [f.model_dump() for f in check_sri(recon.endpoints)]
+    return list(check_sri(recon.endpoints))
 
 
 @pentest_tool("Error and Stack Trace Disclosure Check", check_fn=check_error_disclosure)
-def error_disclosure_tool(endpoints_json: str) -> list[dict]:
+def error_disclosure_tool(endpoints_json: str) -> list[RawFinding]:
     """
     Probe endpoints with error-triggering inputs and scan responses for framework
     stack traces and SQL error messages.
@@ -472,136 +472,136 @@ def error_disclosure_tool(endpoints_json: str) -> list[dict]:
       verbose errors are already present.
       Example: '[{"url": "https://example.com/api/user", "parameters": ["id"]}]'
 
-    Returns raw findings as dicts.
+
     """
-    return [f.model_dump() for f in check_error_disclosure(_parse_endpoints(endpoints_json))]
+    return list(check_error_disclosure(_parse_endpoints(endpoints_json)))
 
 
 @tool("S3 Bucket Check")
-def s3_check_tool(recon_path: str) -> list[dict]:
+def s3_check_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for publicly accessible or listable AWS S3 buckets derived from the
     programme handle and any S3 subdomains in the recon surface.
     Use when the target is known to use AWS, or when S3 subdomains appear in recon.
-    Pass the path to the recon.json file in the run directory. Returns raw findings as dicts.
+    Pass the path to the recon.json file in the run directory.
     """
     recon = _recon_from_path(recon_path)
-    return [f.model_dump() for f in check_s3_buckets(recon)]
+    return list(check_s3_buckets(recon))
 
 
 @tool("Azure Blob Storage Check")
-def azure_storage_check_tool(recon_path: str) -> list[dict]:
+def azure_storage_check_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for publicly accessible Azure Blob Storage containers and exposed SAS
     tokens in endpoint URLs. Use when the target is known to use Azure, or when
     *.blob.core.windows.net subdomains appear in recon.
-    Pass the path to the recon.json file in the run directory. Returns raw findings as dicts.
+    Pass the path to the recon.json file in the run directory.
     """
     recon = _recon_from_path(recon_path)
-    return [f.model_dump() for f in check_azure_storage(recon)]
+    return list(check_azure_storage(recon))
 
 
 @tool("Unauthenticated Elasticsearch Check")
-def elasticsearch_tool(recon_path: str) -> list[dict]:
+def elasticsearch_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an unauthenticated Elasticsearch instance on port 9200.
     Probes /_cluster/health - a 200 response with cluster_name confirms no auth.
     Use when open_ports shows 9200, or when technologies mention Elasticsearch.
-    Pass the path to the recon.json file in the run directory. Returns raw findings as dicts.
+    Pass the path to the recon.json file in the run directory.
     """
     recon = _recon_from_path(recon_path)
     findings = []
     for host, ports in recon.open_ports.items():
         if 9200 in ports:
             findings.extend(check_elasticsearch(host))
-    return [f.model_dump() for f in findings]
+    return list(findings)
 
 
 @tool("Unauthenticated CouchDB Check")
-def couchdb_tool(recon_path: str) -> list[dict]:
+def couchdb_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an unauthenticated CouchDB instance on port 5984.
     Probes /_all_dbs - a 200 response listing databases confirms no auth.
     Use when open_ports shows 5984.
-    Pass the path to the recon.json file in the run directory. Returns raw findings as dicts.
+    Pass the path to the recon.json file in the run directory.
     """
     recon = _recon_from_path(recon_path)
     findings = []
     for host, ports in recon.open_ports.items():
         if 5984 in ports:
             findings.extend(check_couchdb(host))
-    return [f.model_dump() for f in findings]
+    return list(findings)
 
 
 @tool("Unauthenticated Redis Check")
-def redis_tool(recon_path: str) -> list[dict]:
+def redis_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an unauthenticated Redis instance on port 6379 via a PING command.
     A +PONG response without sending AUTH confirms no password is set.
     Use when open_ports shows 6379.
-    Pass the path to the recon.json file in the run directory. Returns raw findings as dicts.
+    Pass the path to the recon.json file in the run directory.
     """
     recon = _recon_from_path(recon_path)
     findings = []
     for host, ports in recon.open_ports.items():
         if 6379 in ports:
             findings.extend(check_redis(host))
-    return [f.model_dump() for f in findings]
+    return list(findings)
 
 
 @tool("Unauthenticated MongoDB Check")
-def mongodb_tool(recon_path: str) -> list[dict]:
+def mongodb_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an unauthenticated MongoDB instance on port 27017.
     Sends a minimal isMaster wire-protocol query - a valid response without
     error confirms the instance accepts connections without credentials.
     Use when open_ports shows 27017.
-    Pass the path to the recon.json file in the run directory. Returns raw findings as dicts.
+    Pass the path to the recon.json file in the run directory.
     """
     recon = _recon_from_path(recon_path)
     findings = []
     for host, ports in recon.open_ports.items():
         if 27017 in ports:
             findings.extend(check_mongodb(host))
-    return [f.model_dump() for f in findings]
+    return list(findings)
 
 
 @tool("Exposed PostgreSQL Check")
-def postgresql_tool(recon_path: str) -> list[dict]:
+def postgresql_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for PostgreSQL on port 5432. Returns CRITICAL if trust authentication
     allows connection without a password; MEDIUM if the port is exposed but
     credentials are required (unnecessary internet exposure).
     Use when open_ports shows 5432.
-    Pass the path to the recon.json file in the run directory. Returns raw findings as dicts.
+    Pass the path to the recon.json file in the run directory.
     """
     recon = _recon_from_path(recon_path)
     findings = []
     for host, ports in recon.open_ports.items():
         if 5432 in ports:
             findings.extend(check_postgresql(host))
-    return [f.model_dump() for f in findings]
+    return list(findings)
 
 
 @tool("Exposed MySQL/MariaDB Check")
-def mysql_tool(recon_path: str) -> list[dict]:
+def mysql_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for MySQL or MariaDB on port 3306. Returns MEDIUM if the port is
     reachable and the server responds with a valid handshake (unnecessary
     internet exposure; verify anonymous login is disabled).
     Use when open_ports shows 3306.
-    Pass the path to the recon.json file in the run directory. Returns raw findings as dicts.
+    Pass the path to the recon.json file in the run directory.
     """
     recon = _recon_from_path(recon_path)
     findings = []
     for host, ports in recon.open_ports.items():
         if 3306 in ports:
             findings.extend(check_mysql(host))
-    return [f.model_dump() for f in findings]
+    return list(findings)
 
 
 @tool("Sensitive Files Check")
-def sensitive_files_tool(endpoints_json: str) -> list[dict]:
+def sensitive_files_tool(endpoints_json: str) -> list[RawFinding]:
     """
     Probe for exposed .git/HEAD, .env, phpinfo.php, Apache server-status, and
     .DS_Store files. Run broadly - these are high-value finds on any target.
@@ -611,13 +611,13 @@ def sensitive_files_tool(endpoints_json: str) -> list[dict]:
       redundant probes.
       Example: '[{"url": "https://example.com/", "status_code": 200}]'
 
-    Returns raw findings as dicts.
+
     """
-    return [f.model_dump() for f in check_sensitive_files(_parse_endpoints(endpoints_json))]
+    return list(check_sensitive_files(_parse_endpoints(endpoints_json)))
 
 
 @tool("Admin Panels Check")
-def admin_panels_tool(endpoints_json: str) -> list[dict]:
+def admin_panels_tool(endpoints_json: str) -> list[RawFinding]:
     """
     Probe common admin panel paths: /admin, /wp-admin, /phpmyadmin, /adminer,
     /manager/html, /_admin. Run broadly on all live endpoints.
@@ -625,115 +625,115 @@ def admin_panels_tool(endpoints_json: str) -> list[dict]:
     endpoints_json: JSON array of endpoint objects. The tool deduplicates by origin.
       Example: '[{"url": "https://example.com/", "status_code": 200}]'
 
-    Returns raw findings as dicts.
+
     """
-    return [f.model_dump() for f in check_admin_panels(_parse_endpoints(endpoints_json))]
+    return list(check_admin_panels(_parse_endpoints(endpoints_json)))
 
 
 @tool("cPanel/WHM Check")
-def cpanel_tool(recon_path: str) -> list[dict]:
+def cpanel_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed cPanel hosting control panel (ports 2082/2083) and
     WHM (WebHost Manager) panel (ports 2086/2087) on all discovered hostnames.
     Use when open_ports shows 2082, 2083, 2086, or 2087, or when the target
     appears to be a shared/managed hosting environment.
-    Pass the path to the recon.json file in the run directory. Returns raw findings as dicts.
+    Pass the path to the recon.json file in the run directory.
     """
     recon = _recon_from_path(recon_path)
-    return [f.model_dump() for f in check_cpanel(recon)]
+    return list(check_cpanel(recon))
 
 
 @tool("Plesk Check")
-def plesk_tool(recon_path: str) -> list[dict]:
+def plesk_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed Plesk web hosting control panel on ports 8880 (HTTP)
     and 8443 (HTTPS). Use when open_ports shows 8880 or 8443, or when the
     target is a managed hosting or VPS provider.
-    Pass the path to the recon.json file in the run directory. Returns raw findings as dicts.
+    Pass the path to the recon.json file in the run directory.
     """
     recon = _recon_from_path(recon_path)
-    return [f.model_dump() for f in check_plesk(recon)]
+    return list(check_plesk(recon))
 
 
 @tool("DirectAdmin Check")
-def directadmin_tool(recon_path: str) -> list[dict]:
+def directadmin_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed DirectAdmin hosting control panel on port 2222.
     Use when open_ports shows 2222 on a target that appears to be shared hosting.
-    Pass the path to the recon.json file in the run directory. Returns raw findings as dicts.
+    Pass the path to the recon.json file in the run directory.
     """
     recon = _recon_from_path(recon_path)
-    return [f.model_dump() for f in check_directadmin(recon)]
+    return list(check_directadmin(recon))
 
 
 @tool("Webmin Check")
-def webmin_tool(recon_path: str) -> list[dict]:
+def webmin_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed Webmin Linux server administration panel on port 10000.
     Use when open_ports shows 10000, or when the target is a self-hosted Linux server.
-    Pass the path to the recon.json file in the run directory. Returns raw findings as dicts.
+    Pass the path to the recon.json file in the run directory.
     """
     recon = _recon_from_path(recon_path)
-    return [f.model_dump() for f in check_webmin(recon)]
+    return list(check_webmin(recon))
 
 
 @tool("Grafana Check")
-def grafana_tool(recon_path: str) -> list[dict]:
+def grafana_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed Grafana metrics dashboard on port 3000 and via /grafana
     reverse-proxy path on existing endpoints.
     Use when open_ports shows 3000, or when technologies mention Grafana, or when
     the target is a DevOps/SRE-heavy organisation.
-    Pass the path to the recon.json file in the run directory. Returns raw findings as dicts.
+    Pass the path to the recon.json file in the run directory.
     """
     recon = _recon_from_path(recon_path)
-    return [f.model_dump() for f in check_grafana(recon)]
+    return list(check_grafana(recon))
 
 
 @tool("Kibana Check")
-def kibana_tool(recon_path: str) -> list[dict]:
+def kibana_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed Kibana log/data visualisation dashboard on port 5601 and
     via /kibana reverse-proxy path on existing endpoints.
     Use when open_ports shows 5601 or 9200 (Elasticsearch stack), or when
     technologies mention Kibana or Elasticsearch.
-    Pass the path to the recon.json file in the run directory. Returns raw findings as dicts.
+    Pass the path to the recon.json file in the run directory.
     """
     recon = _recon_from_path(recon_path)
-    return [f.model_dump() for f in check_kibana(recon)]
+    return list(check_kibana(recon))
 
 
 @tool("Portainer Check")
-def portainer_tool(recon_path: str) -> list[dict]:
+def portainer_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed Portainer Docker management UI on port 9000 and via
     /portainer reverse-proxy path on existing endpoints.
     Use when open_ports shows 9000, or when technologies mention Docker or
     containerised infrastructure.
-    Pass the path to the recon.json file in the run directory. Returns raw findings as dicts.
+    Pass the path to the recon.json file in the run directory.
     """
     recon = _recon_from_path(recon_path)
-    return [f.model_dump() for f in check_portainer(recon)]
+    return list(check_portainer(recon))
 
 
 @tool("Consul/Vault Check")
-def consul_vault_tool(recon_path: str) -> list[dict]:
+def consul_vault_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed HashiCorp Consul UI (port 8500) or Vault UI (port 8200),
     and via /consul/ui and /vault/ui reverse-proxy paths on existing endpoints.
     Use when open_ports shows 8500 or 8200, or when the target is a cloud-native
     or microservices environment.
-    Pass the path to the recon.json file in the run directory. Returns raw findings as dicts.
+    Pass the path to the recon.json file in the run directory.
     """
     recon = _recon_from_path(recon_path)
-    return [f.model_dump() for f in check_consul_vault(recon)]
+    return list(check_consul_vault(recon))
 
 
 @pentest_tool("Prompt Injection Probe", check_fn=check_prompt_injection)
 def prompt_injection_tool(
     endpoints_json: str,
     payloads: list[PromptPayload] | None = None,
-) -> list[dict]:
+) -> list[RawFinding]:
     """
     Probe LLM-backed endpoints for prompt injection by injecting a canary string
     in multiple request formats (OpenAI chat, generic message, prompt completion).
@@ -753,15 +753,13 @@ def prompt_injection_tool(
       - Canary reflected in response (direct injection): CRITICAL
       - Response contains system prompt shaped text (leakage): HIGH
 
-    Returns raw findings as dicts.
+
     """
-    return [
-        f.model_dump() for f in check_prompt_injection(_parse_endpoints(endpoints_json), payloads)
-    ]
+    return list(check_prompt_injection(_parse_endpoints(endpoints_json), payloads))
 
 
 @pentest_tool("NoSQL Injection Scan", check_fn=run_nosqli)
-def nosqli_tool(endpoints_json: str) -> list[dict]:
+def nosqli_tool(endpoints_json: str) -> list[RawFinding]:
     """
     Run nosqli against parameterised endpoints to detect NoSQL injection vulnerabilities.
 
@@ -773,16 +771,16 @@ def nosqli_tool(endpoints_json: str) -> list[dict]:
       - Auth routes (login, signup, profile) with parameter-bearing URLs
       Example: '[{"url": "https://example.com/api/login", "parameters": ["username", "password"]}]'
 
-    Returns raw findings as dicts.
+
     """
-    return [f.model_dump() for f in run_nosqli(_parse_endpoints(endpoints_json))]
+    return list(run_nosqli(_parse_endpoints(endpoints_json)))
 
 
 @pentest_tool("LDAP Injection Probe", check_fn=check_ldap_injection)
 def ldap_injection_tool(
     endpoints_json: str,
     payloads: list[LdapPayload] | None = None,
-) -> list[dict]:
+) -> list[RawFinding]:
     """
     Inject LDAP bypass and enumeration payloads into URL parameters to detect
     LDAP injection vulnerabilities against Active Directory or OpenLDAP backends.
@@ -805,18 +803,16 @@ def ldap_injection_tool(
       MEDIUM - LDAP/AD error strings in response body (confirms LDAP backend)
       MEDIUM - server error (500) only on LDAP payload, not on baseline
 
-    Returns raw findings as dicts.
+
     """
-    return [
-        f.model_dump() for f in check_ldap_injection(_parse_endpoints(endpoints_json), payloads)
-    ]
+    return list(check_ldap_injection(_parse_endpoints(endpoints_json), payloads))
 
 
 @pentest_tool("Command Injection Probe", check_fn=check_cmd_injection)
 def cmd_injection_tool(
     endpoints_json: str,
     payloads: list[CmdPayload] | None = None,
-) -> list[dict]:
+) -> list[RawFinding]:
     """
     Append OS command payloads to URL parameter values using common shell
     separators and look for a canary string echoed back in the response body.
@@ -839,16 +835,16 @@ def cmd_injection_tool(
 
     Detection is in-band only. If no finding is returned on a suspicious endpoint,
     escalate to manual time-based testing (e.g. sleep 5 with response-time delta).
-    Returns raw findings as dicts.
+
     """
-    return [f.model_dump() for f in check_cmd_injection(_parse_endpoints(endpoints_json), payloads)]
+    return list(check_cmd_injection(_parse_endpoints(endpoints_json), payloads))
 
 
 @pentest_tool("XXE Probe", check_fn=check_xxe)
 def xxe_probe_tool(
     endpoints_json: str,
     payloads: list[XxePayload] | None = None,
-) -> list[dict]:
+) -> list[RawFinding]:
     """
     POST crafted XML bodies to endpoints to detect XML External Entity (XXE)
     injection vulnerabilities.
@@ -875,16 +871,16 @@ def xxe_probe_tool(
                  parsing backend; warrants manual OOB/blind XXE follow-up)
 
     Both generic XML and SOAP-envelope wrappers are tried automatically.
-    Returns raw findings as dicts.
+
     """
-    return [f.model_dump() for f in check_xxe(_parse_endpoints(endpoints_json), payloads)]
+    return list(check_xxe(_parse_endpoints(endpoints_json), payloads))
 
 
 @pentest_tool("Prototype Pollution Check", check_fn=check_prototype_pollution)
 def prototype_pollution_tool(
     endpoints_json: str,
     payloads: list[PrototypePollutionPayload] | None = None,
-) -> list[dict]:
+) -> list[RawFinding]:
     """
     Probe endpoints for prototype pollution by injecting __proto__ and
     constructor.prototype payloads via URL query strings and JSON POST bodies,
@@ -914,19 +910,16 @@ def prototype_pollution_tool(
                  prototype chain traversal (warrants manual follow-up).
 
     One finding per endpoint. CRITICAL takes priority over MEDIUM.
-    Returns raw findings as dicts.
+
     """
-    return [
-        f.model_dump()
-        for f in check_prototype_pollution(_parse_endpoints(endpoints_json), payloads)
-    ]
+    return list(check_prototype_pollution(_parse_endpoints(endpoints_json), payloads))
 
 
 @pentest_tool("IDOR Probe", check_fn=check_idor)
 def idor_probe_tool(
     endpoints_json: str,
     attacks: list[IDORAttack] | None = None,
-) -> list[dict]:
+) -> list[RawFinding]:
     """
     Probe ID-shaped URL path segments and parameters for Insecure Direct
     Object Reference (IDOR) - the most-rewarded class on HackerOne (OWASP A01).
@@ -959,9 +952,9 @@ def idor_probe_tool(
     to probe adjacent objects. Use all three (default) for maximum coverage.
 
     One finding per endpoint; stops after the first confirming probe. Does not
-    brute-force ID ranges. Returns raw findings as dicts.
+    brute-force ID ranges.
     """
-    return [f.model_dump() for f in check_idor(_parse_endpoints(endpoints_json), attacks)]
+    return list(check_idor(_parse_endpoints(endpoints_json), attacks))
 
 
 @pentest_tool("JWT Vulnerability Check", check_fn=check_jwt)
@@ -969,7 +962,7 @@ def jwt_check_tool(
     token: str,
     endpoint: str,
     attacks: list[JwtAttack] | None = None,
-) -> list[dict]:
+) -> list[RawFinding]:
     """
     Test a JWT token for common vulnerabilities by replaying forged tokens
     against the authenticated endpoint and detecting 4xx -> 2xx transitions.
@@ -996,9 +989,9 @@ def jwt_check_tool(
 
     Run on every JWT discovered during recon, especially on admin and account
     endpoints. All confirmed bypasses are CRITICAL.
-    Returns raw findings as dicts.
+
     """
-    return [f.model_dump() for f in check_jwt(token, endpoint, attacks)]
+    return list(check_jwt(token, endpoint, attacks))
 
 
 @tool("Recon Subdomains")
@@ -1044,14 +1037,14 @@ def recon_endpoints_tool(
 
 
 @tool("Recon Open Ports")
-def recon_open_ports_tool(recon_path: str, host: str | None = None) -> dict:
+def recon_open_ports_tool(recon_path: str, host: str | None = None) -> OpenPortsMap:
     """
     Return the open-port map per host from recon.json. Passing a ``host``
     restricts the result to that single host. Use this to decide which of the
     port-specific probes to run (Elasticsearch on 9200, Redis on 6379, etc.)
     without loading the whole ReconResult.
     """
-    return recon_open_ports(recon_path, host=host)
+    return OpenPortsMap(hosts=recon_open_ports(recon_path, host=host))
 
 
 @tool("Save Findings")

--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -93,9 +93,18 @@ def pentest_tool(name: str, *, check_fn: object = None) -> Callable[[_PentestFn]
     return decorator
 
 
-def _parse_endpoints(endpoints_json: str) -> list[Endpoint]:
-    """Deserialise a JSON array of endpoint dicts into Endpoint objects."""
-    return [Endpoint.model_validate(e) for e in json.loads(endpoints_json)]
+def _parse_endpoints(endpoints: list[Endpoint]) -> list[Endpoint]:
+    """Re-validate the endpoint list before handing it to a probe.
+
+    The wrapper signature is ``list[Endpoint]`` so the agent-facing
+    ``args_schema`` shows a typed schema, but CrewAI's
+    ``args_schema.model_validate(...).model_dump()`` pass leaves the
+    runtime value as ``list[dict]`` by the time the wrapper body runs.
+    ``model_validate`` accepts both shapes - it returns the same Endpoint
+    when given an instance and constructs one when given a dict - so this
+    single helper is the both-shapes adapter for every probe wrapper.
+    """
+    return [Endpoint.model_validate(e) for e in endpoints]
 
 
 def _recon_from_path(recon_path: str) -> ReconResult:
@@ -116,46 +125,45 @@ def _recon_from_path(recon_path: str) -> ReconResult:
 
 
 @pentest_tool("Nuclei Scan", check_fn=run_nuclei)
-def nuclei_scan_tool(endpoints_json: str, tech_tags_json: str = "[]") -> list[RawFinding]:
+def nuclei_scan_tool(
+    endpoints: list[Endpoint], tech_tags: list[str] | None = None
+) -> list[RawFinding]:
     """
     Run nuclei against a specific set of endpoints, optionally filtered by template tags.
 
-    endpoints_json: JSON array of endpoint objects to scan. Extract from ReconResult:
-      select live endpoints (status_code < 500), serialise to JSON.
-      Example: '[{"url": "https://example.com/", "status_code": 200,
-        "technologies": ["WordPress"]}]'
+    endpoints: list of endpoint objects to scan. Extract from ReconResult:
+      select live endpoints (status_code < 500), use the typed list directly.
+      Example: [{"url": "https://example.com/", "status_code": 200, "technologies": ["WordPress"]}]
 
-    tech_tags_json: JSON array of nuclei template tags to focus on. Map from detected
+    tech_tags: optional list of nuclei template tags to focus on. Map from detected
       technologies: WordPress -> ["wordpress"], Apache -> ["apache"], Spring -> ["spring"].
       Common tags: wordpress, drupal, joomla, apache, nginx, iis, spring, laravel,
-      django, rails, php, cve, exposure, misconfig. Pass "[]" to run all templates.
-      Example: '["wordpress", "cve"]'
+      django, rails, php, cve, exposure, misconfig. Omit or pass an empty list to run all templates.
+      Example: ["wordpress", "cve"]
 
     Prefer narrow tag lists when you have technology intel - running all templates
     against every endpoint is slow and noisy.
 
     """
-    endpoints = _parse_endpoints(endpoints_json)
-    tech_tags: list[str] = json.loads(tech_tags_json)
-    return list(run_nuclei(endpoints, tech_tags=tech_tags or None))
+    return list(run_nuclei(_parse_endpoints(endpoints), tech_tags=tech_tags or None))
 
 
 @pentest_tool("SQLMap Injection Scan", check_fn=run_sqlmap)
-def sqlmap_tool(endpoints_json: str) -> list[RawFinding]:
+def sqlmap_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     """
     Run sqlmap against specific parameterised endpoints.
 
-    endpoints_json: JSON array of endpoint objects that have parameters you want
+    endpoints: list of endpoint objects that have parameters you want
       to test for SQL injection. Only pass endpoints where parameters is non-empty
       and where there is reason to suspect injection (e.g. error disclosure findings
       showing SQL errors, numeric/string parameters in URLs or forms).
-      Example: '[{"url": "https://example.com/search", "parameters": ["q", "page"]}]'
+      Example: [{"url": "https://example.com/search", "parameters": ["q", "page"]}]
 
     Do not pass all endpoints blindly - sqlmap is slow and loud. Pass only the
     endpoints where injection is plausible based on the recon context.
 
     """
-    return list(run_sqlmap(_parse_endpoints(endpoints_json)))
+    return list(run_sqlmap(_parse_endpoints(endpoints)))
 
 
 @pentest_tool("Cookie Security Check", check_fn=check_cookies)
@@ -221,17 +229,17 @@ def csrf_check_tool(recon_path: str) -> list[RawFinding]:
 
 @pentest_tool("SSRF Probe", check_fn=check_ssrf)
 def ssrf_probe_tool(
-    endpoints_json: str,
+    endpoints: list[Endpoint],
     payloads: list[SsrfPayload] | None = None,
 ) -> list[RawFinding]:
     """
     Inject cloud metadata (169.254.169.254) and loopback (127.0.0.1) payloads
     into URL parameters to detect Server-Side Request Forgery.
 
-    endpoints_json: JSON array of endpoint objects. Only pass endpoints that have
+    endpoints: list of endpoint objects. Only pass endpoints that have
       parameters AND where those parameters plausibly accept URLs, hostnames,
       file paths, or resource identifiers (e.g. url=, path=, file=, redirect=, src=).
-      Example: '[{"url": "https://example.com/fetch", "parameters": ["url"]}]'
+      Example: [{"url": "https://example.com/fetch", "parameters": ["url"]}]
 
     payloads: optional list of internal-address variants to try; omit or pass
       null to try all. Useful for stealth or when the cloud provider is known
@@ -239,7 +247,7 @@ def ssrf_probe_tool(
 
 
     """
-    return list(check_ssrf(_parse_endpoints(endpoints_json), payloads))
+    return list(check_ssrf(_parse_endpoints(endpoints), payloads))
 
 
 @pentest_tool("Header Injection Check", check_fn=check_header_injection)
@@ -266,7 +274,7 @@ def host_header_tool(recon_path: str) -> list[RawFinding]:
 
 @pentest_tool("Header XSS Probe", check_fn=check_header_xss)
 def header_xss_tool(
-    endpoints_json: str,
+    endpoints: list[Endpoint],
     header_names: list[XSSHeader] | None = None,
 ) -> list[RawFinding]:
     """
@@ -284,9 +292,9 @@ def header_xss_tool(
       - Recon found analytics or logging endpoints that display User-Agent strings
       - The target is an older web application (PHP, JSP, ASP) with legacy templating
 
-    endpoints_json: JSON array of endpoint objects. Pass a broad set of live
+    endpoints: list of endpoint objects. Pass a broad set of live
       HTML-serving endpoints; error pages and admin paths are especially fruitful.
-      Example: '[{"url": "https://example.com/error", "status_code": 404}]'
+      Example: [{"url": "https://example.com/error", "status_code": 404}]
 
     header_names: optional list of headers to probe; omit or pass null to test
       all five. Narrow this when recon evidence points to a specific header
@@ -295,7 +303,7 @@ def header_xss_tool(
 
 
     """
-    return list(check_header_xss(_parse_endpoints(endpoints_json), header_names))
+    return list(check_header_xss(_parse_endpoints(endpoints), header_names))
 
 
 @pentest_tool("JS Source Map Scan", check_fn=check_js_source_maps)
@@ -312,7 +320,7 @@ def source_maps_tool(recon_path: str) -> list[RawFinding]:
 
 @pentest_tool("Path Traversal Probe", check_fn=check_path_traversal)
 def path_traversal_tool(
-    endpoints_json: str,
+    endpoints: list[Endpoint],
     payloads: list[PathTraversalPayload] | None = None,
 ) -> list[RawFinding]:
     """
@@ -321,7 +329,7 @@ def path_traversal_tool(
     for unique content markers from OS sentinel files (/etc/passwd,
     Windows win.ini) in the response body.
 
-    endpoints_json: JSON array of endpoint objects. Prioritise endpoints that
+    endpoints: list of endpoint objects. Prioritise endpoints that
       have parameters AND where any of the following apply:
       - Parameter names look filesystem-shaped (file, filename, path, page,
         template, include, require, download, doc, image, img, src, view)
@@ -329,7 +337,7 @@ def path_traversal_tool(
         /fetch, /report, /export)
       - The response Content-Type or filename hint shows the server is reading
         files based on the parameter
-      Example: '[{"url": "https://example.com/download", "parameters": ["file"]}]'
+      Example: [{"url": "https://example.com/download", "parameters": ["file"]}]
 
     payloads: optional list of traversal variants to try; omit or pass null
       to try all. When the OS is known, pass only the matching set (e.g. just
@@ -340,11 +348,11 @@ def path_traversal_tool(
     or win.ini almost always implies a file-read primitive worth escalating.
 
     """
-    return list(check_path_traversal(_parse_endpoints(endpoints_json), payloads))
+    return list(check_path_traversal(_parse_endpoints(endpoints), payloads))
 
 
 @pentest_tool("HTTP Parameter Pollution Probe", check_fn=check_hpp)
-def hpp_probe_tool(endpoints_json: str) -> list[RawFinding]:
+def hpp_probe_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     """
     Detect HTTP Parameter Pollution by sending a baseline request
     (`?param=1`) and a polluted request (`?param=1&param=2`) and comparing
@@ -352,7 +360,7 @@ def hpp_probe_tool(endpoints_json: str) -> list[RawFinding]:
     duplicate values as distinguishable from a single value - the
     pre-condition for WAF bypass and access-control bypass exploits.
 
-    endpoints_json: JSON array of endpoint objects. Prioritise endpoints
+    endpoints: list of endpoint objects. Prioritise endpoints
       where any of the following apply:
       - Parameter names look authorisation-shaped (role, admin, is_admin,
         permission, group, user_id) - HPP is most impactful when it can
@@ -360,7 +368,7 @@ def hpp_probe_tool(endpoints_json: str) -> list[RawFinding]:
       - Endpoint sits behind a WAF or rate-limit (HPP is a classic WAF
         bypass primitive)
       - Endpoint is part of an auth or admin flow
-      Example: '[{"url": "https://example.com/api/user", "parameters": ["role", "id"]}]'
+      Example: [{"url": "https://example.com/api/user", "parameters": ["role", "id"]}]
 
     Severity LOW on its own - HPP is a class of behaviour that enables
     further exploitation rather than a vuln in itself. The VR should
@@ -368,12 +376,12 @@ def hpp_probe_tool(endpoints_json: str) -> list[RawFinding]:
     (SQLi filter bypass, access-control override, cache poisoning).
 
     """
-    return list(check_hpp(_parse_endpoints(endpoints_json)))
+    return list(check_hpp(_parse_endpoints(endpoints)))
 
 
 @pentest_tool("Server-Side Template Injection Probe", check_fn=check_ssti)
 def ssti_probe_tool(
-    endpoints_json: str,
+    endpoints: list[Endpoint],
     payloads: list[SstiPayload] | None = None,
 ) -> list[RawFinding]:
     """
@@ -383,14 +391,14 @@ def ssti_probe_tool(
     to appear AND the literal expression to be absent, which rules out the
     common false positive of an app that just echoes the raw input.
 
-    endpoints_json: JSON array of endpoint objects. Prioritise endpoints where
+    endpoints: list of endpoint objects. Prioritise endpoints where
       any of the following apply:
       - Parameter values are rendered into HTML the response returns (search,
         comment, preview, name, template parameters)
       - Technologies mention a template-heavy stack (Flask/Jinja2, Django,
         Symfony/Twig, Rails/ERB, Spring with FreeMarker, etc.)
       - Error disclosure findings mention template internals
-      Example: '[{"url": "https://example.com/preview", "parameters": ["name"]}]'
+      Example: [{"url": "https://example.com/preview", "parameters": ["name"]}]
 
     payloads: optional list of engine variants to try; omit or pass null to
       try all. When the template engine is known from recon, pass only the
@@ -401,12 +409,12 @@ def ssti_probe_tool(
     (sandbox escape, attribute traversal, OS command execution).
 
     """
-    return list(check_ssti(_parse_endpoints(endpoints_json), payloads))
+    return list(check_ssti(_parse_endpoints(endpoints), payloads))
 
 
 @pentest_tool("Open Redirect Probe", check_fn=check_open_redirect)
 def open_redirect_tool(
-    endpoints_json: str,
+    endpoints: list[Endpoint],
     payloads: list[OpenRedirectPayload] | None = None,
 ) -> list[RawFinding]:
     """
@@ -414,14 +422,14 @@ def open_redirect_tool(
     into URL parameters and check whether the response Location, Refresh header,
     or meta-refresh tag points to the canary host.
 
-    endpoints_json: JSON array of endpoint objects. Prioritise endpoints that have
+    endpoints: list of endpoint objects. Prioritise endpoints that have
       parameters AND where any of the following apply:
       - Parameter names look redirect-shaped (redirect, redirect_uri, return,
         return_to, returnto, next, url, dest, destination, goto, target, link,
         forward, continue, callback, rurl, r, u)
       - Path looks like an auth flow (/login, /logout, /signin, /oauth, /sso)
       - Recon noted a 30x response on the endpoint already
-      Example: '[{"url": "https://example.com/login", "parameters": ["next"]}]'
+      Example: [{"url": "https://example.com/login", "parameters": ["next"]}]
 
     payloads: optional list of encoding variants to try; omit or pass null to
       try all.
@@ -430,23 +438,23 @@ def open_redirect_tool(
     redirect_uri and SSO callback endpoints (token theft) - flag those for VR.
 
     """
-    return list(check_open_redirect(_parse_endpoints(endpoints_json), payloads))
+    return list(check_open_redirect(_parse_endpoints(endpoints), payloads))
 
 
 @pentest_tool("Reflected XSS Probe", check_fn=check_reflected_xss)
-def xss_probe_tool(endpoints_json: str) -> list[RawFinding]:
+def xss_probe_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     """
     Inject an angle-bracket canary into URL parameters and check for unescaped
     reflection in the response body.
 
-    endpoints_json: JSON array of endpoint objects. Only pass endpoints that have
+    endpoints: list of endpoint objects. Only pass endpoints that have
       parameters AND where the response is HTML (i.e. the target renders user input
       back into a page rather than returning JSON or a redirect).
-      Example: '[{"url": "https://example.com/search", "parameters": ["q"]}]'
+      Example: [{"url": "https://example.com/search", "parameters": ["q"]}]
 
 
     """
-    return list(check_reflected_xss(_parse_endpoints(endpoints_json)))
+    return list(check_reflected_xss(_parse_endpoints(endpoints)))
 
 
 @pentest_tool("Subresource Integrity Check", check_fn=check_sri)
@@ -461,20 +469,20 @@ def sri_check_tool(recon_path: str) -> list[RawFinding]:
 
 
 @pentest_tool("Error and Stack Trace Disclosure Check", check_fn=check_error_disclosure)
-def error_disclosure_tool(endpoints_json: str) -> list[RawFinding]:
+def error_disclosure_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     """
     Probe endpoints with error-triggering inputs and scan responses for framework
     stack traces and SQL error messages.
 
-    endpoints_json: JSON array of endpoint objects to probe. Prioritise endpoints
+    endpoints: list of endpoint objects to probe. Prioritise endpoints
       where parameters are present (they increase the chance of triggering errors)
       and any endpoint where the error disclosure passive findings from recon suggest
       verbose errors are already present.
-      Example: '[{"url": "https://example.com/api/user", "parameters": ["id"]}]'
+      Example: [{"url": "https://example.com/api/user", "parameters": ["id"]}]
 
 
     """
-    return list(check_error_disclosure(_parse_endpoints(endpoints_json)))
+    return list(check_error_disclosure(_parse_endpoints(endpoints)))
 
 
 @tool("S3 Bucket Check")
@@ -601,33 +609,33 @@ def mysql_tool(recon_path: str) -> list[RawFinding]:
 
 
 @tool("Sensitive Files Check")
-def sensitive_files_tool(endpoints_json: str) -> list[RawFinding]:
+def sensitive_files_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     """
     Probe for exposed .git/HEAD, .env, phpinfo.php, Apache server-status, and
     .DS_Store files. Run broadly - these are high-value finds on any target.
 
-    endpoints_json: JSON array of endpoint objects. Pass a representative set of
+    endpoints: list of endpoint objects. Pass a representative set of
       live endpoints; the tool deduplicates by origin so you can pass many without
       redundant probes.
-      Example: '[{"url": "https://example.com/", "status_code": 200}]'
+      Example: [{"url": "https://example.com/", "status_code": 200}]
 
 
     """
-    return list(check_sensitive_files(_parse_endpoints(endpoints_json)))
+    return list(check_sensitive_files(_parse_endpoints(endpoints)))
 
 
 @tool("Admin Panels Check")
-def admin_panels_tool(endpoints_json: str) -> list[RawFinding]:
+def admin_panels_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     """
     Probe common admin panel paths: /admin, /wp-admin, /phpmyadmin, /adminer,
     /manager/html, /_admin. Run broadly on all live endpoints.
 
-    endpoints_json: JSON array of endpoint objects. The tool deduplicates by origin.
-      Example: '[{"url": "https://example.com/", "status_code": 200}]'
+    endpoints: list of endpoint objects. The tool deduplicates by origin.
+      Example: [{"url": "https://example.com/", "status_code": 200}]
 
 
     """
-    return list(check_admin_panels(_parse_endpoints(endpoints_json)))
+    return list(check_admin_panels(_parse_endpoints(endpoints)))
 
 
 @tool("cPanel/WHM Check")
@@ -731,14 +739,14 @@ def consul_vault_tool(recon_path: str) -> list[RawFinding]:
 
 @pentest_tool("Prompt Injection Probe", check_fn=check_prompt_injection)
 def prompt_injection_tool(
-    endpoints_json: str,
+    endpoints: list[Endpoint],
     payloads: list[PromptPayload] | None = None,
 ) -> list[RawFinding]:
     """
     Probe LLM-backed endpoints for prompt injection by injecting a canary string
     in multiple request formats (OpenAI chat, generic message, prompt completion).
 
-    endpoints_json: JSON array of endpoint objects. Use this tool when:
+    endpoints: list of endpoint objects. Use this tool when:
       - The OSINT Analyst's LLM Endpoint Detection tool returned results
       - Endpoint technologies include 'LLM'
       - URL paths suggest an AI assistant (/chat, /ask, /ai, /assistant, /copilot)
@@ -755,44 +763,44 @@ def prompt_injection_tool(
 
 
     """
-    return list(check_prompt_injection(_parse_endpoints(endpoints_json), payloads))
+    return list(check_prompt_injection(_parse_endpoints(endpoints), payloads))
 
 
 @pentest_tool("NoSQL Injection Scan", check_fn=run_nosqli)
-def nosqli_tool(endpoints_json: str) -> list[RawFinding]:
+def nosqli_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     """
     Run nosqli against parameterised endpoints to detect NoSQL injection vulnerabilities.
 
-    endpoints_json: JSON array of endpoint objects. Prioritise endpoints that have
+    endpoints: list of endpoint objects. Prioritise endpoints that have
       parameters AND where any of the following apply:
       - Technologies mention MongoDB, DocumentDB, Mongoose, or similar document stores
       - Parameters include id, user, username, filter, query, or similar lookup keys
       - Error disclosure findings mention BSON, ObjectId, or a MongoDB driver
       - Auth routes (login, signup, profile) with parameter-bearing URLs
-      Example: '[{"url": "https://example.com/api/login", "parameters": ["username", "password"]}]'
+      Example: [{"url": "https://example.com/api/login", "parameters": ["username", "password"]}]
 
 
     """
-    return list(run_nosqli(_parse_endpoints(endpoints_json)))
+    return list(run_nosqli(_parse_endpoints(endpoints)))
 
 
 @pentest_tool("LDAP Injection Probe", check_fn=check_ldap_injection)
 def ldap_injection_tool(
-    endpoints_json: str,
+    endpoints: list[Endpoint],
     payloads: list[LdapPayload] | None = None,
 ) -> list[RawFinding]:
     """
     Inject LDAP bypass and enumeration payloads into URL parameters to detect
     LDAP injection vulnerabilities against Active Directory or OpenLDAP backends.
 
-    endpoints_json: JSON array of endpoint objects. Prioritise endpoints that have
+    endpoints: list of endpoint objects. Prioritise endpoints that have
       parameters AND where any of the following apply:
       - Parameter names suggest authentication or directory lookup (username, user,
         login, email, uid, cn, search, filter, q)
       - URL path suggests auth or directory (/login, /auth, /search, /directory,
         /ldap, /user)
       - Technologies mention LDAP, Active Directory, OpenLDAP, or JNDI
-      Example: '[{"url": "https://example.com/login", "parameters": ["username"]}]'
+      Example: [{"url": "https://example.com/login", "parameters": ["username"]}]
 
     payloads: optional list of injection variants to try; omit or pass null
       to try all. Use "auth-bypass" first on a /login endpoint to confirm the
@@ -805,12 +813,12 @@ def ldap_injection_tool(
 
 
     """
-    return list(check_ldap_injection(_parse_endpoints(endpoints_json), payloads))
+    return list(check_ldap_injection(_parse_endpoints(endpoints), payloads))
 
 
 @pentest_tool("Command Injection Probe", check_fn=check_cmd_injection)
 def cmd_injection_tool(
-    endpoints_json: str,
+    endpoints: list[Endpoint],
     payloads: list[CmdPayload] | None = None,
 ) -> list[RawFinding]:
     """
@@ -818,7 +826,7 @@ def cmd_injection_tool(
     separators and look for a canary string echoed back in the response body.
     Confirmed echo is CRITICAL - it is direct proof of arbitrary command execution.
 
-    endpoints_json: JSON array of endpoint objects. Prioritise endpoints that have
+    endpoints: list of endpoint objects. Prioritise endpoints that have
       parameters AND where any of the following apply:
       - Parameter names suggest shell or system interaction (cmd, exec, command,
         shell, run, ping, host, ip, addr, query, search, name, input)
@@ -826,7 +834,7 @@ def cmd_injection_tool(
       - URL paths suggest system utilities (/ping, /traceroute, /lookup, /exec,
         /run, /convert, /render, /preview, /generate)
       - Error disclosure findings mention exec, popen, system, or shell functions
-      Example: '[{"url": "https://example.com/ping", "parameters": ["host"]}]'
+      Example: [{"url": "https://example.com/ping", "parameters": ["host"]}]
 
     payloads: optional list of separator variants to try; omit or pass null
       to try all. When the OS is known, pass only matching separators
@@ -837,26 +845,26 @@ def cmd_injection_tool(
     escalate to manual time-based testing (e.g. sleep 5 with response-time delta).
 
     """
-    return list(check_cmd_injection(_parse_endpoints(endpoints_json), payloads))
+    return list(check_cmd_injection(_parse_endpoints(endpoints), payloads))
 
 
 @pentest_tool("XXE Probe", check_fn=check_xxe)
 def xxe_probe_tool(
-    endpoints_json: str,
+    endpoints: list[Endpoint],
     payloads: list[XxePayload] | None = None,
 ) -> list[RawFinding]:
     """
     POST crafted XML bodies to endpoints to detect XML External Entity (XXE)
     injection vulnerabilities.
 
-    endpoints_json: JSON array of endpoint objects. Prioritise endpoints where
+    endpoints: list of endpoint objects. Prioritise endpoints where
       any of the following apply:
       - technologies mention SOAP, XML-RPC, WSDL, XML, or web services
       - URL path contains /soap, /xml, /wsdl, /rpc, /service, /api, or ends
         in .asmx, .wsdl, .xml
       - The OSINT Analyst noted XML or SOAP in the response body or headers
       - The endpoint accepts file uploads (multipart may include XML processing)
-      Example: '[{"url": "https://example.com/soap/service", "status_code": 200}]'
+      Example: [{"url": "https://example.com/soap/service", "status_code": 200}]
 
     payloads: optional list of probe variants to try; omit or pass null to
       try all. linux-* probes target /etc/passwd, windows-* probes target
@@ -873,12 +881,12 @@ def xxe_probe_tool(
     Both generic XML and SOAP-envelope wrappers are tried automatically.
 
     """
-    return list(check_xxe(_parse_endpoints(endpoints_json), payloads))
+    return list(check_xxe(_parse_endpoints(endpoints), payloads))
 
 
 @pentest_tool("Prototype Pollution Check", check_fn=check_prototype_pollution)
 def prototype_pollution_tool(
-    endpoints_json: str,
+    endpoints: list[Endpoint],
     payloads: list[PrototypePollutionPayload] | None = None,
 ) -> list[RawFinding]:
     """
@@ -887,14 +895,14 @@ def prototype_pollution_tool(
     then checking whether a canary property is reflected in the response or
     whether the server returns an unhandled error.
 
-    endpoints_json: JSON array of endpoint objects. Use this tool when:
+    endpoints: list of endpoint objects. Use this tool when:
       - Technologies mention Node.js, Express, Koa, Hapi, Fastify, or other
         JavaScript/TypeScript server frameworks
       - The API accepts JSON request bodies (Content-Type: application/json)
       - URL parameters are parsed server-side into plain objects (lodash merge,
         recursive assign, query-string to object conversions)
       - The target is a REST or GraphQL API with a JavaScript backend
-      Example: '[{"url": "https://api.example.com/users", "status_code": 200}]'
+      Example: [{"url": "https://api.example.com/users", "status_code": 200}]
 
     payloads: optional list of injection variants to try; omit or pass null
       to try all. The proto-* and constructor-* names are URL query-string
@@ -912,12 +920,12 @@ def prototype_pollution_tool(
     One finding per endpoint. CRITICAL takes priority over MEDIUM.
 
     """
-    return list(check_prototype_pollution(_parse_endpoints(endpoints_json), payloads))
+    return list(check_prototype_pollution(_parse_endpoints(endpoints), payloads))
 
 
 @pentest_tool("IDOR Probe", check_fn=check_idor)
 def idor_probe_tool(
-    endpoints_json: str,
+    endpoints: list[Endpoint],
     attacks: list[IDORAttack] | None = None,
 ) -> list[RawFinding]:
     """
@@ -941,11 +949,11 @@ def idor_probe_tool(
       HIGH   - 200 response body contains a PII pattern (email, sensitive key)
       MEDIUM - unexpected 200 for boundary ID (id=0 or id=-1)
 
-    endpoints_json: JSON array of endpoint objects. Prioritise endpoints where:
+    endpoints: list of endpoint objects. Prioritise endpoints where:
       - The URL path includes numeric segments (/api/users/42, /orders/9)
       - Parameters include id, user_id, account_id, order_id, or similar
       - The endpoint handles authenticated or per-user data
-      Example: '[{"url": "https://example.com/api/users/42", "status_code": 200}]'
+      Example: [{"url": "https://example.com/api/users/42", "status_code": 200}]
 
     Use attacks=["boundary"] for a quiet reconnaissance pass (2 requests per
     candidate). Use attacks=["sequential"] when you already know an ID and want
@@ -954,7 +962,7 @@ def idor_probe_tool(
     One finding per endpoint; stops after the first confirming probe. Does not
     brute-force ID ranges.
     """
-    return list(check_idor(_parse_endpoints(endpoints_json), attacks))
+    return list(check_idor(_parse_endpoints(endpoints), attacks))
 
 
 @pentest_tool("JWT Vulnerability Check", check_fn=check_jwt)
@@ -1022,9 +1030,9 @@ def recon_endpoints_tool(
     case-insensitively. Returns an EndpointPage with total, offset, returned,
     and a typed endpoints list - paginate by re-calling with a larger offset.
 
-    Use this to build the endpoints_json argument for the narrow probe tools
-    (sqlmap_tool, nuclei_scan_tool, etc.): serialise page.endpoints to JSON
-    and pass it through.
+    Use this to build the ``endpoints`` argument for the narrow probe tools
+    (sqlmap_tool, nuclei_scan_tool, etc.): pass ``page.endpoints`` straight
+    through - the probe wrappers accept ``list[Endpoint]`` directly.
     """
     return recon_endpoints(
         recon_path,
@@ -1048,19 +1056,25 @@ def recon_open_ports_tool(recon_path: str, host: str | None = None) -> OpenPorts
 
 
 @tool("Save Findings")
-def save_findings_tool(findings_json: str) -> str:
+def save_findings_tool(findings: list[RawFinding]) -> str:
     """
     Write the collected raw findings to findings.json in the run directory.
-    Call this once after all probe tools have run, passing a JSON array of
-    finding dicts. Returns the relative filename for downstream agents.
+    Call this once after all probe tools have run, passing the typed list
+    of findings collected from the probe tools. Returns the relative
+    filename for downstream agents.
     """
     import runtime
 
     out_path = runtime.run_dir() / "findings.json"
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    # Validate the payload parses as JSON before writing.
-    json.loads(findings_json)
-    out_path.write_text(findings_json, encoding="utf-8")
+    # CrewAI args-schema validation produces list[dict] from the LLM JSON
+    # before invoking us; re-validate so the persisted artefact is the
+    # canonical typed shape findings.json consumers depend on.
+    validated = [RawFinding.model_validate(f) for f in findings]
+    out_path.write_text(
+        json.dumps([f.model_dump(mode="json") for f in validated]),
+        encoding="utf-8",
+    )
     return "findings.json"
 
 

--- a/squad/programme_manager/__init__.py
+++ b/squad/programme_manager/__init__.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from crewai.tools import tool
 
 import runtime
+from models.h1 import Programme, ProgrammePreview
 from squad import SquadMember
 from tools.h1_api import h1
 
@@ -25,7 +26,7 @@ def browse_programmes_tool(
     submission_state: str | None = None,
     sort: str | None = None,
     limit: int | None = None,
-) -> list[dict]:
+) -> list[ProgrammePreview]:
     """
     Survey the accessible H1 catalog with lightweight previews - one HTTP
     call per page, no per-programme detail fetch. Cheap, so use this first
@@ -45,22 +46,23 @@ def browse_programmes_tool(
       - sort: e.g. "-launched_at" for newest first
       - limit: cap on total previews (default config.h1.max_programmes)
 
-    Returns a list of ProgrammePreview dicts. Hydrate shortlisted handles
-    with hydrate_programme_tool.
+    Returns a list of ProgrammePreview. Hydrate shortlisted handles with
+    hydrate_programme_tool.
     """
-    previews = h1.browse_programmes(
-        asset_type=asset_type,
-        bookmarked=bookmarked,
-        offers_bounties=offers_bounties,
-        submission_state=submission_state,
-        sort=sort,
-        limit=limit,
+    return list(
+        h1.browse_programmes(
+            asset_type=asset_type,
+            bookmarked=bookmarked,
+            offers_bounties=offers_bounties,
+            submission_state=submission_state,
+            sort=sort,
+            limit=limit,
+        )
     )
-    return [p.model_dump() for p in previews]
 
 
 @tool("Hydrate HackerOne Programme")
-def hydrate_programme_tool(handle: str) -> dict:
+def hydrate_programme_tool(handle: str) -> Programme:
     """
     Fetch full programme detail for one handle - bounty_table, structured
     scope, policy text, response/payout stats. One HTTP call.
@@ -73,7 +75,7 @@ def hydrate_programme_tool(handle: str) -> dict:
     cache_path = runtime.programme_cache_path(prog.handle)
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     cache_path.write_text(prog.model_dump_json(), encoding="utf-8")
-    return prog.model_dump()
+    return prog
 
 
 @tool("Save Selected Programme")

--- a/squad/technical_author/__init__.py
+++ b/squad/technical_author/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from crewai.tools import tool
 
 from models import ProgrammeReportSummary
-from squad import SquadMember, cached_tool, read_run_file_tool, read_run_filelist_tool
+from squad import SquadMember, read_run_file_tool, read_run_filelist_tool
 from tools import http
 from tools.cwe_data import CWEEntry
 from tools.cwe_data import lookup as cwe_lookup
@@ -43,7 +43,7 @@ def sanitise_evidence_tool(text: str) -> SanitisationReport:
     return sanitise_evidence(text)
 
 
-@cached_tool("Lookup CWE")
+@tool("Lookup CWE")
 def lookup_cwe_tool(query: str) -> list[CWEEntry]:
     """
     Find Common Weakness Enumeration entries that match a query. Pass a
@@ -55,7 +55,7 @@ def lookup_cwe_tool(query: str) -> list[CWEEntry]:
     return list(cwe_lookup(query))
 
 
-@cached_tool("Lookup OWASP Guidance")
+@tool("Lookup OWASP Guidance")
 def lookup_owasp_tool(query: str) -> list[OWASPEntry]:
     """
     Find OWASP Cheat Sheet entries that match a query (topic slug or title

--- a/squad/technical_author/__init__.py
+++ b/squad/technical_author/__init__.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from crewai.tools import tool
 
-from squad import SquadMember, read_run_file_tool, read_run_filelist_tool
+from squad import SquadMember, cached_tool, read_run_file_tool, read_run_filelist_tool
 from tools import cwe_data, http, owasp_data
 from tools.h1_api import h1
 from tools.report_tools import (
@@ -36,7 +36,7 @@ def sanitise_evidence_tool(text: str) -> dict:
     return sanitise_evidence(text).model_dump()
 
 
-@tool("Lookup CWE")
+@cached_tool("Lookup CWE")
 def lookup_cwe_tool(query: str) -> list[dict]:
     """
     Find Common Weakness Enumeration entries that match a query. Pass a
@@ -58,7 +58,7 @@ def lookup_cwe_tool(query: str) -> list[dict]:
     ]
 
 
-@tool("Lookup OWASP Guidance")
+@cached_tool("Lookup OWASP Guidance")
 def lookup_owasp_tool(query: str) -> list[dict]:
     """
     Find OWASP Cheat Sheet entries that match a query (topic slug or title

--- a/squad/technical_author/__init__.py
+++ b/squad/technical_author/__init__.py
@@ -6,12 +6,19 @@ from pathlib import Path
 
 from crewai.tools import tool
 
+from models import ProgrammeReportSummary
 from squad import SquadMember, cached_tool, read_run_file_tool, read_run_filelist_tool
-from tools import cwe_data, http, owasp_data
+from tools import http
+from tools.cwe_data import CWEEntry
+from tools.cwe_data import lookup as cwe_lookup
 from tools.h1_api import h1
+from tools.owasp_data import OWASPEntry
+from tools.owasp_data import lookup as owasp_lookup
 from tools.report_tools import (
     FinalisationError,
     ReportDraft,
+    ReportDraftResult,
+    SanitisationReport,
     calculate_cvss_score,
     finalise_drafts,
     load_verified,
@@ -23,7 +30,7 @@ from tools.workspace import resolve_run_path
 
 
 @tool("Sanitise Evidence")
-def sanitise_evidence_tool(text: str) -> dict:
+def sanitise_evidence_tool(text: str) -> SanitisationReport:
     """
     Redact credentials, cookies, bearer tokens, JWTs, AWS keys and secret-shaped
     key=value pairs from a chunk of evidence so it is safe to inline in a
@@ -33,11 +40,11 @@ def sanitise_evidence_tool(text: str) -> dict:
     request that proves the issue. Run this on the Penetration Tester's raw
     evidence before pasting it into Draft Vulnerability Report.
     """
-    return sanitise_evidence(text).model_dump()
+    return sanitise_evidence(text)
 
 
 @cached_tool("Lookup CWE")
-def lookup_cwe_tool(query: str) -> list[dict]:
+def lookup_cwe_tool(query: str) -> list[CWEEntry]:
     """
     Find Common Weakness Enumeration entries that match a query. Pass a
     vuln_class string ("SQLi", "ReflectedXSS"), a CWE name ("Cross-Site
@@ -45,21 +52,11 @@ def lookup_cwe_tool(query: str) -> list[dict]:
     short description, MITRE URL, and the matching OWASP cheat-sheet topic so
     you can chain to Lookup OWASP Guidance.
     """
-    entries = cwe_data.lookup(query)
-    return [
-        {
-            "cwe_id": e.cwe_id,
-            "name": e.name,
-            "description": e.description,
-            "url": e.url,
-            "owasp_topic": e.owasp_topic,
-        }
-        for e in entries
-    ]
+    return list(cwe_lookup(query))
 
 
 @cached_tool("Lookup OWASP Guidance")
-def lookup_owasp_tool(query: str) -> list[dict]:
+def lookup_owasp_tool(query: str) -> list[OWASPEntry]:
     """
     Find OWASP Cheat Sheet entries that match a query (topic slug or title
     keyword such as "sql injection", "ssrf", "authorization"). Returns each
@@ -67,16 +64,7 @@ def lookup_owasp_tool(query: str) -> list[dict]:
     canonical cheatsheetseries.owasp.org URL to cite in the Remediation
     section.
     """
-    entries = owasp_data.lookup(query)
-    return [
-        {
-            "topic": e.topic,
-            "title": e.title,
-            "url": e.url,
-            "key_principles": e.key_principles,
-        }
-        for e in entries
-    ]
+    return list(owasp_lookup(query))
 
 
 @tool("Calculate CVSS Score")
@@ -91,7 +79,9 @@ def calculate_cvss_tool(vector: str) -> float:
 
 
 @tool("List Programme Reports")
-def list_programme_reports_tool(programme_handle: str, page_size: int = 25) -> list[dict]:
+def list_programme_reports_tool(
+    programme_handle: str, page_size: int = 25
+) -> list[ProgrammeReportSummary]:
     """
     List recent public reports on this programme so you can write a title that
     is distinct from existing submissions. Returns each report's id, title,
@@ -102,12 +92,12 @@ def list_programme_reports_tool(programme_handle: str, page_size: int = 25) -> l
     http.set_programme(programme_handle)
     reports = h1.list_reports(programme_handle, page_size=page_size)
     return [
-        {
-            "report_id": r.get("id"),
-            "title": r.get("attributes", {}).get("title"),
-            "severity": r.get("attributes", {}).get("severity_rating"),
-            "state": r.get("attributes", {}).get("state"),
-        }
+        ProgrammeReportSummary(
+            report_id=r.get("id"),
+            title=r.get("attributes", {}).get("title"),
+            severity=r.get("attributes", {}).get("severity_rating"),
+            state=r.get("attributes", {}).get("state"),
+        )
         for r in reports
     ]
 
@@ -125,7 +115,7 @@ def draft_report_tool(
     cvss_vector: str,
     cwe_id: int,
     verified_path: str = "verified.json",
-) -> dict:
+) -> ReportDraftResult:
     """
     Draft a single H1-format report for one verified finding and run quality
     validation against it. The carried fields (target, vuln_class, severity)
@@ -144,9 +134,10 @@ def draft_report_tool(
       - cvss_vector + cwe_id: must match the computed CVSS score and an entry
         in the CWE catalogue
 
-    Returns {"path": "drafts/NNN.json", "validation": {ok, issues}}. When
-    ok is false, re-run with the issues addressed - Finalise Reports refuses
-    to consolidate drafts with unresolved errors.
+    Returns a ReportDraftResult with the relative draft path and a
+    ValidationReport. When validation.ok is false, re-run with the issues
+    addressed - Finalise Reports refuses to consolidate drafts with
+    unresolved errors.
     """
     verified = load_verified(resolve_run_path(verified_path))
     if finding_index < 0 or finding_index >= len(verified):
@@ -173,11 +164,10 @@ def draft_report_tool(
         remediation=remediation.strip(),
     )
     path = save_draft(draft)
-    report = validate_draft(draft)
-    return {
-        "path": str(path.relative_to(path.parents[1])),
-        "validation": report.model_dump(),
-    }
+    return ReportDraftResult(
+        path=str(path.relative_to(path.parents[1])),
+        validation=validate_draft(draft),
+    )
 
 
 @tool("Finalise Reports")

--- a/squad/vulnerability_researcher/__init__.py
+++ b/squad/vulnerability_researcher/__init__.py
@@ -9,7 +9,13 @@ from typing import Protocol, cast
 
 from crewai.tools import tool
 
-from models import Severity
+from models import (
+    CveEntry,
+    ProgrammeReportSummary,
+    RawFinding,
+    RawFindingSummary,
+    Severity,
+)
 from models.attack import (
     AttackPlan,
     AttackPlanFinalisationError,
@@ -17,20 +23,28 @@ from models.attack import (
 )
 from models.h1 import Programme
 from squad import (
+    CrewAITool,
     SquadMember,
+    cached_tool,
     read_attack_plan_tool,
     read_run_file_tool,
     read_run_filelist_tool,
 )
-from tools import cwe_data, http, owasp_data
+from tools import http
+from tools.cwe_data import CWEEntry
+from tools.cwe_data import lookup as cwe_lookup
 from tools.h1_api import h1
+from tools.owasp_data import OWASPEntry
+from tools.owasp_data import lookup as owasp_lookup
 from tools.pentest import lookup_cve
 from tools.report_tools import calculate_cvss_score
 from tools.research_tools import finalise_research
 from tools.research_vocab import compose_research_brief_doc
 from tools.triage_tools import (
+    AssessmentResult,
     DiscardEntry,
     DiscardReason,
+    DiscardResult,
     SeverityDecision,
     TriageAssessment,
     TriageFinalisationError,
@@ -49,11 +63,14 @@ from tools.workspace import resolve_run_path
 _ResearchBriefFn = Callable[..., str]
 
 
-class _ResearchBriefTool(Protocol):
-    """Runtime shape of a CrewAI @tool: callable that exposes .func and .description."""
+class _ResearchBriefTool(CrewAITool, Protocol):
+    """Runtime shape of a CrewAI @tool: callable that exposes .func and .description.
 
-    func: _ResearchBriefFn
-    description: str
+    Inherits ``name`` / ``description`` / ``func`` from ``CrewAITool`` and
+    pins the call signature to the workspace-handle ``str`` return - the
+    research brief tool writes ``attack_plan.json`` and hands the next
+    agent its filename.
+    """
 
     def __call__(self, *args: object, **kwargs: object) -> str: ...
 
@@ -79,18 +96,20 @@ def research_brief_tool(name: str) -> Callable[[_ResearchBriefFn], _ResearchBrie
 
 
 @tool("NVD CVE Lookup")
-def lookup_cve_tool(keyword: str) -> list[dict]:
+def lookup_cve_tool(keyword: str) -> list[CveEntry]:
     """
     Search the NVD for CVEs matching a vulnerability class or technology
     keyword. Use this to identify known-vulnerable versions of the
     technologies the OSINT Analyst detected, so the Penetration Tester
     can run targeted probes instead of shotgun scans.
     """
-    return lookup_cve(keyword)
+    return [CveEntry(**r) for r in lookup_cve(keyword)]
 
 
 @tool("List Programme Reports")
-def list_programme_reports_tool(programme_handle: str, page_size: int = 25) -> list[dict]:
+def list_programme_reports_tool(
+    programme_handle: str, page_size: int = 25
+) -> list[ProgrammeReportSummary]:
     """
     List recent public reports filed against this programme. Use this to
     understand what vulnerability classes others have already found: spot
@@ -102,12 +121,12 @@ def list_programme_reports_tool(programme_handle: str, page_size: int = 25) -> l
     http.set_programme(programme_handle)
     reports = h1.list_reports(programme_handle, page_size=page_size)
     return [
-        {
-            "report_id": r.get("id"),
-            "title": r.get("attributes", {}).get("title"),
-            "severity": r.get("attributes", {}).get("severity_rating"),
-            "state": r.get("attributes", {}).get("state"),
-        }
+        ProgrammeReportSummary(
+            report_id=r.get("id"),
+            title=r.get("attributes", {}).get("title"),
+            severity=r.get("attributes", {}).get("severity_rating"),
+            state=r.get("attributes", {}).get("state"),
+        )
         for r in reports
     ]
 
@@ -165,7 +184,7 @@ def finalise_research_tool(
 
 
 @tool("List Raw Findings")
-def list_raw_findings_tool(findings_path: str = "findings.json") -> list[dict]:
+def list_raw_findings_tool(findings_path: str = "findings.json") -> list[RawFindingSummary]:
     """
     Compact summary of every raw finding in findings.json: returns
     {index, title, vuln_class, target, severity_hint, evidence_bytes} per
@@ -175,20 +194,20 @@ def list_raw_findings_tool(findings_path: str = "findings.json") -> list[dict]:
     """
     raw = load_raw_findings(resolve_run_path(findings_path))
     return [
-        {
-            "index": i,
-            "title": f.title,
-            "vuln_class": f.vuln_class,
-            "target": f.target,
-            "severity_hint": f.severity_hint.value,
-            "evidence_bytes": len(f.evidence),
-        }
+        RawFindingSummary(
+            index=i,
+            title=f.title,
+            vuln_class=f.vuln_class,
+            target=f.target,
+            severity_hint=f.severity_hint,
+            evidence_bytes=len(f.evidence),
+        )
         for i, f in enumerate(raw)
     ]
 
 
 @tool("Read Raw Finding")
-def read_raw_finding_tool(index: int, findings_path: str = "findings.json") -> dict:
+def read_raw_finding_tool(index: int, findings_path: str = "findings.json") -> RawFinding:
     """
     Return the full raw finding at ``index`` from findings.json including its
     evidence payload (which can be large). Pair with List Raw Findings to
@@ -197,7 +216,7 @@ def read_raw_finding_tool(index: int, findings_path: str = "findings.json") -> d
     raw = load_raw_findings(resolve_run_path(findings_path))
     if index < 0 or index >= len(raw):
         raise ValueError(f"index {index} out of range (findings.json has {len(raw)} entries)")
-    return raw[index].model_dump(mode="json")
+    return raw[index]
 
 
 @tool("Calculate CVSS Score")
@@ -211,44 +230,25 @@ def calculate_cvss_tool(vector: str) -> float:
     return calculate_cvss_score(vector)
 
 
-@tool("Lookup CWE")
-def lookup_cwe_tool(query: str) -> list[dict]:
+@cached_tool("Lookup CWE")
+def lookup_cwe_tool(query: str) -> list[CWEEntry]:
     """
     Find Common Weakness Enumeration entries that match a query. Useful when
     writing the remediation section to cite the canonical MITRE definition
     and chain to the matching OWASP cheat-sheet via Lookup OWASP Guidance.
     """
-    entries = cwe_data.lookup(query)
-    return [
-        {
-            "cwe_id": e.cwe_id,
-            "name": e.name,
-            "description": e.description,
-            "url": e.url,
-            "owasp_topic": e.owasp_topic,
-        }
-        for e in entries
-    ]
+    return list(cwe_lookup(query))
 
 
-@tool("Lookup OWASP Guidance")
-def lookup_owasp_tool(query: str) -> list[dict]:
+@cached_tool("Lookup OWASP Guidance")
+def lookup_owasp_tool(query: str) -> list[OWASPEntry]:
     """
     Find OWASP Cheat Sheet entries that match a query (topic slug, title, or
     short alias such as "ssrf", "csrf", "sqli"). Returns title, paste-friendly
     key_principles, and the canonical cheatsheetseries.owasp.org URL to cite
     in the remediation section.
     """
-    entries = owasp_data.lookup(query)
-    return [
-        {
-            "topic": e.topic,
-            "title": e.title,
-            "url": e.url,
-            "key_principles": e.key_principles,
-        }
-        for e in entries
-    ]
+    return list(owasp_lookup(query))
 
 
 @tool("Assess Raw Finding")
@@ -265,7 +265,7 @@ def assess_finding_tool(
     remediation: str,
     findings_path: str = "findings.json",
     programme_handle: str | None = None,
-) -> dict:
+) -> AssessmentResult:
     """
     Author one triage assessment for the raw finding at ``finding_index`` and
     run the quality gate. The carried fields (target, vuln_class,
@@ -286,8 +286,9 @@ def assess_finding_tool(
       - remediation: actionable fix with an OWASP or CWE URL citation
 
     Out-of-scope or below-floor findings are rejected: use Discard Finding
-    instead. Returns {"path": "assessments/NNN.json", "validation": {...}};
-    when validation.ok is false, re-run with the issues addressed.
+    instead. Returns an AssessmentResult with the relative assessment path
+    and a TriageValidationReport; when validation.ok is false, re-run with
+    the issues addressed.
     """
     raw = load_raw_findings(resolve_run_path(findings_path))
     if finding_index < 0 or finding_index >= len(raw):
@@ -313,11 +314,10 @@ def assess_finding_tool(
         remediation=remediation.strip(),
     )
     path = save_assessment(assessment)
-    report = validate_assessment_impl(assessment, finding, programme)
-    return {
-        "path": str(path.relative_to(path.parents[1])),
-        "validation": report.model_dump(),
-    }
+    return AssessmentResult(
+        path=str(path.relative_to(path.parents[1])),
+        validation=validate_assessment_impl(assessment, finding, programme),
+    )
 
 
 @tool("Discard Finding")
@@ -326,13 +326,13 @@ def discard_finding_tool(
     reason: str,
     rationale: str,
     findings_path: str = "findings.json",
-) -> dict:
+) -> DiscardResult:
     """
     Mark a raw finding as not eligible for verified.json. ``reason`` must be
     one of: out_of_scope, below_floor, false_positive, duplicate,
     non_exploitable. ``rationale`` is a one-sentence justification recorded
     on the discard entry and surfaced in the briefing to the Technical
-    Author. Returns {"path": "discards/NNN.json"}.
+    Author. Returns a DiscardResult with the relative discard path.
     """
     raw = load_raw_findings(resolve_run_path(findings_path))
     if finding_index < 0 or finding_index >= len(raw):
@@ -349,7 +349,7 @@ def discard_finding_tool(
         rationale=rationale.strip(),
     )
     path = save_discard(entry)
-    return {"path": str(path.relative_to(path.parents[1]))}
+    return DiscardResult(path=str(path.relative_to(path.parents[1])))
 
 
 @tool("Finalise Triage")

--- a/squad/vulnerability_researcher/__init__.py
+++ b/squad/vulnerability_researcher/__init__.py
@@ -25,7 +25,6 @@ from models.h1 import Programme
 from squad import (
     CrewAITool,
     SquadMember,
-    cached_tool,
     read_attack_plan_tool,
     read_run_file_tool,
     read_run_filelist_tool,
@@ -230,7 +229,7 @@ def calculate_cvss_tool(vector: str) -> float:
     return calculate_cvss_score(vector)
 
 
-@cached_tool("Lookup CWE")
+@tool("Lookup CWE")
 def lookup_cwe_tool(query: str) -> list[CWEEntry]:
     """
     Find Common Weakness Enumeration entries that match a query. Useful when
@@ -240,7 +239,7 @@ def lookup_cwe_tool(query: str) -> list[CWEEntry]:
     return list(cwe_lookup(query))
 
 
-@cached_tool("Lookup OWASP Guidance")
+@tool("Lookup OWASP Guidance")
 def lookup_owasp_tool(query: str) -> list[OWASPEntry]:
     """
     Find OWASP Cheat Sheet entries that match a query (topic slug, title, or

--- a/squad/workspace_tools.py
+++ b/squad/workspace_tools.py
@@ -4,27 +4,27 @@ from __future__ import annotations
 
 from crewai.tools import tool
 
+from models import RunFile, RunFileContent
 from models.attack import AttackPlan
 from tools import workspace
 from tools.research_tools import attack_plan_path, load_attack_plan
 
 
 @tool("List Run Files")
-def read_run_filelist_tool() -> list[dict]:
+def read_run_filelist_tool() -> list[RunFile]:
     """List the artefacts written to the current run directory by the squad
     so far, each with its name and byte size. Use this to discover what an
     upstream teammate has produced before deciding which file to sample with
     Read Run File."""
-    return workspace.list_run_files()
+    return [RunFile(**entry) for entry in workspace.list_run_files()]
 
 
 @tool("Read Run File")
-def read_run_file_tool(relative_path: str) -> dict:
+def read_run_file_tool(relative_path: str) -> RunFileContent:
     """Read a file from the current run directory and return its full contents.
     ``relative_path`` is a path relative to the run directory (e.g.
-    "recon.json") - the only kind of path this tool accepts. Returns
-    {name, size_bytes, content}."""
-    return workspace.read_run_file(relative_path)
+    "recon.json") - the only kind of path this tool accepts."""
+    return RunFileContent(**workspace.read_run_file(relative_path))
 
 
 @tool("Read Attack Plan")

--- a/tests/test_squad_disclosure_coordinator.py
+++ b/tests/test_squad_disclosure_coordinator.py
@@ -9,7 +9,7 @@ underlying helpers are exercised in their own dedicated test files.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -18,11 +18,11 @@ pytestmark = pytest.mark.unit
 
 class TestDisclosureCoordinatorTools:
     def test_submit_report_tool(self, disclosure_report) -> None:
+        from models.h1 import SubmissionResult, SubmissionStatus
         from squad.disclosure_coordinator import submit_report_tool
 
         report_json = disclosure_report.model_dump_json()
-        submission = MagicMock()
-        submission.model_dump.return_value = {"submitted": True, "id": "h1-42"}
+        submission = SubmissionResult(report_id="h1-42", status=SubmissionStatus.SUBMITTED)
 
         with (
             patch("squad.disclosure_coordinator.http.set_programme") as mhttp,
@@ -34,7 +34,7 @@ class TestDisclosureCoordinatorTools:
         ):
             result = submit_report_tool.func(report_json)
 
-        assert result == {"submitted": True, "id": "h1-42"}
+        assert result == submission
         mhttp.assert_called_once_with(disclosure_report.programme_handle)
         msave.assert_called_once()
         msub.assert_called_once()
@@ -59,4 +59,5 @@ class TestDisclosureCoordinatorTools:
 
         assert isinstance(result, list)
         assert len(result) == 1
-        assert result[0]["title"] == "SQL Injection in search"
+        assert result[0].title == "SQL Injection in search"
+        assert result[0].report_id == "1"

--- a/tests/test_squad_osint_analyst.py
+++ b/tests/test_squad_osint_analyst.py
@@ -304,8 +304,6 @@ class TestOsintAnalystTools:
         from squad.osint_analyst import lookup_cwe_tool
         from tools.cwe_data import CWEEntry
 
-        # Caches across tests; clear so this case sees a real lookup.
-        lookup_cwe_tool.func.cache_clear()  # type: ignore[attr-defined]
         result = lookup_cwe_tool.func("XSS")
         assert isinstance(result, list)
         assert result
@@ -316,7 +314,6 @@ class TestOsintAnalystTools:
         from squad.osint_analyst import lookup_owasp_tool
         from tools.owasp_data import OWASPEntry
 
-        lookup_owasp_tool.func.cache_clear()  # type: ignore[attr-defined]
         result = lookup_owasp_tool.func("sql injection")
         assert isinstance(result, list)
         assert all(isinstance(r, OWASPEntry) for r in result)

--- a/tests/test_squad_osint_analyst.py
+++ b/tests/test_squad_osint_analyst.py
@@ -79,8 +79,10 @@ class TestOsintAnalystTools:
             for p in reversed(patches):
                 p.stop()
 
-        assert isinstance(result, dict)
-        assert result["validation"]["ok"] is True
+        from tools.recon_insights import HostAnnotation
+
+        assert isinstance(result, HostAnnotation)
+        assert result.validation.ok is True
         assert (tmp_path / "host_insights" / "api.example.com.json").exists()
 
     def test_annotate_host_tool_surfaces_validation_issues(
@@ -108,9 +110,11 @@ class TestOsintAnalystTools:
             for p in reversed(patches):
                 p.stop()
 
-        assert isinstance(result, dict)
-        assert result["validation"]["ok"] is False
-        sections = {i["section"] for i in result["validation"]["issues"]}
+        from tools.recon_insights import HostAnnotation
+
+        assert isinstance(result, HostAnnotation)
+        assert result.validation.ok is False
+        sections = {i.section for i in result.validation.issues}
         assert "notes" in sections
 
     def test_uncovered_hosts_tool_returns_missing(self, programme, recon_result, tmp_path) -> None:
@@ -197,7 +201,7 @@ class TestOsintAnalystTools:
                 p.stop()
 
         assert isinstance(result, list)
-        assert result[0]["url"] == endpoint.url
+        assert result[0].url == endpoint.url
 
     def test_probe_hostnames_tool_empty_list(self) -> None:
         from squad.osint_analyst import probe_hostnames_tool
@@ -260,14 +264,7 @@ class TestOsintAnalystTools:
                 p.stop()
 
         assert isinstance(result, list)
-        assert result == [
-            {
-                "hostname": "legacy.example.com",
-                "cname": "bucket.s3.amazonaws.com",
-                "reason": "cname_to_vulnerable_provider",
-                "service": "AWS S3",
-            }
-        ]
+        assert result == [candidate]
 
     def test_detect_takeover_candidates_tool_empty(self) -> None:
         from squad.osint_analyst import detect_takeover_candidates_tool
@@ -305,18 +302,25 @@ class TestOsintAnalystTools:
 
     def test_lookup_cwe_tool(self) -> None:
         from squad.osint_analyst import lookup_cwe_tool
+        from tools.cwe_data import CWEEntry
 
+        # Caches across tests; clear so this case sees a real lookup.
+        lookup_cwe_tool.func.cache_clear()  # type: ignore[attr-defined]
         result = lookup_cwe_tool.func("XSS")
         assert isinstance(result, list)
         assert result
-        assert result[0]["cwe_id"] == 79
+        assert isinstance(result[0], CWEEntry)
+        assert result[0].cwe_id == 79
 
     def test_lookup_owasp_tool(self) -> None:
         from squad.osint_analyst import lookup_owasp_tool
+        from tools.owasp_data import OWASPEntry
 
+        lookup_owasp_tool.func.cache_clear()  # type: ignore[attr-defined]
         result = lookup_owasp_tool.func("sql injection")
         assert isinstance(result, list)
-        assert any("SQL_Injection_Prevention" in r["url"] for r in result)
+        assert all(isinstance(r, OWASPEntry) for r in result)
+        assert any("SQL_Injection_Prevention" in r.url for r in result)
 
     def test_cert_transparency_tool(self) -> None:
         from squad.osint_analyst import cert_transparency_tool
@@ -345,6 +349,7 @@ class TestOsintAnalystTools:
         m.assert_called_once_with("example.com")
 
     def test_llm_detection_tool(self, endpoint) -> None:
+        from models import LlmEndpoint
         from squad.osint_analyst import llm_detection_tool
 
         endpoints_json = json.dumps([endpoint.model_dump(mode="json")])
@@ -354,5 +359,5 @@ class TestOsintAnalystTools:
         ) as m:
             result = llm_detection_tool.func(endpoints_json)
 
-        assert result == [endpoint.model_dump()]
+        assert result == [LlmEndpoint.model_validate(endpoint.model_dump())]
         assert len(m.call_args[0][0]) == 1

--- a/tests/test_squad_penetration_tester.py
+++ b/tests/test_squad_penetration_tester.py
@@ -30,7 +30,7 @@ class TestPenetrationTesterTools:
         ):
             result = nuclei_scan_tool.func(endpoints_json, '["wordpress"]')
 
-        assert result == [raw_finding_low.model_dump()]
+        assert result == [raw_finding_low]
 
     def test_sqlmap_tool(self, endpoint, raw_finding_low) -> None:
         from squad.penetration_tester import sqlmap_tool
@@ -42,7 +42,7 @@ class TestPenetrationTesterTools:
         ):
             result = sqlmap_tool.func(endpoints_json)
 
-        assert result == [raw_finding_low.model_dump()]
+        assert result == [raw_finding_low]
 
     def test_cookie_check_tool(self, recon_result, raw_finding_low, tmp_path) -> None:
         from squad.penetration_tester import cookie_check_tool
@@ -59,7 +59,7 @@ class TestPenetrationTesterTools:
         ):
             result = cookie_check_tool.func("recon.json")
 
-        assert result == [raw_finding_low.model_dump()]
+        assert result == [raw_finding_low]
         mhttp.assert_called_once_with(recon_result.programme.handle)
 
     def test_cors_check_tool(self, recon_result, raw_finding_low, tmp_path) -> None:
@@ -77,7 +77,7 @@ class TestPenetrationTesterTools:
         ):
             result = cors_check_tool.func("recon.json")
 
-        assert result == [raw_finding_low.model_dump()]
+        assert result == [raw_finding_low]
 
     def test_csrf_check_tool(self, recon_result, raw_finding_low, tmp_path) -> None:
         from squad.penetration_tester import csrf_check_tool
@@ -94,7 +94,7 @@ class TestPenetrationTesterTools:
         ):
             result = csrf_check_tool.func("recon.json")
 
-        assert result == [raw_finding_low.model_dump()]
+        assert result == [raw_finding_low]
 
     def test_ssrf_probe_tool(self, endpoint, raw_finding_low) -> None:
         from squad.penetration_tester import ssrf_probe_tool
@@ -106,7 +106,7 @@ class TestPenetrationTesterTools:
         ):
             result = ssrf_probe_tool.func(endpoints_json, None)
 
-        assert result == [raw_finding_low.model_dump()]
+        assert result == [raw_finding_low]
 
     def test_header_injection_tool(self, recon_result, raw_finding_low, tmp_path) -> None:
         from squad.penetration_tester import header_injection_tool
@@ -123,7 +123,7 @@ class TestPenetrationTesterTools:
         ):
             result = header_injection_tool.func("recon.json")
 
-        assert result == [raw_finding_low.model_dump()]
+        assert result == [raw_finding_low]
 
     def test_host_header_tool(self, recon_result, raw_finding_low, tmp_path) -> None:
         from squad.penetration_tester import host_header_tool
@@ -140,7 +140,7 @@ class TestPenetrationTesterTools:
         ):
             result = host_header_tool.func("recon.json")
 
-        assert result == [raw_finding_low.model_dump()]
+        assert result == [raw_finding_low]
 
     def test_save_findings_tool(self, raw_finding_low, tmp_path) -> None:
         from squad.penetration_tester import save_findings_tool
@@ -179,6 +179,9 @@ class TestPenetrationTesterTools:
 
         recon_path = tmp_path / "recon.json"
         recon_path.write_text(recon_result.model_dump_json(), encoding="utf-8")
+        from models import OpenPortsMap
+
         with patch("tools.workspace.runtime.run_dir", return_value=tmp_path):
             result = recon_open_ports_tool.func("recon.json")
-        assert result == recon_result.open_ports
+        assert isinstance(result, OpenPortsMap)
+        assert result.hosts == recon_result.open_ports

--- a/tests/test_squad_penetration_tester.py
+++ b/tests/test_squad_penetration_tester.py
@@ -23,24 +23,22 @@ class TestPenetrationTesterTools:
     def test_nuclei_scan_tool(self, endpoint, raw_finding_low) -> None:
         from squad.penetration_tester import nuclei_scan_tool
 
-        endpoints_json = json.dumps([endpoint.model_dump(mode="json")])
         with patch(
             "squad.penetration_tester.run_nuclei",
             return_value=[raw_finding_low],
         ):
-            result = nuclei_scan_tool.func(endpoints_json, '["wordpress"]')
+            result = nuclei_scan_tool.func([endpoint.model_dump(mode="json")], ["wordpress"])
 
         assert result == [raw_finding_low]
 
     def test_sqlmap_tool(self, endpoint, raw_finding_low) -> None:
         from squad.penetration_tester import sqlmap_tool
 
-        endpoints_json = json.dumps([endpoint.model_dump(mode="json")])
         with patch(
             "squad.penetration_tester.run_sqlmap",
             return_value=[raw_finding_low],
         ):
-            result = sqlmap_tool.func(endpoints_json)
+            result = sqlmap_tool.func([endpoint.model_dump(mode="json")])
 
         assert result == [raw_finding_low]
 
@@ -99,12 +97,11 @@ class TestPenetrationTesterTools:
     def test_ssrf_probe_tool(self, endpoint, raw_finding_low) -> None:
         from squad.penetration_tester import ssrf_probe_tool
 
-        endpoints_json = json.dumps([endpoint.model_dump(mode="json")])
         with patch(
             "squad.penetration_tester.check_ssrf",
             return_value=[raw_finding_low],
         ):
-            result = ssrf_probe_tool.func(endpoints_json, None)
+            result = ssrf_probe_tool.func([endpoint.model_dump(mode="json")], None)
 
         assert result == [raw_finding_low]
 
@@ -143,14 +140,15 @@ class TestPenetrationTesterTools:
         assert result == [raw_finding_low]
 
     def test_save_findings_tool(self, raw_finding_low, tmp_path) -> None:
+        from models import RawFinding
         from squad.penetration_tester import save_findings_tool
 
-        findings_json = json.dumps([raw_finding_low.model_dump(mode="json")])
         with patch("runtime.run_dir", return_value=tmp_path):
-            result = save_findings_tool.func(findings_json)
+            result = save_findings_tool.func([raw_finding_low.model_dump(mode="json")])
 
         assert result == "findings.json"
-        assert (tmp_path / "findings.json").read_text(encoding="utf-8") == findings_json
+        persisted = json.loads((tmp_path / "findings.json").read_text(encoding="utf-8"))
+        assert [RawFinding.model_validate(f) for f in persisted] == [raw_finding_low]
 
     def test_recon_subdomains_tool(self, recon_result, tmp_path) -> None:
         from squad.penetration_tester import recon_subdomains_tool

--- a/tests/test_squad_programme_manager.py
+++ b/tests/test_squad_programme_manager.py
@@ -33,7 +33,7 @@ class TestBrowseProgrammesTool:
         ) as mbrowse:
             result = browse_programmes_tool.func(offers_bounties=True)
 
-        assert result == [p.model_dump() for p in previews]
+        assert result == previews
         # No filter args defaulted, only the one we passed in flight.
         mbrowse.assert_called_once_with(
             asset_type=None,
@@ -88,7 +88,7 @@ class TestHydrateProgrammeTool:
         ):
             result = hydrate_programme_tool.func(programme.handle)
 
-        assert result == programme.model_dump()
+        assert result == programme
         mhydrate.assert_called_once_with(programme.handle)
         assert cache_path.exists()
 

--- a/tests/test_squad_technical_author.py
+++ b/tests/test_squad_technical_author.py
@@ -63,6 +63,7 @@ class TestTechnicalAuthorTools:
         self, verified_vuln, tmp_path
     ) -> None:
         from squad.technical_author import draft_report_tool
+        from tools.report_tools import ReportDraftResult
 
         self._write_verified(tmp_path, verified_vuln)
         with (
@@ -71,12 +72,13 @@ class TestTechnicalAuthorTools:
         ):
             result = draft_report_tool.func(**self._good_authoring())
 
-        assert isinstance(result, dict)
-        assert result["validation"]["ok"] is True
+        assert isinstance(result, ReportDraftResult)
+        assert result.validation.ok is True
         assert (tmp_path / "drafts" / "000.json").exists()
 
     def test_draft_report_tool_surfaces_validation_issues(self, verified_vuln, tmp_path) -> None:
         from squad.technical_author import draft_report_tool
+        from tools.report_tools import ReportDraftResult
 
         self._write_verified(tmp_path, verified_vuln)
         with (
@@ -85,9 +87,9 @@ class TestTechnicalAuthorTools:
         ):
             result = draft_report_tool.func(**self._good_authoring(title="bad title"))
 
-        assert isinstance(result, dict)
-        assert result["validation"]["ok"] is False
-        sections = {i["section"] for i in result["validation"]["issues"]}
+        assert isinstance(result, ReportDraftResult)
+        assert result.validation.ok is False
+        sections = {i.section for i in result.validation.issues}
         assert "title" in sections
 
     def test_draft_report_tool_rejects_out_of_range_index(self, verified_vuln, tmp_path) -> None:
@@ -131,20 +133,23 @@ class TestTechnicalAuthorTools:
 
     def test_sanitise_evidence_tool_returns_redactions(self) -> None:
         from squad.technical_author import sanitise_evidence_tool
+        from tools.report_tools import SanitisationReport
 
         result = sanitise_evidence_tool.func("Authorization: Bearer abc.def.ghi")
-        assert isinstance(result, dict)
-        assert "Bearer abc.def.ghi" not in result["sanitised"]
-        assert result["redactions"]
+        assert isinstance(result, SanitisationReport)
+        assert "Bearer abc.def.ghi" not in result.sanitised
+        assert result.redactions
 
     def test_lookup_cwe_tool_finds_known_class(self) -> None:
         from squad.technical_author import lookup_cwe_tool
+        from tools.cwe_data import CWEEntry
 
         result = lookup_cwe_tool.func("SQLi")
         assert isinstance(result, list)
         assert result
-        assert result[0]["cwe_id"] == 89
-        assert "cwe.mitre.org" in result[0]["url"]
+        assert isinstance(result[0], CWEEntry)
+        assert result[0].cwe_id == 89
+        assert "cwe.mitre.org" in result[0].url
 
     def test_lookup_cwe_tool_empty_for_unknown(self) -> None:
         from squad.technical_author import lookup_cwe_tool
@@ -165,11 +170,13 @@ class TestTechnicalAuthorTools:
 
     def test_lookup_owasp_tool_returns_cheatsheet(self) -> None:
         from squad.technical_author import lookup_owasp_tool
+        from tools.owasp_data import OWASPEntry
 
         result = lookup_owasp_tool.func("sql injection")
         assert isinstance(result, list)
         assert result
-        assert any("SQL_Injection_Prevention" in r["url"] for r in result)
+        assert all(isinstance(r, OWASPEntry) for r in result)
+        assert any("SQL_Injection_Prevention" in r.url for r in result)
 
     def test_calculate_cvss_tool(self) -> None:
         from squad.technical_author import calculate_cvss_tool
@@ -184,6 +191,7 @@ class TestTechnicalAuthorTools:
         m.assert_called_once_with("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
 
     def test_list_programme_reports_tool(self) -> None:
+        from models import ProgrammeReportSummary
         from squad.technical_author import list_programme_reports_tool
 
         h1_reports = [
@@ -203,12 +211,12 @@ class TestTechnicalAuthorTools:
             result = list_programme_reports_tool.func("acme", page_size=10)
 
         assert result == [
-            {
-                "report_id": "1",
-                "title": "Existing report",
-                "severity": "high",
-                "state": "triaged",
-            }
+            ProgrammeReportSummary(
+                report_id="1",
+                title="Existing report",
+                severity="high",
+                state="triaged",
+            )
         ]
         mhttp.assert_called_once_with("acme")
         mlist.assert_called_once_with("acme", page_size=10)

--- a/tests/test_squad_technical_author.py
+++ b/tests/test_squad_technical_author.py
@@ -151,6 +151,18 @@ class TestTechnicalAuthorTools:
 
         assert lookup_cwe_tool.func("zzz-not-a-class") == []
 
+    def test_lookup_cwe_tool_memoises_repeat_queries(self) -> None:
+        from squad.technical_author import lookup_cwe_tool
+
+        # Tool.func is typed Callable[P, R]; cached_tool wraps it in
+        # functools.cache, which adds cache_clear at runtime.
+        lookup_cwe_tool.func.cache_clear()  # type: ignore[attr-defined]
+        first = lookup_cwe_tool.func("XXE")
+        second = lookup_cwe_tool.func("XXE")
+        # Same object identity proves the cache decorator is in effect; the
+        # default ``@tool`` wrapper would build a fresh list on every call.
+        assert first is second
+
     def test_lookup_owasp_tool_returns_cheatsheet(self) -> None:
         from squad.technical_author import lookup_owasp_tool
 

--- a/tests/test_squad_technical_author.py
+++ b/tests/test_squad_technical_author.py
@@ -156,18 +156,6 @@ class TestTechnicalAuthorTools:
 
         assert lookup_cwe_tool.func("zzz-not-a-class") == []
 
-    def test_lookup_cwe_tool_memoises_repeat_queries(self) -> None:
-        from squad.technical_author import lookup_cwe_tool
-
-        # Tool.func is typed Callable[P, R]; cached_tool wraps it in
-        # functools.cache, which adds cache_clear at runtime.
-        lookup_cwe_tool.func.cache_clear()  # type: ignore[attr-defined]
-        first = lookup_cwe_tool.func("XXE")
-        second = lookup_cwe_tool.func("XXE")
-        # Same object identity proves the cache decorator is in effect; the
-        # default ``@tool`` wrapper would build a fresh list on every call.
-        assert first is second
-
     def test_lookup_owasp_tool_returns_cheatsheet(self) -> None:
         from squad.technical_author import lookup_owasp_tool
         from tools.owasp_data import OWASPEntry

--- a/tests/test_squad_tool_contracts.py
+++ b/tests/test_squad_tool_contracts.py
@@ -1,0 +1,146 @@
+"""
+tests/test_squad_tool_contracts.py - contract test that walks every
+``MEMBER.tools`` entry across the squad and asserts each ``@tool``-wrapped
+function returns a pydantic ``BaseModel`` subclass or ``list[BaseModel]``.
+
+The rule is the one the ``cybersquad-tool`` skill prescribes: returning a
+bare ``dict`` or ``list[dict]`` strips the schema the agent should be
+reading. The exception is ``finalise_X`` / ``save_X`` workspace-handle
+tools that return the filename as ``str`` - those are whitelisted by name.
+
+Why this lives in CI rather than mypy: the typed annotation is enforced at
+runtime against the runtime registry of every ``SquadMember.tools`` entry.
+A new tool with the wrong return type fails this test in the same PR that
+introduces it, before any downstream agent sees the half-typed contract.
+"""
+
+from __future__ import annotations
+
+import typing
+from typing import get_args, get_origin
+
+import pytest
+from pydantic import BaseModel
+
+from squad import CrewAITool
+from squad.disclosure_coordinator import MEMBER as DISCLOSURE_COORDINATOR
+from squad.osint_analyst import MEMBER as OSINT_ANALYST
+from squad.penetration_tester import MEMBER as PENETRATION_TESTER
+from squad.programme_manager import MEMBER as PROGRAMME_MANAGER
+from squad.technical_author import MEMBER as TECHNICAL_AUTHOR
+from squad.vulnerability_researcher import MEMBER as VULNERABILITY_RESEARCHER
+
+pytestmark = pytest.mark.unit
+
+
+# Tools that intentionally return a workspace-handle string (the filename
+# the next agent passes to a typed reader). The cybersquad-tool skill spells
+# out why these stay as ``str`` rather than wrapping a ``WorkspaceHandle``
+# model: the filename IS the handle, and the typed reader is the contract.
+_HANDLE_TOOLS: frozenset[str] = frozenset(
+    {
+        "Run Initial Sweep",
+        "Finalise Recon",
+        "Finalise Research",
+        "Finalise Triage",
+        "Finalise Reports",
+        "Save Findings",
+        "Save Selected Programme",
+    }
+)
+
+
+def _every_tool() -> list[tuple[str, CrewAITool]]:
+    """Flat list of (agent_slug, tool) pairs across every squad member."""
+    out: list[tuple[str, CrewAITool]] = []
+    for member in (
+        PROGRAMME_MANAGER,
+        OSINT_ANALYST,
+        PENETRATION_TESTER,
+        VULNERABILITY_RESEARCHER,
+        TECHNICAL_AUTHOR,
+        DISCLOSURE_COORDINATOR,
+    ):
+        for tool_obj in member.tools:
+            out.append((member.slug, tool_obj))
+    return out
+
+
+def _is_pydantic_model(annotation: object) -> bool:
+    return isinstance(annotation, type) and issubclass(annotation, BaseModel)
+
+
+def _is_list_of_pydantic(annotation: object) -> bool:
+    origin = get_origin(annotation)
+    if origin is not list:
+        return False
+    args = get_args(annotation)
+    return len(args) == 1 and _is_pydantic_model(args[0])
+
+
+def _is_whitelisted_handle(tool_obj: CrewAITool, return_annotation: object) -> bool:
+    """Workspace-handle ``str`` returns are allowed for the named tools."""
+    return tool_obj.name in _HANDLE_TOOLS and return_annotation is str
+
+
+def _is_list_of_strings(annotation: object) -> bool:
+    """list[str] is permitted for flat handle / hostname lists.
+
+    The Recon Subdomains tool returns a bare hostname list and the cert
+    transparency / historical URL tools return hostname lists too - there
+    is no schema beyond ``str`` to enforce here.
+    """
+    origin = get_origin(annotation)
+    if origin is not list:
+        return False
+    args = get_args(annotation)
+    return len(args) == 1 and args[0] is str
+
+
+def _is_primitive(annotation: object) -> bool:
+    """float (CVSS), int, bool are allowed for scalar-result tools."""
+    return annotation in (float, int, bool)
+
+
+class TestSquadToolContracts:
+    @pytest.mark.parametrize(
+        ("agent_slug", "tool_obj"),
+        _every_tool(),
+        ids=[f"{slug}::{t.name}" for slug, t in _every_tool()],
+    )
+    def test_tool_return_annotation_is_typed(self, agent_slug: str, tool_obj: CrewAITool) -> None:
+        """Every tool returns a BaseModel, a list[BaseModel], or a whitelisted
+        primitive. ``dict``, ``list[dict]``, ``list[Any]``, bare ``list`` all
+        fail."""
+        hints = typing.get_type_hints(tool_obj.func)
+        assert "return" in hints, f"{agent_slug}::{tool_obj.name} has no return annotation"
+        ret = hints["return"]
+
+        if _is_pydantic_model(ret):
+            return
+        if _is_list_of_pydantic(ret):
+            return
+        if _is_whitelisted_handle(tool_obj, ret):
+            return
+        if _is_list_of_strings(ret):
+            return
+        if _is_primitive(ret):
+            return
+
+        pytest.fail(
+            f"{agent_slug}::{tool_obj.name} returns {ret!r}; "
+            "must be a pydantic BaseModel, list[BaseModel], list[str], "
+            "a primitive, or a whitelisted workspace-handle str."
+        )
+
+    def test_squad_member_tools_is_typed_list(self) -> None:
+        """``SquadMember.tools`` carries a typed list, not ``list[Any]``.
+
+        The runtime check is intentionally minimal - the dataclass field
+        is statically ``list[CrewAITool]``, so this asserts the Protocol
+        is satisfied by every tool registered today.
+        """
+        for _slug, tool_obj in _every_tool():
+            assert isinstance(tool_obj, CrewAITool), (
+                f"{tool_obj!r} does not satisfy CrewAITool: missing name/description/func"
+            )

--- a/tests/test_squad_vulnerability_researcher.py
+++ b/tests/test_squad_vulnerability_researcher.py
@@ -266,7 +266,6 @@ class TestVulnerabilityResearcherTools:
         from squad.vulnerability_researcher import lookup_cwe_tool
         from tools.cwe_data import CWEEntry
 
-        lookup_cwe_tool.func.cache_clear()  # type: ignore[attr-defined]
         result = lookup_cwe_tool.func("SQLi")
         assert isinstance(result, list)
         assert result
@@ -277,7 +276,6 @@ class TestVulnerabilityResearcherTools:
         from squad.vulnerability_researcher import lookup_owasp_tool
         from tools.owasp_data import OWASPEntry
 
-        lookup_owasp_tool.func.cache_clear()  # type: ignore[attr-defined]
         result = lookup_owasp_tool.func("sql injection")
         assert isinstance(result, list)
         assert all(isinstance(r, OWASPEntry) for r in result)

--- a/tests/test_squad_vulnerability_researcher.py
+++ b/tests/test_squad_vulnerability_researcher.py
@@ -19,16 +19,22 @@ pytestmark = pytest.mark.unit
 
 class TestVulnerabilityResearcherTools:
     def test_lookup_cve_tool(self) -> None:
+        from models import CveEntry
         from squad.vulnerability_researcher import lookup_cve_tool
 
-        sentinel = [{"cve_id": "CVE-2024-1234"}]
+        expected = CveEntry(
+            id="CVE-2024-1234",
+            cvss_score=9.8,
+            cvss_vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            description="Test CVE",
+        )
         with patch(
             "squad.vulnerability_researcher.lookup_cve",
-            return_value=sentinel,
+            return_value=[expected.model_dump()],
         ) as m:
             result = lookup_cve_tool.func("sql injection")
 
-        assert result == sentinel
+        assert result == [expected]
         m.assert_called_once_with("sql injection")
 
     def test_list_programme_reports_tool_returns_all(self) -> None:
@@ -63,8 +69,8 @@ class TestVulnerabilityResearcherTools:
 
         assert isinstance(result, list)
         assert len(result) == 2
-        assert result[0]["report_id"] == "1"
-        assert result[1]["severity"] == "medium"
+        assert result[0].report_id == "1"
+        assert result[1].severity == "medium"
 
     def test_list_programme_reports_tool_handles_missing_fields(self) -> None:
         from squad.vulnerability_researcher import list_programme_reports_tool
@@ -81,8 +87,8 @@ class TestVulnerabilityResearcherTools:
 
         assert isinstance(result, list)
         assert len(result) == 1
-        assert result[0]["title"] is None
-        assert result[0]["severity"] is None
+        assert result[0].title is None
+        assert result[0].severity is None
 
     def test_finalise_research_tool_writes_attack_plan(self, tmp_path) -> None:
         from squad.vulnerability_researcher import finalise_research_tool
@@ -233,19 +239,20 @@ class TestVulnerabilityResearcherTools:
             result = list_raw_findings_tool.func()
 
         assert isinstance(result, list)
-        assert result[0]["index"] == 0
-        assert result[0]["vuln_class"] == raw_finding_high.vuln_class
-        assert result[0]["evidence_bytes"] == len(raw_finding_high.evidence)
+        assert result[0].index == 0
+        assert result[0].vuln_class == raw_finding_high.vuln_class
+        assert result[0].evidence_bytes == len(raw_finding_high.evidence)
 
     def test_read_raw_finding_tool(self, raw_finding_high, tmp_path) -> None:
+        from models import RawFinding
         from squad.vulnerability_researcher import read_raw_finding_tool
 
         self._write_findings(tmp_path, raw_finding_high)
         with patch("tools.workspace.runtime.run_dir", return_value=tmp_path):
             result = read_raw_finding_tool.func(0)
 
-        assert isinstance(result, dict)
-        assert result["target"] == raw_finding_high.target
+        assert isinstance(result, RawFinding)
+        assert result.target == raw_finding_high.target
 
     def test_read_raw_finding_tool_rejects_out_of_range(self, raw_finding_high, tmp_path) -> None:
         from squad.vulnerability_researcher import read_raw_finding_tool
@@ -257,18 +264,24 @@ class TestVulnerabilityResearcherTools:
 
     def test_lookup_cwe_tool_finds_known_class(self) -> None:
         from squad.vulnerability_researcher import lookup_cwe_tool
+        from tools.cwe_data import CWEEntry
 
+        lookup_cwe_tool.func.cache_clear()  # type: ignore[attr-defined]
         result = lookup_cwe_tool.func("SQLi")
         assert isinstance(result, list)
         assert result
-        assert result[0]["cwe_id"] == 89
+        assert isinstance(result[0], CWEEntry)
+        assert result[0].cwe_id == 89
 
     def test_lookup_owasp_tool_returns_cheatsheet(self) -> None:
         from squad.vulnerability_researcher import lookup_owasp_tool
+        from tools.owasp_data import OWASPEntry
 
+        lookup_owasp_tool.func.cache_clear()  # type: ignore[attr-defined]
         result = lookup_owasp_tool.func("sql injection")
         assert isinstance(result, list)
-        assert any("SQL_Injection_Prevention" in r["url"] for r in result)
+        assert all(isinstance(r, OWASPEntry) for r in result)
+        assert any("SQL_Injection_Prevention" in r.url for r in result)
 
     def test_calculate_cvss_tool(self) -> None:
         from squad.vulnerability_researcher import calculate_cvss_tool
@@ -309,8 +322,10 @@ class TestVulnerabilityResearcherTools:
             for p in reversed(patches):
                 p.stop()
 
-        assert isinstance(result, dict)
-        assert result["validation"]["ok"] is True
+        from tools.triage_tools import AssessmentResult
+
+        assert isinstance(result, AssessmentResult)
+        assert result.validation.ok is True
         assert (tmp_path / "assessments" / "000.json").exists()
 
     def test_assess_finding_tool_surfaces_validation_issues(
@@ -331,9 +346,11 @@ class TestVulnerabilityResearcherTools:
             for p in reversed(patches):
                 p.stop()
 
-        assert isinstance(result, dict)
-        assert result["validation"]["ok"] is False
-        sections = {i["section"] for i in result["validation"]["issues"]}
+        from tools.triage_tools import AssessmentResult
+
+        assert isinstance(result, AssessmentResult)
+        assert result.validation.ok is False
+        sections = {i.section for i in result.validation.issues}
         assert "description" in sections
 
     def test_discard_finding_tool_writes_discard(self, raw_finding_high, tmp_path) -> None:
@@ -350,7 +367,10 @@ class TestVulnerabilityResearcherTools:
                 rationale="On reproduction the tool's marker did not appear.",
             )
 
-        assert isinstance(result, dict)
+        from tools.triage_tools import DiscardResult
+
+        assert isinstance(result, DiscardResult)
+        assert result.path == "discards/000.json"
         assert (tmp_path / "discards" / "000.json").exists()
 
     def test_discard_finding_tool_rejects_thin_rationale(self, raw_finding_high, tmp_path) -> None:

--- a/tests/test_squad_workspace_tools.py
+++ b/tests/test_squad_workspace_tools.py
@@ -18,22 +18,24 @@ pytestmark = pytest.mark.unit
 
 class TestSharedWorkspaceTools:
     def test_read_run_filelist_tool(self, tmp_path) -> None:
+        from models import RunFile
         from squad import read_run_filelist_tool
 
         (tmp_path / "recon.json").write_text("{}", encoding="utf-8")
         with patch("tools.workspace.runtime.run_dir", return_value=tmp_path):
             result = read_run_filelist_tool.func()
-        assert result == [{"name": "recon.json", "size_bytes": 2}]
+        assert result == [RunFile(name="recon.json", size_bytes=2)]
 
     def test_read_run_file_tool(self, tmp_path) -> None:
+        from models import RunFileContent
         from squad import read_run_file_tool
 
         (tmp_path / "recon.json").write_text("hello", encoding="utf-8")
         with patch("tools.workspace.runtime.run_dir", return_value=tmp_path):
             result = read_run_file_tool.func("recon.json")
-        assert isinstance(result, dict)
-        assert result["content"] == "hello"
-        assert result["size_bytes"] == 5
+        assert isinstance(result, RunFileContent)
+        assert result.content == "hello"
+        assert result.size_bytes == 5
 
     def test_read_run_file_tool_refuses_escape(self, tmp_path) -> None:
         from squad import read_run_file_tool

--- a/tools/cwe_data.py
+++ b/tools/cwe_data.py
@@ -19,7 +19,7 @@ slug from `tools/owasp_data.py`.
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, computed_field
 
 
 class CWEEntry(BaseModel):
@@ -31,6 +31,10 @@ class CWEEntry(BaseModel):
     aliases: list[str]
     owasp_topic: str | None = None
 
+    # Exposed as a computed_field rather than a plain @property so it appears
+    # in model_dump output - the @tool wrapper returns list[CWEEntry] direct
+    # and the agent sees the MITRE URL it cites in the remediation section.
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def url(self) -> str:
         return f"https://cwe.mitre.org/data/definitions/{self.cwe_id}.html"

--- a/tools/owasp_data.py
+++ b/tools/owasp_data.py
@@ -15,7 +15,7 @@ in one hop.
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, computed_field
 
 _BASE_URL = "https://cheatsheetseries.owasp.org/cheatsheets"
 
@@ -28,6 +28,10 @@ class OWASPEntry(BaseModel):
     key_principles: list[str]
     aliases: list[str] = []  # short keywords the TA may use to find this sheet
 
+    # Exposed as a computed_field rather than a plain @property so it appears
+    # in model_dump output - the @tool wrapper returns list[OWASPEntry] direct
+    # and the agent sees the cheatsheetseries.owasp.org URL it cites.
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def url(self) -> str:
         return f"{_BASE_URL}/{self.topic}_Cheat_Sheet.html"

--- a/tools/recon_insights.py
+++ b/tools/recon_insights.py
@@ -65,6 +65,18 @@ class InsightValidationReport(BaseModel):
     issues: list[InsightValidationIssue] = Field(default_factory=list)
 
 
+class HostAnnotation(BaseModel):
+    """Return shape of the Annotate Host tool.
+
+    ``path`` is the workspace-relative location of the persisted insight
+    (e.g. ``host_insights/api.example.com.json``); ``validation`` is the
+    quality-gate report for the insight that was just authored.
+    """
+
+    path: str
+    validation: InsightValidationReport
+
+
 def validate_insight(
     insight: HostInsight,
     sweep: ReconResult,

--- a/tools/report_tools.py
+++ b/tools/report_tools.py
@@ -337,6 +337,18 @@ class ValidationReport(BaseModel):
     issues: list[ValidationIssue] = Field(default_factory=list)
 
 
+class ReportDraftResult(BaseModel):
+    """Return shape of the Draft Vulnerability Report tool.
+
+    ``path`` is the workspace-relative location of the persisted draft
+    (e.g. ``drafts/000.json``); ``validation`` is the quality-gate report
+    for the draft that was just authored.
+    """
+
+    path: str
+    validation: ValidationReport
+
+
 def _count_sentences(text: str) -> int:
     text = text.strip()
     if not text:

--- a/tools/triage_tools.py
+++ b/tools/triage_tools.py
@@ -149,6 +149,30 @@ class TriageValidationReport(BaseModel):
     issues: list[TriageValidationIssue] = Field(default_factory=list)
 
 
+class AssessmentResult(BaseModel):
+    """Return shape of the Assess Raw Finding tool.
+
+    ``path`` is the workspace-relative location of the persisted assessment
+    (e.g. ``assessments/000.json``); ``validation`` is the quality-gate
+    report for the assessment that was just authored. The pair lives on a
+    single model so the agent does not have to remember which keys to
+    inspect on a bare dict.
+    """
+
+    path: str
+    validation: TriageValidationReport
+
+
+class DiscardResult(BaseModel):
+    """Return shape of the Discard Finding tool.
+
+    ``path`` is the workspace-relative location of the persisted discard
+    entry (e.g. ``discards/000.json``).
+    """
+
+    path: str
+
+
 def _count_steps_too_short(steps: list[str]) -> list[int]:
     """Return 1-based indices of steps whose stripped length is < 10."""
     return [n for n, s in enumerate(steps, 1) if len(s.strip()) < 10]


### PR DESCRIPTION
## Summary

Closes #139. Typed pydantic returns for every `@tool` wrapper across the squad, plus the typed-parameter follow-on that the same audit unblocked (`list[Endpoint]` replacing `endpoints_json: str` on PT). What started as a tiny `cached_tool` helper grew into the full #139 sweep when the contract test went red on the first run.

Net-zero on `cached_tool`: added in `c3f65dd`, removed in `fd11508` after [review feedback](https://github.com/coolhandle01/cybersquad/pull/145#issuecomment-4520396152) showed CrewAI 1.14.5 already memoises every `@tool` call at the agent-runtime layer.

## What landed

### Typed pydantic returns (`4b67ffe`, closes #139)

Every `@tool` / `@pentest_tool` / `@research_brief_tool` wrapper in `squad/` now returns a pydantic `BaseModel` subclass or `list[BaseModel]`. The pattern this replaces - `[f.model_dump() for f in check_X(...)]` - was stripping schemas on the way out and forcing the agent to reconstitute shape from docstrings. Roughly 73 wrappers retyped; the underlying probe / lookup helpers already returned typed models, the wrappers just had to stop flattening them.

Three pieces of enforcement landed alongside the sweep so the contract is now checked in CI rather than implicit:

- **`CrewAITool` Protocol** in `squad/__init__.py` carrying `name` / `description` / `func`. Per-agent `_PentestTool` and `_ResearchBriefTool` Protocols extend it. `SquadMember.tools` is now `list[CrewAITool]` instead of `list[Any]`.
- **`tests/test_squad_tool_contracts.py`** walks every `MEMBER.tools` entry and asserts the return annotation is one of: pydantic `BaseModel` subclass, `list[BaseModel]`, a primitive (`float` for CVSS), `list[str]` for flat handle lists, or a whitelisted workspace-handle `str` (`finalise_X` / `save_X`).
- **New models grouped with their existing neighbours** in `models/`: `ProgrammeReportSummary`, `OpenPortsMap`, `LlmEndpoint`, `HostInsight` / `HostRole` / `HostPriority`, `RawFindingSummary`, `AssessmentResult`, `DiscardResult`, `SanitisationReport`, `ReportDraftResult`, plus `CveEntry` / `CWEEntry` / `OWASPEntry` lifted from their `tools/` modules.

Exception preserved: workspace-handle strings (`"findings.json"`, `"attack_plan.json"`, `"verified.json"`, the reports manifest filename) stay as bare `str` returns - those are typed handles the next agent passes to a typed reader.

### Typed endpoints parameter (`c969a96`)

Sweeps every PT wrapper that previously took `endpoints_json: str` to `endpoints: list[Endpoint]` (and `tech_tags: list[str] | None` on the nuclei wrapper, `findings: list[RawFinding]` on save_findings). Modern CrewAI's `args_schema.model_validate(...).model_dump()` accepts `list[<Model>]` directly, so the agent now sees a typed `Endpoint` schema with `$defs/Endpoint` instead of "pass a JSON string".

`_parse_endpoints` keeps its name but is now the both-shape adapter - CrewAI's runtime hands the wrapper `list[dict]` after schema validation, while direct test invocations pass `list[Endpoint]`. Pydantic's `model_validate` accepts either, so one helper covers both paths.

Skill markdown (`cybersquad-tool`, `cybersquad-pentest-tool`) updated to reflect the retired pattern.

### `cached_tool` added then dropped (`c3f65dd` + `fd11508`)

Originally added a `functools.cache`-wrapping helper for the CWE / OWASP lookup tools on TA / OSINT / VR. Reviewer pointed out that CrewAI 1.14.5 already short-circuits the second call through `tools_handler.cache.read(...)` at `tool_usage.py:274-285` before `tool.func` runs at all, so the inner cache saved no work on the agent path. The memoisation test only passed because it called `tool.func` directly, asserting an identity property (`first is second`) that CrewAI's outer cache does not preserve either way. Reverted in full, including the test and the now-stale `lookup_*.func.cache_clear()` setup calls in the OSINT / VR test suites.

Full rationale: https://github.com/coolhandle01/cybersquad/pull/145#issuecomment-4520952756

## Relationship to #143

#143 (explicit `args_schema=` Pydantic class with per-field `Field(description=...)` on every pentest probe) is **independent and unblocked** by this work, not addressed by it. The typed-parameter sweep in `c969a96` makes #143 cheaper - the probe signatures are now properly typed, so the work in #143 is "lift each signature into a BaseModel and add Field descriptions" rather than "type the params and then..." `grep "args_schema" tools/pentest/ squad/penetration_tester/` finds zero `args_schema=` arguments in this PR; #143's acceptance criteria are all still open.

## Test plan

- [x] `ruff check .` - clean
- [x] `ruff format --check .` - clean
- [x] `mypy . --ignore-missing-imports` - clean
- [x] `pylint .` - 9.87/10 (no new findings vs base)
- [x] `pytest -m unit --cov --cov-report=term-missing` - 1064 passed, 91.5% coverage
- [x] `bandit -c pyproject.toml -r . -q` - clean
- [x] Contract test (`tests/test_squad_tool_contracts.py`) green - the enforcement that closes #139