### PR TITLE
refactor(pentest): explicit args_schema on every probe tool (#143)

### DIFF
--- a/.claude/skills/cybersquad-pentest-tool/SKILL.md
+++ b/.claude/skills/cybersquad-pentest-tool/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cybersquad-pentest-tool
-description: The attack-classification pattern every multi-variant pentest probe follows in cybersquad. StrEnum variants, `check_X` filter parameter, `@pentest_tool` wrapper with OWASP categorisation. Builds on cybersquad-tool. Load before editing any pentest probe.
+description: The attack-classification pattern every multi-variant pentest probe follows in cybersquad. StrEnum variants, `check_X` filter parameter, `@pentest_tool` wrapper with OWASP categorisation and an explicit `args_schema`. Builds on cybersquad-tool. Load before editing any pentest probe.
 ---
 
 # cybersquad pentest tool conventions
@@ -71,14 +71,15 @@ The import must be added in sorted position with other `from tools.pentest.*` im
 
 ## The squad @pentest_tool wrapper
 
-In `squad/penetration_tester/__init__.py`, use `@pentest_tool` (not bare `@tool`) for every pentest check/run function. Pass `check_fn=` so the OWASP section is injected into the agent-facing docstring automatically:
+In `squad/penetration_tester/__init__.py`, use `@pentest_tool` (not bare `@tool`) for every pentest check/run function. Pass `check_fn=` so the OWASP section is injected into the agent-facing docstring automatically, and `args_schema=` so the LLM sees a hand-written Pydantic contract instead of the signature-inferred one:
 
 1. Import the StrEnum alongside the check function: `from tools.pentest.ssrf import SsrfPayload, check_ssrf`.
 2. Include the filter parameter in the wrapper signature with the correct type (not bare `str`, not `list[str]`).
-3. Use `@pentest_tool` with `check_fn=`:
+3. Define an explicit `args_schema` class right above the wrapper (see the next section).
+4. Use `@pentest_tool` with `check_fn=` and `args_schema=`:
 
 ```python
-@pentest_tool("SSRF Probe", check_fn=check_ssrf)
+@pentest_tool("SSRF Probe", check_fn=check_ssrf, args_schema=_SsrfArgs)
 def ssrf_probe_tool(
     endpoints: list[Endpoint],
     payloads: list[SsrfPayload] | None = None,
@@ -86,9 +87,42 @@ def ssrf_probe_tool(
     return list(check_ssrf(_parse_endpoints(endpoints), payloads))
 ```
 
-4. Document each variant in the docstring so the agent knows when to pick a subset. Include what the variant targets, when it is useful, and the request-cost implication of narrowing.
+5. Document each variant in the docstring so the agent knows when to pick a subset. Include what the variant targets, when it is useful, and the request-cost implication of narrowing.
 
-`pentest_tool` is defined at the top of the squad module. Do not use bare `@tool` for any `tools.pentest.*` function — only cloud tools and recon/utility wrappers keep `@tool`.
+`pentest_tool` is defined at the top of the squad module. Do not use bare `@tool` for any `tools.pentest.*` function - only cloud tools and recon/utility wrappers keep `@tool`. `args_schema=` is keyword-required: a probe without an explicit schema fails import.
+
+## The explicit args_schema
+
+Every pentest probe carries an explicit Pydantic `args_schema` model that the LLM sees as the tool contract. The inferred path cannot attach per-field descriptions, so each field is built by hand:
+
+```python
+class _SsrfArgs(BaseModel):
+    """Explicit args_schema for the SSRF Probe tool (#143)."""
+
+    endpoints: list[Endpoint] = Field(
+        description=(
+            "Endpoint objects whose parameters plausibly accept URLs,"
+            " hostnames, file paths, or resource identifiers (url=, path=,"
+            " file=, redirect=, src=). Skip endpoints without parameters."
+        ),
+    )
+    payloads: list[SsrfPayload] | None = Field(
+        default=None,
+        description=(
+            "Optional list of internal-address variants to try; omit or pass"
+            " null to try all. Pass ['aws-imds'] for an AWS-hosted target."
+        ),
+    )
+```
+
+Rules:
+
+- Class name: underscore-prefixed `_<ToolName>Args`. The leading underscore marks it as module-private; the contract test in `tests/test_pentest_args_schemas.py` uses the prefix to discover all schemas.
+- Every field gets a `Field(description=...)`. Phrase descriptions as targeting guidance the agent uses to pick inputs, not type information the schema already encodes.
+- Field types mirror the wrapper signature exactly. StrEnum variants stay as `list[<StrEnum>] | None` (not `list[str]`) - the schema validation then rejects unknown values upstream of the wrapper, before any request fires.
+- The schema lives in `squad/penetration_tester/__init__.py` directly above the wrapper it decorates. Co-locate, do not import from a separate module.
+
+When you add a new probe, add a matching entry to `_PROBE_SCHEMAS` in `tests/test_pentest_args_schemas.py`. The structural check there will refuse the PR if the registry and the mapping disagree.
 
 ## Anti-patterns to catch
 

--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Protocol, cast
 
 from crewai.tools import tool
+from pydantic import BaseModel, Field
 
 from models import Endpoint, EndpointPage, OpenPortsMap, RawFinding, ReconResult
 from squad import (
@@ -79,8 +80,21 @@ class _PentestTool(CrewAITool, Protocol):
     def __call__(self, *args: object, **kwargs: object) -> list[RawFinding]: ...
 
 
-def pentest_tool(name: str, *, check_fn: object = None) -> Callable[[_PentestFn], _PentestTool]:
-    """Drop-in replacement for @tool that auto-appends OWASP categories from check_fn."""
+def pentest_tool(
+    name: str,
+    *,
+    check_fn: object = None,
+    args_schema: type[BaseModel],
+) -> Callable[[_PentestFn], _PentestTool]:
+    """Drop-in replacement for @tool that auto-appends OWASP categories from check_fn.
+
+    ``args_schema`` is the explicit Pydantic schema the agent sees when picking
+    the tool. Per #143 it is keyword-required: every pentest probe must declare
+    a hand-written schema because the inferred path cannot attach per-field
+    descriptions. The ``Tool.args_schema`` set by the underlying ``@tool``
+    decorator from the function signature is overwritten here with the
+    explicit class.
+    """
 
     def decorator(fn: _PentestFn) -> _PentestTool:
         if check_fn is not None:
@@ -88,7 +102,9 @@ def pentest_tool(name: str, *, check_fn: object = None) -> Callable[[_PentestFn]
             if cats:
                 lines = "\n".join(f"  - {c}" for c in cats)
                 fn.__doc__ = (fn.__doc__ or "").rstrip() + f"\n\nOWASP Top 10:\n{lines}\n"
-        return cast(_PentestTool, tool(name)(fn))
+        wrapped = tool(name)(fn)
+        wrapped.args_schema = args_schema
+        return cast(_PentestTool, wrapped)
 
     return decorator
 
@@ -124,7 +140,28 @@ def _recon_from_path(recon_path: str) -> ReconResult:
     return recon
 
 
-@pentest_tool("Nuclei Scan", check_fn=run_nuclei)
+class _NucleiScanArgs(BaseModel):
+    """Explicit args_schema for the Nuclei Scan tool (#143)."""
+
+    endpoints: list[Endpoint] = Field(
+        description=(
+            "Live endpoint objects to scan (status_code < 500). Pass the typed"
+            " list directly from recon; do not stringify."
+        ),
+    )
+    tech_tags: list[str] | None = Field(
+        default=None,
+        description=(
+            "Optional nuclei template tags to focus on, mapped from detected"
+            " technologies (e.g. ['wordpress', 'cve']). Omit or pass null to"
+            " run all templates. Common tags: wordpress, drupal, joomla,"
+            " apache, nginx, iis, spring, laravel, django, rails, php, cve,"
+            " exposure, misconfig."
+        ),
+    )
+
+
+@pentest_tool("Nuclei Scan", check_fn=run_nuclei, args_schema=_NucleiScanArgs)
 def nuclei_scan_tool(
     endpoints: list[Endpoint], tech_tags: list[str] | None = None
 ) -> list[RawFinding]:
@@ -148,7 +185,21 @@ def nuclei_scan_tool(
     return list(run_nuclei(_parse_endpoints(endpoints), tech_tags=tech_tags or None))
 
 
-@pentest_tool("SQLMap Injection Scan", check_fn=run_sqlmap)
+class _SqlmapArgs(BaseModel):
+    """Explicit args_schema for the SQLMap Injection Scan tool (#143)."""
+
+    endpoints: list[Endpoint] = Field(
+        description=(
+            "Parameterised endpoint objects to test for SQL injection. Pass"
+            " only endpoints whose ``parameters`` is non-empty AND where"
+            " injection is plausible (SQL errors observed, numeric/string"
+            " parameters in URLs or forms). Do not pass all endpoints"
+            " blindly - sqlmap is slow and loud."
+        ),
+    )
+
+
+@pentest_tool("SQLMap Injection Scan", check_fn=run_sqlmap, args_schema=_SqlmapArgs)
 def sqlmap_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     """
     Run sqlmap against specific parameterised endpoints.
@@ -166,7 +217,18 @@ def sqlmap_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     return list(run_sqlmap(_parse_endpoints(endpoints)))
 
 
-@pentest_tool("Cookie Security Check", check_fn=check_cookies)
+class _CookieCheckArgs(BaseModel):
+    """Explicit args_schema for the Cookie Security Check tool (#143)."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. Cookies are"
+            " inspected across every host the OSINT Analyst recorded."
+        ),
+    )
+
+
+@pentest_tool("Cookie Security Check", check_fn=check_cookies, args_schema=_CookieCheckArgs)
 def cookie_check_tool(recon_path: str) -> list[RawFinding]:
     """
     Inspect Set-Cookie attributes across the recon surface for: missing
@@ -185,7 +247,22 @@ def cookie_check_tool(recon_path: str) -> list[RawFinding]:
     return list(check_cookies(recon.endpoints))
 
 
-@pentest_tool("CORS Misconfiguration Check", check_fn=check_cors_misconfiguration)
+class _CorsCheckArgs(BaseModel):
+    """Explicit args_schema for the CORS Misconfiguration Check tool (#143)."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. CORS"
+            " misconfigurations are probed against every live endpoint."
+        ),
+    )
+
+
+@pentest_tool(
+    "CORS Misconfiguration Check",
+    check_fn=check_cors_misconfiguration,
+    args_schema=_CorsCheckArgs,
+)
 def cors_check_tool(recon_path: str) -> list[RawFinding]:
     """
     Check all live endpoints for CORS misconfigurations: origin reflection,
@@ -197,7 +274,18 @@ def cors_check_tool(recon_path: str) -> list[RawFinding]:
     return list(check_cors_misconfiguration(recon.endpoints))
 
 
-@pentest_tool("CSRF Detection", check_fn=check_csrf)
+class _CsrfCheckArgs(BaseModel):
+    """Explicit args_schema for the CSRF Detection tool (#143)."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. CSRF probes"
+            " run against every HTML endpoint with a POST form."
+        ),
+    )
+
+
+@pentest_tool("CSRF Detection", check_fn=check_csrf, args_schema=_CsrfCheckArgs)
 def csrf_check_tool(recon_path: str) -> list[RawFinding]:
     """
     Detect CSRF vulnerabilities across HTML endpoints in the recon surface.
@@ -227,7 +315,28 @@ def csrf_check_tool(recon_path: str) -> list[RawFinding]:
     return list(check_csrf(recon.endpoints))
 
 
-@pentest_tool("SSRF Probe", check_fn=check_ssrf)
+class _SsrfArgs(BaseModel):
+    """Explicit args_schema for the SSRF Probe tool (#143)."""
+
+    endpoints: list[Endpoint] = Field(
+        description=(
+            "Endpoint objects whose parameters plausibly accept URLs,"
+            " hostnames, file paths, or resource identifiers (url=, path=,"
+            " file=, redirect=, src=). Skip endpoints without parameters."
+        ),
+    )
+    payloads: list[SsrfPayload] | None = Field(
+        default=None,
+        description=(
+            "Optional list of internal-address variants to try; omit or pass"
+            " null to try all. Pass ['aws-imds'] for an AWS-hosted target,"
+            " ['localhost-ipv4'] / ['localhost-ipv6'] for internal-service"
+            " reachability."
+        ),
+    )
+
+
+@pentest_tool("SSRF Probe", check_fn=check_ssrf, args_schema=_SsrfArgs)
 def ssrf_probe_tool(
     endpoints: list[Endpoint],
     payloads: list[SsrfPayload] | None = None,
@@ -250,7 +359,22 @@ def ssrf_probe_tool(
     return list(check_ssrf(_parse_endpoints(endpoints), payloads))
 
 
-@pentest_tool("Header Injection Check", check_fn=check_header_injection)
+class _HeaderInjectionArgs(BaseModel):
+    """Explicit args_schema for the Header Injection Check tool (#143)."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. CRLF probes"
+            " run broadly against every endpoint."
+        ),
+    )
+
+
+@pentest_tool(
+    "Header Injection Check",
+    check_fn=check_header_injection,
+    args_schema=_HeaderInjectionArgs,
+)
 def header_injection_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for CRLF injection via X-Forwarded-For and similar headers.
@@ -261,7 +385,23 @@ def header_injection_tool(recon_path: str) -> list[RawFinding]:
     return list(check_header_injection(recon.endpoints))
 
 
-@pentest_tool("Host Header Attack Check", check_fn=check_host_headers)
+class _HostHeaderArgs(BaseModel):
+    """Explicit args_schema for the Host Header Attack Check tool (#143)."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. Host-header"
+            " reflection and X-Original-URL / X-Rewrite-URL overrides are"
+            " probed across every endpoint."
+        ),
+    )
+
+
+@pentest_tool(
+    "Host Header Attack Check",
+    check_fn=check_host_headers,
+    args_schema=_HostHeaderArgs,
+)
 def host_header_tool(recon_path: str) -> list[RawFinding]:
     """
     Test for Host header reflection (cache poisoning, password-reset poisoning)
@@ -272,7 +412,27 @@ def host_header_tool(recon_path: str) -> list[RawFinding]:
     return list(check_host_headers(recon.endpoints))
 
 
-@pentest_tool("Header XSS Probe", check_fn=check_header_xss)
+class _HeaderXssArgs(BaseModel):
+    """Explicit args_schema for the Header XSS Probe tool (#143)."""
+
+    endpoints: list[Endpoint] = Field(
+        description=(
+            "Live HTML-serving endpoint objects. Error pages and admin paths"
+            " are especially fruitful - they tend to echo request metadata"
+            " into the response body."
+        ),
+    )
+    header_names: list[XSSHeader] | None = Field(
+        default=None,
+        description=(
+            "Optional list of headers to probe; omit or pass null to test all"
+            " five. Narrow when recon evidence points to a specific header"
+            " (e.g. ['User-Agent', 'Referer'])."
+        ),
+    )
+
+
+@pentest_tool("Header XSS Probe", check_fn=check_header_xss, args_schema=_HeaderXssArgs)
 def header_xss_tool(
     endpoints: list[Endpoint],
     header_names: list[XSSHeader] | None = None,
@@ -306,7 +466,23 @@ def header_xss_tool(
     return list(check_header_xss(_parse_endpoints(endpoints), header_names))
 
 
-@pentest_tool("JS Source Map Scan", check_fn=check_js_source_maps)
+class _SourceMapsArgs(BaseModel):
+    """Explicit args_schema for the JS Source Map Scan tool (#143)."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. Exposed"
+            " .js.map files are discovered across every HTML page that"
+            " loads JavaScript bundles."
+        ),
+    )
+
+
+@pentest_tool(
+    "JS Source Map Scan",
+    check_fn=check_js_source_maps,
+    args_schema=_SourceMapsArgs,
+)
 def source_maps_tool(recon_path: str) -> list[RawFinding]:
     """
     Discover exposed .js.map source map files and scan reconstructed source for
@@ -318,7 +494,34 @@ def source_maps_tool(recon_path: str) -> list[RawFinding]:
     return list(check_js_source_maps(recon.endpoints))
 
 
-@pentest_tool("Path Traversal Probe", check_fn=check_path_traversal)
+class _PathTraversalArgs(BaseModel):
+    """Explicit args_schema for the Path Traversal Probe tool (#143)."""
+
+    endpoints: list[Endpoint] = Field(
+        description=(
+            "Parameterised endpoint objects. Prioritise filesystem-shaped"
+            " parameter names (file, filename, path, page, template, include,"
+            " require, download, doc, image, img, src, view) and paths that"
+            " suggest file serving (/download, /view, /preview, /fetch,"
+            " /report, /export)."
+        ),
+    )
+    payloads: list[PathTraversalPayload] | None = Field(
+        default=None,
+        description=(
+            "Optional list of traversal encoding variants to try; omit or"
+            " pass null to try all. When the target OS is known, pass only"
+            " the matching set (e.g. ['unix-basic', 'unix-encoded'] for"
+            " Linux)."
+        ),
+    )
+
+
+@pentest_tool(
+    "Path Traversal Probe",
+    check_fn=check_path_traversal,
+    args_schema=_PathTraversalArgs,
+)
 def path_traversal_tool(
     endpoints: list[Endpoint],
     payloads: list[PathTraversalPayload] | None = None,
@@ -351,7 +554,25 @@ def path_traversal_tool(
     return list(check_path_traversal(_parse_endpoints(endpoints), payloads))
 
 
-@pentest_tool("HTTP Parameter Pollution Probe", check_fn=check_hpp)
+class _HppArgs(BaseModel):
+    """Explicit args_schema for the HTTP Parameter Pollution Probe tool (#143)."""
+
+    endpoints: list[Endpoint] = Field(
+        description=(
+            "Parameterised endpoint objects. Prioritise authorisation-shaped"
+            " parameter names (role, admin, is_admin, permission, group,"
+            " user_id), WAF-fronted endpoints, and auth or admin flows -"
+            " HPP is highest-impact as a WAF bypass or privilege flip"
+            " primitive."
+        ),
+    )
+
+
+@pentest_tool(
+    "HTTP Parameter Pollution Probe",
+    check_fn=check_hpp,
+    args_schema=_HppArgs,
+)
 def hpp_probe_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     """
     Detect HTTP Parameter Pollution by sending a baseline request
@@ -379,7 +600,33 @@ def hpp_probe_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     return list(check_hpp(_parse_endpoints(endpoints)))
 
 
-@pentest_tool("Server-Side Template Injection Probe", check_fn=check_ssti)
+class _SstiArgs(BaseModel):
+    """Explicit args_schema for the Server-Side Template Injection Probe tool (#143)."""
+
+    endpoints: list[Endpoint] = Field(
+        description=(
+            "Parameterised endpoint objects. Prioritise endpoints where the"
+            " parameter is rendered into HTML the response returns (search,"
+            " comment, preview, name, template parameters) and where the"
+            " stack is template-heavy (Flask/Jinja2, Django, Symfony/Twig,"
+            " Rails/ERB, Spring/FreeMarker)."
+        ),
+    )
+    payloads: list[SstiPayload] | None = Field(
+        default=None,
+        description=(
+            "Optional list of template-engine variants to try; omit or pass"
+            " null to try all. When the engine is known from recon, pass"
+            " only the matching engine (e.g. ['jinja2'] for a Flask target)."
+        ),
+    )
+
+
+@pentest_tool(
+    "Server-Side Template Injection Probe",
+    check_fn=check_ssti,
+    args_schema=_SstiArgs,
+)
 def ssti_probe_tool(
     endpoints: list[Endpoint],
     payloads: list[SstiPayload] | None = None,
@@ -412,7 +659,31 @@ def ssti_probe_tool(
     return list(check_ssti(_parse_endpoints(endpoints), payloads))
 
 
-@pentest_tool("Open Redirect Probe", check_fn=check_open_redirect)
+class _OpenRedirectArgs(BaseModel):
+    """Explicit args_schema for the Open Redirect Probe tool (#143)."""
+
+    endpoints: list[Endpoint] = Field(
+        description=(
+            "Parameterised endpoint objects. Prioritise redirect-shaped"
+            " parameter names (redirect, redirect_uri, return, return_to,"
+            " returnto, next, url, dest, destination, goto, target, link,"
+            " forward, continue, callback, rurl, r, u) and auth-flow paths"
+            " (/login, /logout, /signin, /oauth, /sso)."
+        ),
+    )
+    payloads: list[OpenRedirectPayload] | None = Field(
+        default=None,
+        description=(
+            "Optional list of redirect encoding variants to try; omit or pass null to try all."
+        ),
+    )
+
+
+@pentest_tool(
+    "Open Redirect Probe",
+    check_fn=check_open_redirect,
+    args_schema=_OpenRedirectArgs,
+)
 def open_redirect_tool(
     endpoints: list[Endpoint],
     payloads: list[OpenRedirectPayload] | None = None,
@@ -441,7 +712,23 @@ def open_redirect_tool(
     return list(check_open_redirect(_parse_endpoints(endpoints), payloads))
 
 
-@pentest_tool("Reflected XSS Probe", check_fn=check_reflected_xss)
+class _XssArgs(BaseModel):
+    """Explicit args_schema for the Reflected XSS Probe tool (#143)."""
+
+    endpoints: list[Endpoint] = Field(
+        description=(
+            "Parameterised endpoint objects. Pass only endpoints whose"
+            " response is HTML (the target renders user input back into a"
+            " page) rather than JSON or a redirect."
+        ),
+    )
+
+
+@pentest_tool(
+    "Reflected XSS Probe",
+    check_fn=check_reflected_xss,
+    args_schema=_XssArgs,
+)
 def xss_probe_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     """
     Inject an angle-bracket canary into URL parameters and check for unescaped
@@ -457,7 +744,22 @@ def xss_probe_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     return list(check_reflected_xss(_parse_endpoints(endpoints)))
 
 
-@pentest_tool("Subresource Integrity Check", check_fn=check_sri)
+class _SriCheckArgs(BaseModel):
+    """Explicit args_schema for the Subresource Integrity Check tool (#143)."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. SRI gaps are"
+            " scanned across every HTML-serving endpoint."
+        ),
+    )
+
+
+@pentest_tool(
+    "Subresource Integrity Check",
+    check_fn=check_sri,
+    args_schema=_SriCheckArgs,
+)
 def sri_check_tool(recon_path: str) -> list[RawFinding]:
     """
     Scan HTML pages for cross-origin <script> and <link> tags missing an
@@ -468,7 +770,24 @@ def sri_check_tool(recon_path: str) -> list[RawFinding]:
     return list(check_sri(recon.endpoints))
 
 
-@pentest_tool("Error and Stack Trace Disclosure Check", check_fn=check_error_disclosure)
+class _ErrorDisclosureArgs(BaseModel):
+    """Explicit args_schema for the Error and Stack Trace Disclosure Check tool (#143)."""
+
+    endpoints: list[Endpoint] = Field(
+        description=(
+            "Endpoint objects to probe with error-triggering inputs."
+            " Prioritise parameterised endpoints (parameters increase the"
+            " chance of triggering an error) and any endpoint where passive"
+            " error-disclosure findings already suggest verbose errors."
+        ),
+    )
+
+
+@pentest_tool(
+    "Error and Stack Trace Disclosure Check",
+    check_fn=check_error_disclosure,
+    args_schema=_ErrorDisclosureArgs,
+)
 def error_disclosure_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     """
     Probe endpoints with error-triggering inputs and scan responses for framework
@@ -737,7 +1056,33 @@ def consul_vault_tool(recon_path: str) -> list[RawFinding]:
     return list(check_consul_vault(recon))
 
 
-@pentest_tool("Prompt Injection Probe", check_fn=check_prompt_injection)
+class _PromptInjectionArgs(BaseModel):
+    """Explicit args_schema for the Prompt Injection Probe tool (#143)."""
+
+    endpoints: list[Endpoint] = Field(
+        description=(
+            "LLM-backed endpoint objects. Pass endpoints where the OSINT"
+            " Analyst's LLM Endpoint Detection tool returned results,"
+            " technologies include 'LLM', or paths suggest an AI assistant"
+            " (/chat, /ask, /ai, /assistant, /copilot)."
+        ),
+    )
+    payloads: list[PromptPayload] | None = Field(
+        default=None,
+        description=(
+            "Optional list of injection-technique variants to try; omit or"
+            " pass null to try all. Use ['override'] for direct instruction"
+            " override, ['conversation'] for transcript-style, ['token-"
+            "boundary'] for models that recognise chat delimiter tokens."
+        ),
+    )
+
+
+@pentest_tool(
+    "Prompt Injection Probe",
+    check_fn=check_prompt_injection,
+    args_schema=_PromptInjectionArgs,
+)
 def prompt_injection_tool(
     endpoints: list[Endpoint],
     payloads: list[PromptPayload] | None = None,
@@ -766,7 +1111,21 @@ def prompt_injection_tool(
     return list(check_prompt_injection(_parse_endpoints(endpoints), payloads))
 
 
-@pentest_tool("NoSQL Injection Scan", check_fn=run_nosqli)
+class _NosqliArgs(BaseModel):
+    """Explicit args_schema for the NoSQL Injection Scan tool (#143)."""
+
+    endpoints: list[Endpoint] = Field(
+        description=(
+            "Parameterised endpoint objects. Prioritise endpoints where"
+            " technologies mention MongoDB / DocumentDB / Mongoose, parameters"
+            " include id / user / username / filter / query, error disclosure"
+            " findings mention BSON / ObjectId, or the endpoint is an auth"
+            " route (login, signup, profile) with parameter-bearing URLs."
+        ),
+    )
+
+
+@pentest_tool("NoSQL Injection Scan", check_fn=run_nosqli, args_schema=_NosqliArgs)
 def nosqli_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     """
     Run nosqli against parameterised endpoints to detect NoSQL injection vulnerabilities.
@@ -784,7 +1143,35 @@ def nosqli_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     return list(run_nosqli(_parse_endpoints(endpoints)))
 
 
-@pentest_tool("LDAP Injection Probe", check_fn=check_ldap_injection)
+class _LdapInjectionArgs(BaseModel):
+    """Explicit args_schema for the LDAP Injection Probe tool (#143)."""
+
+    endpoints: list[Endpoint] = Field(
+        description=(
+            "Parameterised endpoint objects. Prioritise endpoints whose"
+            " parameter names suggest authentication or directory lookup"
+            " (username, user, login, email, uid, cn, search, filter, q),"
+            " paths suggest auth / directory (/login, /auth, /search,"
+            " /directory, /ldap, /user), or technologies mention LDAP /"
+            " Active Directory / OpenLDAP / JNDI."
+        ),
+    )
+    payloads: list[LdapPayload] | None = Field(
+        default=None,
+        description=(
+            "Optional list of LDAP injection variants to try; omit or pass"
+            " null to try all. Use ['auth-bypass'] first on a /login"
+            " endpoint to confirm the class with a single request, then"
+            " escalate."
+        ),
+    )
+
+
+@pentest_tool(
+    "LDAP Injection Probe",
+    check_fn=check_ldap_injection,
+    args_schema=_LdapInjectionArgs,
+)
 def ldap_injection_tool(
     endpoints: list[Endpoint],
     payloads: list[LdapPayload] | None = None,
@@ -816,7 +1203,36 @@ def ldap_injection_tool(
     return list(check_ldap_injection(_parse_endpoints(endpoints), payloads))
 
 
-@pentest_tool("Command Injection Probe", check_fn=check_cmd_injection)
+class _CmdInjectionArgs(BaseModel):
+    """Explicit args_schema for the Command Injection Probe tool (#143)."""
+
+    endpoints: list[Endpoint] = Field(
+        description=(
+            "Parameterised endpoint objects. Prioritise endpoints whose"
+            " parameter names suggest shell / system interaction (cmd, exec,"
+            " command, shell, run, ping, host, ip, addr, query, search,"
+            " name, input), technologies mention CGI / Perl / PHP, paths"
+            " suggest system utilities (/ping, /traceroute, /lookup, /exec,"
+            " /run, /convert, /render, /preview, /generate), or error"
+            " disclosure findings mention exec / popen / system / shell."
+        ),
+    )
+    payloads: list[CmdPayload] | None = Field(
+        default=None,
+        description=(
+            "Optional list of shell-separator variants to try; omit or pass"
+            " null to try all. When the OS is known, pass only matching"
+            " separators (e.g. ['windows-amp'] for an IIS target;"
+            " ['semicolon', 'dollar-paren'] for a known Unix target)."
+        ),
+    )
+
+
+@pentest_tool(
+    "Command Injection Probe",
+    check_fn=check_cmd_injection,
+    args_schema=_CmdInjectionArgs,
+)
 def cmd_injection_tool(
     endpoints: list[Endpoint],
     payloads: list[CmdPayload] | None = None,
@@ -848,7 +1264,31 @@ def cmd_injection_tool(
     return list(check_cmd_injection(_parse_endpoints(endpoints), payloads))
 
 
-@pentest_tool("XXE Probe", check_fn=check_xxe)
+class _XxeArgs(BaseModel):
+    """Explicit args_schema for the XXE Probe tool (#143)."""
+
+    endpoints: list[Endpoint] = Field(
+        description=(
+            "Endpoint objects. Prioritise endpoints whose technologies mention"
+            " SOAP / XML-RPC / WSDL / XML / web services, paths contain"
+            " /soap /xml /wsdl /rpc /service /api or end in .asmx / .wsdl /"
+            " .xml, OSINT noted XML or SOAP in the response, or the endpoint"
+            " accepts file uploads."
+        ),
+    )
+    payloads: list[XxePayload] | None = Field(
+        default=None,
+        description=(
+            "Optional list of probe variants to try; omit or pass null to"
+            " try all. linux-* probes target /etc/passwd, windows-* probes"
+            " target win.ini, error-* probes are MEDIUM-severity backend"
+            " confirmation only. Select error-* alone for a quiet 'is there"
+            " an XML parser?' reconnaissance pass."
+        ),
+    )
+
+
+@pentest_tool("XXE Probe", check_fn=check_xxe, args_schema=_XxeArgs)
 def xxe_probe_tool(
     endpoints: list[Endpoint],
     payloads: list[XxePayload] | None = None,
@@ -884,7 +1324,36 @@ def xxe_probe_tool(
     return list(check_xxe(_parse_endpoints(endpoints), payloads))
 
 
-@pentest_tool("Prototype Pollution Check", check_fn=check_prototype_pollution)
+class _PrototypePollutionArgs(BaseModel):
+    """Explicit args_schema for the Prototype Pollution Check tool (#143)."""
+
+    endpoints: list[Endpoint] = Field(
+        description=(
+            "Endpoint objects. Prioritise endpoints whose technologies mention"
+            " Node.js / Express / Koa / Hapi / Fastify or other JS / TS"
+            " server frameworks, the API accepts JSON request bodies, URL"
+            " parameters are parsed server-side into plain objects (lodash"
+            " merge, recursive assign), or the target is a REST / GraphQL"
+            " API with a JavaScript backend."
+        ),
+    )
+    payloads: list[PrototypePollutionPayload] | None = Field(
+        default=None,
+        description=(
+            "Optional list of injection variants to try; omit or pass null"
+            " to try all. proto-* / constructor-* target URL query-string"
+            " vectors, json-* target JSON POST body vectors. Pass json-*"
+            " alone for a JSON-only API or proto-* alone for a quick"
+            " reconnaissance pass."
+        ),
+    )
+
+
+@pentest_tool(
+    "Prototype Pollution Check",
+    check_fn=check_prototype_pollution,
+    args_schema=_PrototypePollutionArgs,
+)
 def prototype_pollution_tool(
     endpoints: list[Endpoint],
     payloads: list[PrototypePollutionPayload] | None = None,
@@ -923,7 +1392,30 @@ def prototype_pollution_tool(
     return list(check_prototype_pollution(_parse_endpoints(endpoints), payloads))
 
 
-@pentest_tool("IDOR Probe", check_fn=check_idor)
+class _IdorArgs(BaseModel):
+    """Explicit args_schema for the IDOR Probe tool (#143)."""
+
+    endpoints: list[Endpoint] = Field(
+        description=(
+            "Endpoint objects. Prioritise endpoints whose URL path includes"
+            " numeric segments (/api/users/42, /orders/9), parameters include"
+            " id / user_id / account_id / order_id, or the endpoint handles"
+            " authenticated or per-user data."
+        ),
+    )
+    attacks: list[IDORAttack] | None = Field(
+        default=None,
+        description=(
+            "Optional list of IDOR attack strategies to run; omit or pass"
+            " null to run all three. Use ['boundary'] for a quiet recon pass"
+            " (2 requests per candidate), ['sequential'] when an ID is"
+            " already known and adjacent objects are suspected, or all three"
+            " for maximum coverage."
+        ),
+    )
+
+
+@pentest_tool("IDOR Probe", check_fn=check_idor, args_schema=_IdorArgs)
 def idor_probe_tool(
     endpoints: list[Endpoint],
     attacks: list[IDORAttack] | None = None,
@@ -965,7 +1457,43 @@ def idor_probe_tool(
     return list(check_idor(_parse_endpoints(endpoints), attacks))
 
 
-@pentest_tool("JWT Vulnerability Check", check_fn=check_jwt)
+class _JwtCheckArgs(BaseModel):
+    """Explicit args_schema for the JWT Vulnerability Check tool (#143)."""
+
+    token: str = Field(
+        description=(
+            "Raw JWT string (three base64url parts separated by dots)."
+            " Source from Authorization: Bearer headers, Set-Cookie session"
+            " / auth cookies, JS source or API responses with access_token /"
+            " id_token fields, or any cookie value beginning with 'eyJ'"
+            " (base64url-encoded JSON header)."
+        ),
+    )
+    endpoint: str = Field(
+        description=(
+            "URL that validates the JWT - should return 401 / 403 without"
+            " a valid token and 200 on success. Use the endpoint where the"
+            " token was first observed (e.g. /api/profile, /api/me,"
+            " /dashboard)."
+        ),
+    )
+    attacks: list[JwtAttack] | None = Field(
+        default=None,
+        description=(
+            "Optional list of attack classes to run; omit or pass null to"
+            " run all seven. Useful when chaining - e.g. ['alg-none',"
+            " 'claims-escalation'] to confirm missing signature verification"
+            " without firing every kid variant against an endpoint where"
+            " kid is not even in the header."
+        ),
+    )
+
+
+@pentest_tool(
+    "JWT Vulnerability Check",
+    check_fn=check_jwt,
+    args_schema=_JwtCheckArgs,
+)
 def jwt_check_tool(
     token: str,
     endpoint: str,

--- a/tests/test_pentest_args_schemas.py
+++ b/tests/test_pentest_args_schemas.py
@@ -1,0 +1,279 @@
+"""
+tests/test_pentest_args_schemas.py - contract tests for the explicit
+Pydantic ``args_schema`` every pentest probe carries (closes #143).
+
+The PT agent's pentest probes hit live programmes; a mis-call costs money
+and noise. The ``args_schema`` is the per-tool contract the LLM is shown
+when picking the tool, so the rules below enforce two things in CI:
+
+  1. Every probe carries an explicit, underscore-prefixed schema class
+     (one we wrote by hand, not the title-cased class CrewAI synthesises
+     from the function signature).
+  2. Every field on every schema carries a non-empty ``description`` -
+     the explicit path can address fields individually and the inferred
+     path cannot, so we make sure the new capability is actually used.
+
+Per-probe accept/reject coverage lives in ``TestSchemaAcceptReject``.
+Schemas with StrEnum filter parameters get a known-good / unknown-value
+case; required-field schemas get a missing-field rejection; endpoint-
+taking schemas get a wrong-shape rejection. The existing behavioural
+tests (``test_ssrf.py``, ``test_idor.py`` etc.) cover probe behaviour
+separately and are unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from squad.penetration_tester import (
+    MEMBER,
+    _CmdInjectionArgs,
+    _CookieCheckArgs,
+    _CorsCheckArgs,
+    _CsrfCheckArgs,
+    _ErrorDisclosureArgs,
+    _HeaderInjectionArgs,
+    _HeaderXssArgs,
+    _HostHeaderArgs,
+    _HppArgs,
+    _IdorArgs,
+    _JwtCheckArgs,
+    _LdapInjectionArgs,
+    _NosqliArgs,
+    _NucleiScanArgs,
+    _OpenRedirectArgs,
+    _PathTraversalArgs,
+    _PromptInjectionArgs,
+    _PrototypePollutionArgs,
+    _SourceMapsArgs,
+    _SqlmapArgs,
+    _SriCheckArgs,
+    _SsrfArgs,
+    _SstiArgs,
+    _XssArgs,
+    _XxeArgs,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# Tool-name -> explicit schema class. Every entry is a pentest probe;
+# the cloud / recon / write / workspace tools on the PT agent are out of
+# scope for #143 and intentionally absent.
+_PROBE_SCHEMAS: dict[str, type[BaseModel]] = {
+    "Nuclei Scan": _NucleiScanArgs,
+    "SQLMap Injection Scan": _SqlmapArgs,
+    "Cookie Security Check": _CookieCheckArgs,
+    "CORS Misconfiguration Check": _CorsCheckArgs,
+    "CSRF Detection": _CsrfCheckArgs,
+    "SSRF Probe": _SsrfArgs,
+    "Header Injection Check": _HeaderInjectionArgs,
+    "Host Header Attack Check": _HostHeaderArgs,
+    "Header XSS Probe": _HeaderXssArgs,
+    "JS Source Map Scan": _SourceMapsArgs,
+    "Path Traversal Probe": _PathTraversalArgs,
+    "HTTP Parameter Pollution Probe": _HppArgs,
+    "Server-Side Template Injection Probe": _SstiArgs,
+    "Open Redirect Probe": _OpenRedirectArgs,
+    "Reflected XSS Probe": _XssArgs,
+    "Subresource Integrity Check": _SriCheckArgs,
+    "Error and Stack Trace Disclosure Check": _ErrorDisclosureArgs,
+    "NoSQL Injection Scan": _NosqliArgs,
+    "Prompt Injection Probe": _PromptInjectionArgs,
+    "LDAP Injection Probe": _LdapInjectionArgs,
+    "Command Injection Probe": _CmdInjectionArgs,
+    "XXE Probe": _XxeArgs,
+    "Prototype Pollution Check": _PrototypePollutionArgs,
+    "IDOR Probe": _IdorArgs,
+    "JWT Vulnerability Check": _JwtCheckArgs,
+}
+
+
+def _tools_by_name() -> dict[str, object]:
+    """Look up MEMBER.tools by display name once, share across tests."""
+    return {t.name: t for t in MEMBER.tools}
+
+
+class TestPentestArgsSchemaContracts:
+    @pytest.mark.parametrize("tool_name", sorted(_PROBE_SCHEMAS))
+    def test_probe_wires_explicit_schema(self, tool_name: str) -> None:
+        """Every probe registers the explicit schema class on its Tool."""
+        tool_obj = _tools_by_name()[tool_name]
+        expected = _PROBE_SCHEMAS[tool_name]
+        assert tool_obj.args_schema is expected, (  # type: ignore[attr-defined]
+            f"{tool_name} args_schema is {tool_obj.args_schema!r}; expected {expected!r}"  # type: ignore[attr-defined]
+        )
+
+    @pytest.mark.parametrize(
+        ("tool_name", "schema_cls"),
+        sorted(_PROBE_SCHEMAS.items()),
+        ids=sorted(_PROBE_SCHEMAS),
+    )
+    def test_every_field_has_description(self, tool_name: str, schema_cls: type[BaseModel]) -> None:
+        """Per #143: every field on every probe schema carries a description."""
+        for field_name, field_info in schema_cls.model_fields.items():
+            desc = field_info.description
+            assert desc, f"{tool_name}::{field_name} missing Field(description=...)"
+            assert isinstance(desc, str) and desc.strip(), (
+                f"{tool_name}::{field_name} description is blank"
+            )
+
+    def test_every_probe_in_squad_has_schema_mapping(self) -> None:
+        """The mapping above must cover every @pentest_tool wrapper.
+
+        If a new pentest probe is added without a schema, this test fires
+        before reviewers see the PR. The check is structural: every probe
+        whose Tool exposes a private (``_*``) args_schema class name is in
+        the mapping; every entry in the mapping resolves to a registered
+        tool on the PT agent.
+        """
+        tools = _tools_by_name()
+        private_schema_tools = {
+            name
+            for name, t in tools.items()
+            if getattr(getattr(t, "args_schema", None), "__name__", "").startswith("_")
+        }
+        assert private_schema_tools == set(_PROBE_SCHEMAS), (
+            "Mismatch between PT @pentest_tool wrappers and _PROBE_SCHEMAS: "
+            f"in registry but not mapping = {private_schema_tools - set(_PROBE_SCHEMAS)}; "
+            f"in mapping but not registry = {set(_PROBE_SCHEMAS) - private_schema_tools}"
+        )
+
+
+class TestSchemaAcceptReject:
+    # Each entry: (tool_name, valid_kwargs, invalid_kwargs, invalid_match)
+    # Schemas with a StrEnum filter parameter get a known-good acceptance
+    # and an unknown-value rejection. Required-field schemas get a missing-
+    # field rejection. Endpoint-taking schemas get a wrong-shape rejection.
+
+    @pytest.mark.parametrize(
+        ("schema_cls", "kwargs"),
+        [
+            (_SsrfArgs, {"endpoints": [], "payloads": ["aws-imds"]}),
+            (_SsrfArgs, {"endpoints": []}),
+            (_HeaderXssArgs, {"endpoints": [], "header_names": ["User-Agent"]}),
+            (_PathTraversalArgs, {"endpoints": [], "payloads": ["unix-basic"]}),
+            (_SstiArgs, {"endpoints": [], "payloads": ["jinja2"]}),
+            (_OpenRedirectArgs, {"endpoints": [], "payloads": ["protocol-relative"]}),
+            (_PromptInjectionArgs, {"endpoints": [], "payloads": ["override"]}),
+            (_LdapInjectionArgs, {"endpoints": [], "payloads": ["auth-bypass"]}),
+            (_CmdInjectionArgs, {"endpoints": [], "payloads": ["semicolon"]}),
+            (_XxeArgs, {"endpoints": [], "payloads": ["linux-generic"]}),
+            (
+                _PrototypePollutionArgs,
+                {"endpoints": [], "payloads": ["proto-dot"]},
+            ),
+            (_IdorArgs, {"endpoints": [], "attacks": ["boundary"]}),
+            (
+                _JwtCheckArgs,
+                {
+                    "token": "eyJ.x.y",
+                    "endpoint": "https://victim.example.com/api/me",
+                    "attacks": ["alg-none"],
+                },
+            ),
+            (_NucleiScanArgs, {"endpoints": [], "tech_tags": ["wordpress"]}),
+            (_SqlmapArgs, {"endpoints": []}),
+            (_NosqliArgs, {"endpoints": []}),
+            (_XssArgs, {"endpoints": []}),
+            (_HppArgs, {"endpoints": []}),
+            (_ErrorDisclosureArgs, {"endpoints": []}),
+            (_CookieCheckArgs, {"recon_path": "recon.json"}),
+            (_CorsCheckArgs, {"recon_path": "recon.json"}),
+            (_CsrfCheckArgs, {"recon_path": "recon.json"}),
+            (_HeaderInjectionArgs, {"recon_path": "recon.json"}),
+            (_HostHeaderArgs, {"recon_path": "recon.json"}),
+            (_SourceMapsArgs, {"recon_path": "recon.json"}),
+            (_SriCheckArgs, {"recon_path": "recon.json"}),
+        ],
+    )
+    def test_schema_accepts_known_input(
+        self, schema_cls: type[BaseModel], kwargs: dict[str, object]
+    ) -> None:
+        """Known-good shapes pass model_validate without raising."""
+        instance = schema_cls.model_validate(kwargs)
+        assert isinstance(instance, schema_cls)
+
+    # StrEnum-filtered probes - unknown payload / attack value must reject.
+    @pytest.mark.parametrize(
+        ("schema_cls", "field_name"),
+        [
+            (_SsrfArgs, "payloads"),
+            (_HeaderXssArgs, "header_names"),
+            (_PathTraversalArgs, "payloads"),
+            (_SstiArgs, "payloads"),
+            (_OpenRedirectArgs, "payloads"),
+            (_PromptInjectionArgs, "payloads"),
+            (_LdapInjectionArgs, "payloads"),
+            (_CmdInjectionArgs, "payloads"),
+            (_XxeArgs, "payloads"),
+            (_PrototypePollutionArgs, "payloads"),
+            (_IdorArgs, "attacks"),
+            (_JwtCheckArgs, "attacks"),
+        ],
+    )
+    def test_unknown_strenum_value_rejected(
+        self, schema_cls: type[BaseModel], field_name: str
+    ) -> None:
+        """An unknown StrEnum member must fail validation, not silently coerce."""
+        base: dict[str, object] = {field_name: ["this-is-not-a-real-variant"]}
+        if "endpoints" in schema_cls.model_fields:
+            base["endpoints"] = []
+        if "token" in schema_cls.model_fields:
+            base["token"] = "eyJ.x.y"
+        if "endpoint" in schema_cls.model_fields:
+            base["endpoint"] = "https://victim.example.com/api/me"
+        with pytest.raises(ValidationError):
+            schema_cls.model_validate(base)
+
+    @pytest.mark.parametrize(
+        "schema_cls",
+        [
+            _NucleiScanArgs,
+            _SqlmapArgs,
+            _SsrfArgs,
+            _HeaderXssArgs,
+            _PathTraversalArgs,
+            _SstiArgs,
+            _OpenRedirectArgs,
+            _PromptInjectionArgs,
+            _LdapInjectionArgs,
+            _CmdInjectionArgs,
+            _XxeArgs,
+            _PrototypePollutionArgs,
+            _IdorArgs,
+            _NosqliArgs,
+            _XssArgs,
+            _HppArgs,
+            _ErrorDisclosureArgs,
+        ],
+    )
+    def test_missing_required_endpoints_rejected(self, schema_cls: type[BaseModel]) -> None:
+        """``endpoints`` is required on every endpoint-taking probe schema."""
+        with pytest.raises(ValidationError):
+            schema_cls.model_validate({})
+
+    @pytest.mark.parametrize(
+        "schema_cls",
+        [
+            _CookieCheckArgs,
+            _CorsCheckArgs,
+            _CsrfCheckArgs,
+            _HeaderInjectionArgs,
+            _HostHeaderArgs,
+            _SourceMapsArgs,
+            _SriCheckArgs,
+        ],
+    )
+    def test_missing_required_recon_path_rejected(self, schema_cls: type[BaseModel]) -> None:
+        """``recon_path`` is required on every recon-path-taking schema."""
+        with pytest.raises(ValidationError):
+            schema_cls.model_validate({})
+
+    def test_jwt_requires_both_token_and_endpoint(self) -> None:
+        """JWT check needs the raw token and the validating endpoint."""
+        with pytest.raises(ValidationError):
+            _JwtCheckArgs.model_validate({"token": "eyJ.x.y"})
+        with pytest.raises(ValidationError):
+            _JwtCheckArgs.model_validate({"endpoint": "https://victim.example.com/api"})


### PR DESCRIPTION
## Summary

Closes #143. Every `@pentest_tool` wrapper on the Penetration Tester now declares an explicit Pydantic `args_schema` with `Field(description=...)` on every parameter, replacing the signature-inferred schema CrewAI used to build from each function's signature.

The motivation is the one #143 spells out: pentest probes hit live programmes; the schema is a contract, not a hint, and the contract is now enforced upfront. The inferred path crammed every parameter description into the docstring where field-level descriptions couldn't be addressed individually; the explicit path can, and now does.

Probe behaviour is untouched - this is a wrapper-layer refactor. The `@pentest_tool` OWASP categorisation layer still runs; the underlying `check_X` / `run_X` functions are unchanged.

## What landed

### `pentest_tool` factory: `args_schema` keyword-required

`squad/penetration_tester/__init__.py` extends the factory to take an `args_schema: type[BaseModel]` (keyword-only, no default). After `@tool(name)(fn)` runs, the schema CrewAI builds from the signature is overwritten with the explicit class. A probe that forgets to pass `args_schema=` fails at import - the conditional that would have allowed `None` is gone so there is no dead branch.

### 25 per-probe schema classes

One `_<ToolName>Args` BaseModel per `@pentest_tool` wrapper, declared immediately above the wrapper it decorates. Every field gets `Field(description=...)` written as agent-facing targeting guidance (which parameter names to prioritise, which paths to skip, when to narrow the StrEnum filter). StrEnum variants stay typed as `list[<StrEnum>] | None` - the schema validation now rejects unknown variants upstream of the wrapper, before any request fires.

Covered probes: Nuclei Scan, SQLMap Injection Scan, Cookie Security Check, CORS Misconfiguration Check, CSRF Detection, SSRF Probe, Header Injection Check, Host Header Attack Check, Header XSS Probe, JS Source Map Scan, Path Traversal Probe, HTTP Parameter Pollution Probe, Server-Side Template Injection Probe, Open Redirect Probe, Reflected XSS Probe, Subresource Integrity Check, Error and Stack Trace Disclosure Check, NoSQL Injection Scan, Prompt Injection Probe, LDAP Injection Probe, Command Injection Probe, XXE Probe, Prototype Pollution Check, IDOR Probe, JWT Vulnerability Check.

Out of scope per the issue: cloud / recon / write / workspace `@tool` wrappers on the PT agent keep the inferred schema. The cybersquad-pentest-tool skill is specifically about probe-style tools; cloud wrappers may warrant the same treatment in a follow-up issue.

### Contract tests

New file `tests/test_pentest_args_schemas.py`. Three layers:

- **Wiring:** for every entry in `_PROBE_SCHEMAS`, the registered tool's `args_schema` is the explicit class (`is` identity, not `isinstance`).
- **Structure:** every field on every schema has a non-empty `description`. A structural check refuses the PR if a new probe is added without a matching entry in `_PROBE_SCHEMAS` (the registry-and-mapping must agree).
- **Accept/reject:** known-good inputs validate; unknown StrEnum variants reject; missing required `endpoints` / `recon_path` / `token` + `endpoint` reject. 114 parametrized cases in total.

Existing behavioural tests (`tests/test_ssrf.py`, `tests/test_idor.py`, `tests/test_squad_penetration_tester.py` etc.) are unchanged.

### Skill update

`.claude/skills/cybersquad-pentest-tool/SKILL.md` gains an "explicit args_schema" section as the third element of the probe pattern alongside StrEnum and `@pentest_tool`. Naming convention (`_<ToolName>Args`), field rules (every field gets a description, types mirror the wrapper signature exactly), and the contract-test registry are all documented.

## Acceptance criteria

- [x] Every pentest probe has an `args_schema` Pydantic model.
- [x] Every schema field carries a `Field(description=...)`.
- [x] StrEnum variants preserved for variant-selection parameters.
- [x] `cybersquad-pentest-tool` skill text updated to make `args_schema` part of the pattern.
- [x] Per-probe contract tests for schema accept/reject. Existing behavioural tests unchanged.
- [x] Coverage floor (`fail_under=90`) holds.
- [x] `selection_rationale` / probe rationale output unchanged - the refactor is invisible to downstream agents.

## Test plan

- [x] `ruff check .` - clean
- [x] `ruff format --check .` - clean
- [x] `mypy . --ignore-missing-imports` - clean
- [x] `pylint .` - 9.87/10 (no new findings vs base)
- [x] `pytest -m unit --cov` - 1178 passed, 91.60% coverage (above 90% floor)
- [x] `bandit -c pyproject.toml -r . -q` - clean
- [x] New `tests/test_pentest_args_schemas.py` - 114 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_017Y6J78aD8zhcr71Ap3kKD6)_