### PR TITLE
refactor(pt-cloud): explicit args_schema on cloud/infra check tools (#147)

### DIFF
--- a/.claude/skills/cybersquad-tool/SKILL.md
+++ b/.claude/skills/cybersquad-tool/SKILL.md
@@ -1,11 +1,47 @@
 ---
 name: cybersquad-tool
-description: Universal rules for every CrewAI `@tool`-wrapped function in cybersquad. Pydantic return shape, typed parameters, writer/reader workspace pair. Load before editing any `@tool` wrapper.
+description: Universal rules for every CrewAI `@tool`-wrapped function in cybersquad. Pydantic return shape, typed parameters, explicit `args_schema` via `@typed_tool`, writer/reader workspace pair. Load before editing any `@tool` wrapper.
 ---
 
 # cybersquad @tool conventions
 
 Every CrewAI `@tool`-wrapped function the agents see follows these rules. They are universal; `cybersquad-pentest-tool` is a specialisation that adds OWASP + StrEnum + `@pentest_tool` on top of this baseline. If you are touching a pentest probe wrapper, load both.
+
+## Use `@typed_tool`, not bare `@tool`
+
+`@typed_tool(name, args_schema=...)` lives in `squad/__init__.py` and is the blessed replacement for `crewai.tools.tool`. It accepts a keyword-required `args_schema` Pydantic class that overrides the schema CrewAI would otherwise infer from the function signature.
+
+```python
+from pydantic import BaseModel, Field
+from squad import typed_tool
+
+class _S3CheckArgs(BaseModel):
+    """Explicit args_schema for the S3 Bucket Check tool."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. Buckets are"
+            " derived from the programme handle and any S3 subdomains the"
+            " OSINT Analyst surfaced."
+        ),
+    )
+
+
+@typed_tool("S3 Bucket Check", args_schema=_S3CheckArgs)
+def s3_check_tool(recon_path: str) -> list[RawFinding]:
+    ...
+```
+
+Why this matters: every tool's contract is what the LLM reads when picking the tool, including per-field guidance. The inferred path cannot attach per-field `Field(description=...)`; the explicit path can, and writing those descriptions is where the LLM gets the targeting signal that keeps probes on-scope. Per-field descriptions also reject unknown StrEnum variants upstream of any HTTP request - the validation fires before a mis-call costs a request.
+
+Rules:
+
+- Class name is underscore-prefixed `_<ToolName>Args`. The contract test in `tests/test_pt_args_schemas.py` discovers PT-agent schemas via this prefix. Other agents will get parallel `_<X>_SCHEMAS` test mappings as #148/#149/#150 land.
+- Every field carries a `Field(description=...)` phrased as agent-facing targeting guidance ("fire when open_ports shows X", "prioritise endpoints where Y"), not type information the schema already encodes.
+- Field types mirror the wrapper signature exactly. StrEnum filters stay typed (`list[<StrEnum>] | None`), never `list[str]`.
+- Schema lives inline in the same module as the wrapper, directly above the decorator. Do not import from a separate file.
+
+`@pentest_tool` composes on top of `@typed_tool`: pentest probes still use `@pentest_tool` so the OWASP injection layer runs, and the `args_schema=` argument flows through. `@research_brief_tool` will compose the same way once #150 lands.
 
 ## Return a pydantic model, or `list[<Model>]`
 
@@ -38,7 +74,7 @@ Never `dict`, `list[dict]`, or bare `list` (no inner type). CrewAI serialises py
 
 ```python
 # correct
-@pentest_tool("SSRF Probe", check_fn=check_ssrf)
+@pentest_tool("SSRF Probe", check_fn=check_ssrf, args_schema=_SsrfArgs)
 def ssrf_probe_tool(
     endpoints: list[Endpoint],
     payloads: list[SsrfPayload] | None = None,
@@ -79,14 +115,17 @@ The reader returns the typed model; downstream agents work against the schema, n
 - `[f.model_dump() for f in check_X(...)]` in any wrapper body - drop the comprehension, just `return list(check_X(...))`.
 - Return annotation of `dict` for a structured payload that has a pydantic shape already.
 - Bare `list` (no inner type) as a return annotation - either it is `list[str]` for a flat handle list, or it is `list[<Model>]` for structured rows.
+- `@tool("...")` from `crewai.tools` for a new wrapper. Use `@typed_tool` (or `@pentest_tool` for probes) so `args_schema` is enforced. Bare `@tool` survives only on the recon / write / workspace wrappers still on the #148-#150 backlog.
+- An `args_schema` class with a field that lacks `Field(description=...)`. The whole point of the explicit path is per-field guidance; an empty description is the same gap the inferred path had.
 - New workspace writer with no typed reader.
 - `from squad.workspace_tools import ...` in a consumer instead of `from squad import ...` - the re-export exists so the import path stays stable when shared tools move.
 
 ## Canonical examples
 
-Cross-agent intent matters: this skill applies to every agent's `@tool` wrappers, not just the pentester's. The codebase is mid-migration (#139) so exemplary typed returns are still sparse - one canonical pydantic-return example today, plus the workspace-handle string family.
+Cross-agent intent matters: this skill applies to every agent's `@tool` wrappers, not just the pentester's. The codebase is mid-migration (#139 typed returns, #143/#146/#147 explicit args_schemas) - the PT agent is fully migrated, the other four are on the #148-#150 backlog.
 
-- `squad/penetration_tester/__init__.py` `recon_endpoints_tool` returns `EndpointPage` - the only `@tool` in the codebase today that follows the pydantic-return rule end-to-end. The wrapper lives on PT but it reads OSINT's recon output, so the pattern is cross-agent.
+- `squad/penetration_tester/__init__.py` is the migration's tip. Every `@typed_tool` and `@pentest_tool` carries an explicit `_<ToolName>Args` schema directly above the wrapper, with `Field(description=...)` on every field. Pentest probes (`ssrf_probe_tool`, `idor_probe_tool`) are the shortest examples; cloud / infra wrappers (`s3_check_tool`, `mongodb_tool`) show the `recon_path: str` shape.
+- `squad/penetration_tester/__init__.py` `recon_endpoints_tool` returns `EndpointPage` - the canonical typed-return example. The wrapper lives on PT but it reads OSINT's recon output, so the pattern is cross-agent.
 - The workspace-handle string family demonstrates the `str` exception (writer returns the filename, next agent passes it to a typed reader):
   - `Finalise Recon` (`squad/osint_analyst/__init__.py`) -> `"recon.json"`
   - `Finalise Research` (`squad/vulnerability_researcher/__init__.py`) -> `"attack_plan.json"`

--- a/squad/__init__.py
+++ b/squad/__init__.py
@@ -29,9 +29,11 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from typing import Protocol, cast, runtime_checkable
 
 from crewai import Agent, Task
+from crewai.tools import tool
+from pydantic import BaseModel
 
 from squad.workspace_tools import (
     read_attack_plan_tool,
@@ -46,12 +48,13 @@ SQUAD_SKILLS_DIR = Path(__file__).parent / "skills"
 class CrewAITool(Protocol):
     """The shape every ``MEMBER.tools`` entry conforms to.
 
-    The decorators in use - the bare ``@tool``, ``@pentest_tool``,
-    ``@research_brief_tool`` - all produce CrewAI ``Tool`` instances that
-    carry ``name``, ``description``, and ``func``. This Protocol is the
-    single shared surface those decorators expose, so the registry can be
-    ``list[CrewAITool]`` rather than ``list[Any]`` and the contract test in
-    ``tests/test_squad_tool_contracts.py`` has a typed handle to walk.
+    The decorators in use - the bare ``@tool``, ``@typed_tool``,
+    ``@pentest_tool``, ``@research_brief_tool`` - all produce CrewAI ``Tool``
+    instances that carry ``name``, ``description``, and ``func``. This
+    Protocol is the single shared surface those decorators expose, so the
+    registry can be ``list[CrewAITool]`` rather than ``list[Any]`` and the
+    contract test in ``tests/test_squad_tool_contracts.py`` has a typed
+    handle to walk.
 
     ``func`` is declared via ``@property`` (rather than as a plain class
     attribute) so the Protocol is satisfied by CrewAI's ``Tool`` model -
@@ -65,6 +68,33 @@ class CrewAITool(Protocol):
 
     @property
     def func(self) -> Callable[..., object]: ...
+
+
+def typed_tool(
+    name: str, *, args_schema: type[BaseModel]
+) -> Callable[[Callable[..., object]], CrewAITool]:
+    """The blessed cybersquad replacement for bare ``@crewai.tools.tool``.
+
+    Equivalent to ``tool(name)`` except that ``args_schema`` is keyword-
+    required: the explicit Pydantic class overrides the signature-inferred
+    schema CrewAI would otherwise build. Per #143/#146 every cybersquad
+    ``@tool`` wrapper carries one, because the inferred path cannot attach
+    per-field ``Field(description=...)`` and the agent reads those
+    descriptions when picking the tool.
+
+    ``pentest_tool`` and ``research_brief_tool`` compose on top of this
+    helper: they call ``typed_tool`` underneath and then layer their own
+    docstring-injection (OWASP categories for the pentest wrapper, brief
+    formatting for the research one). Anything that does not need a
+    specialist wrapper uses ``@typed_tool`` directly.
+    """
+
+    def decorator(fn: Callable[..., object]) -> CrewAITool:
+        wrapped = tool(name)(fn)
+        wrapped.args_schema = args_schema
+        return cast(CrewAITool, wrapped)
+
+    return decorator
 
 
 @dataclass(frozen=True)
@@ -148,4 +178,5 @@ __all__ = [
     "read_attack_plan_tool",
     "read_run_filelist_tool",
     "read_run_file_tool",
+    "typed_tool",
 ]

--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -15,6 +15,7 @@ from squad import (
     read_attack_plan_tool,
     read_run_file_tool,
     read_run_filelist_tool,
+    typed_tool,
 )
 from tools import http
 from tools.cloud import (
@@ -86,14 +87,13 @@ def pentest_tool(
     check_fn: object = None,
     args_schema: type[BaseModel],
 ) -> Callable[[_PentestFn], _PentestTool]:
-    """Drop-in replacement for @tool that auto-appends OWASP categories from check_fn.
+    """Pentest-specialised wrapper. Composes ``typed_tool`` plus OWASP injection.
 
-    ``args_schema`` is the explicit Pydantic schema the agent sees when picking
-    the tool. Per #143 it is keyword-required: every pentest probe must declare
-    a hand-written schema because the inferred path cannot attach per-field
-    descriptions. The ``Tool.args_schema`` set by the underlying ``@tool``
-    decorator from the function signature is overwritten here with the
-    explicit class.
+    ``typed_tool`` handles the schema override; ``pentest_tool`` layers the
+    OWASP categories from ``check_fn.owasp_categories`` into the agent-facing
+    docstring. Every pentest probe goes through this wrapper, never bare
+    ``@tool`` and never raw ``@typed_tool`` - the OWASP framing is what the
+    PT agent's role.md teaches it to reason against.
     """
 
     def decorator(fn: _PentestFn) -> _PentestTool:
@@ -102,8 +102,7 @@ def pentest_tool(
             if cats:
                 lines = "\n".join(f"  - {c}" for c in cats)
                 fn.__doc__ = (fn.__doc__ or "").rstrip() + f"\n\nOWASP Top 10:\n{lines}\n"
-        wrapped = tool(name)(fn)
-        wrapped.args_schema = args_schema
+        wrapped = typed_tool(name, args_schema=args_schema)(fn)
         return cast(_PentestTool, wrapped)
 
     return decorator
@@ -804,7 +803,21 @@ def error_disclosure_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     return list(check_error_disclosure(_parse_endpoints(endpoints)))
 
 
-@tool("S3 Bucket Check")
+class _S3CheckArgs(BaseModel):
+    """Explicit args_schema for the S3 Bucket Check tool (#147)."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. Buckets are"
+            " derived from the programme handle and any S3 subdomains the"
+            " OSINT Analyst surfaced. Worth firing when the target is known"
+            " to use AWS or when *.s3 / *.s3.amazonaws.com subdomains appear"
+            " in recon."
+        ),
+    )
+
+
+@typed_tool("S3 Bucket Check", args_schema=_S3CheckArgs)
 def s3_check_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for publicly accessible or listable AWS S3 buckets derived from the
@@ -816,7 +829,20 @@ def s3_check_tool(recon_path: str) -> list[RawFinding]:
     return list(check_s3_buckets(recon))
 
 
-@tool("Azure Blob Storage Check")
+class _AzureStorageCheckArgs(BaseModel):
+    """Explicit args_schema for the Azure Blob Storage Check tool (#147)."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. Fire when the"
+            " target is known to use Azure, or when"
+            " *.blob.core.windows.net subdomains appear in recon. Probes for"
+            " public containers and SAS-token leakage in endpoint URLs."
+        ),
+    )
+
+
+@typed_tool("Azure Blob Storage Check", args_schema=_AzureStorageCheckArgs)
 def azure_storage_check_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for publicly accessible Azure Blob Storage containers and exposed SAS
@@ -828,7 +854,20 @@ def azure_storage_check_tool(recon_path: str) -> list[RawFinding]:
     return list(check_azure_storage(recon))
 
 
-@tool("Unauthenticated Elasticsearch Check")
+class _ElasticsearchCheckArgs(BaseModel):
+    """Explicit args_schema for the Unauthenticated Elasticsearch Check tool (#147)."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. Fire when"
+            " open_ports shows 9200, or when technologies mention"
+            " Elasticsearch. Probes /_cluster/health; a 200 with"
+            " cluster_name confirms no auth."
+        ),
+    )
+
+
+@typed_tool("Unauthenticated Elasticsearch Check", args_schema=_ElasticsearchCheckArgs)
 def elasticsearch_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an unauthenticated Elasticsearch instance on port 9200.
@@ -844,7 +883,19 @@ def elasticsearch_tool(recon_path: str) -> list[RawFinding]:
     return list(findings)
 
 
-@tool("Unauthenticated CouchDB Check")
+class _CouchdbCheckArgs(BaseModel):
+    """Explicit args_schema for the Unauthenticated CouchDB Check tool (#147)."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. Fire when"
+            " open_ports shows 5984. Probes /_all_dbs; a 200 listing"
+            " databases confirms no auth."
+        ),
+    )
+
+
+@typed_tool("Unauthenticated CouchDB Check", args_schema=_CouchdbCheckArgs)
 def couchdb_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an unauthenticated CouchDB instance on port 5984.
@@ -860,7 +911,19 @@ def couchdb_tool(recon_path: str) -> list[RawFinding]:
     return list(findings)
 
 
-@tool("Unauthenticated Redis Check")
+class _RedisCheckArgs(BaseModel):
+    """Explicit args_schema for the Unauthenticated Redis Check tool (#147)."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. Fire when"
+            " open_ports shows 6379. Sends a PING; a +PONG without AUTH"
+            " confirms no password is set."
+        ),
+    )
+
+
+@typed_tool("Unauthenticated Redis Check", args_schema=_RedisCheckArgs)
 def redis_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an unauthenticated Redis instance on port 6379 via a PING command.
@@ -876,7 +939,20 @@ def redis_tool(recon_path: str) -> list[RawFinding]:
     return list(findings)
 
 
-@tool("Unauthenticated MongoDB Check")
+class _MongodbCheckArgs(BaseModel):
+    """Explicit args_schema for the Unauthenticated MongoDB Check tool (#147)."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. Fire when"
+            " open_ports shows 27017. Sends a minimal isMaster wire query;"
+            " a valid response without error confirms unauthenticated"
+            " access."
+        ),
+    )
+
+
+@typed_tool("Unauthenticated MongoDB Check", args_schema=_MongodbCheckArgs)
 def mongodb_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an unauthenticated MongoDB instance on port 27017.
@@ -893,7 +969,21 @@ def mongodb_tool(recon_path: str) -> list[RawFinding]:
     return list(findings)
 
 
-@tool("Exposed PostgreSQL Check")
+class _PostgresqlCheckArgs(BaseModel):
+    """Explicit args_schema for the Exposed PostgreSQL Check tool (#147)."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. Fire when"
+            " open_ports shows 5432. CRITICAL if trust authentication"
+            " allows connection without a password; MEDIUM if the port is"
+            " exposed but credentials are required (unnecessary internet"
+            " exposure)."
+        ),
+    )
+
+
+@typed_tool("Exposed PostgreSQL Check", args_schema=_PostgresqlCheckArgs)
 def postgresql_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for PostgreSQL on port 5432. Returns CRITICAL if trust authentication
@@ -910,7 +1000,20 @@ def postgresql_tool(recon_path: str) -> list[RawFinding]:
     return list(findings)
 
 
-@tool("Exposed MySQL/MariaDB Check")
+class _MysqlCheckArgs(BaseModel):
+    """Explicit args_schema for the Exposed MySQL/MariaDB Check tool (#147)."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. Fire when"
+            " open_ports shows 3306. MEDIUM if the port is reachable and"
+            " the server responds with a valid handshake (unnecessary"
+            " internet exposure; verify anonymous login is disabled)."
+        ),
+    )
+
+
+@typed_tool("Exposed MySQL/MariaDB Check", args_schema=_MysqlCheckArgs)
 def mysql_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for MySQL or MariaDB on port 3306. Returns MEDIUM if the port is
@@ -927,7 +1030,21 @@ def mysql_tool(recon_path: str) -> list[RawFinding]:
     return list(findings)
 
 
-@tool("Sensitive Files Check")
+class _SensitiveFilesArgs(BaseModel):
+    """Explicit args_schema for the Sensitive Files Check tool (#147)."""
+
+    endpoints: list[Endpoint] = Field(
+        description=(
+            "Endpoint objects. Pass a representative set of live endpoints;"
+            " the tool deduplicates by origin so many can be passed without"
+            " redundant probes. High-value finds on any target (.git/HEAD,"
+            " .env, phpinfo.php, Apache server-status, .DS_Store) - run"
+            " broadly."
+        ),
+    )
+
+
+@typed_tool("Sensitive Files Check", args_schema=_SensitiveFilesArgs)
 def sensitive_files_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     """
     Probe for exposed .git/HEAD, .env, phpinfo.php, Apache server-status, and
@@ -943,7 +1060,20 @@ def sensitive_files_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     return list(check_sensitive_files(_parse_endpoints(endpoints)))
 
 
-@tool("Admin Panels Check")
+class _AdminPanelsArgs(BaseModel):
+    """Explicit args_schema for the Admin Panels Check tool (#147)."""
+
+    endpoints: list[Endpoint] = Field(
+        description=(
+            "Endpoint objects. The tool deduplicates by origin so passing"
+            " many is safe. Probes common admin paths (/admin, /wp-admin,"
+            " /phpmyadmin, /adminer, /manager/html, /_admin) - run broadly"
+            " on all live endpoints."
+        ),
+    )
+
+
+@typed_tool("Admin Panels Check", args_schema=_AdminPanelsArgs)
 def admin_panels_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     """
     Probe common admin panel paths: /admin, /wp-admin, /phpmyadmin, /adminer,
@@ -957,7 +1087,21 @@ def admin_panels_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     return list(check_admin_panels(_parse_endpoints(endpoints)))
 
 
-@tool("cPanel/WHM Check")
+class _CpanelArgs(BaseModel):
+    """Explicit args_schema for the cPanel/WHM Check tool (#147)."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. Fire when"
+            " open_ports shows 2082, 2083, 2086, or 2087, or when the"
+            " target appears to be a shared / managed hosting environment."
+            " Probes cPanel (2082/2083) and WHM (2086/2087) on every"
+            " discovered hostname."
+        ),
+    )
+
+
+@typed_tool("cPanel/WHM Check", args_schema=_CpanelArgs)
 def cpanel_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed cPanel hosting control panel (ports 2082/2083) and
@@ -970,7 +1114,20 @@ def cpanel_tool(recon_path: str) -> list[RawFinding]:
     return list(check_cpanel(recon))
 
 
-@tool("Plesk Check")
+class _PleskArgs(BaseModel):
+    """Explicit args_schema for the Plesk Check tool (#147)."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. Fire when"
+            " open_ports shows 8880 or 8443, or when the target is a"
+            " managed hosting or VPS provider. Probes Plesk on 8880 (HTTP)"
+            " and 8443 (HTTPS)."
+        ),
+    )
+
+
+@typed_tool("Plesk Check", args_schema=_PleskArgs)
 def plesk_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed Plesk web hosting control panel on ports 8880 (HTTP)
@@ -982,7 +1139,19 @@ def plesk_tool(recon_path: str) -> list[RawFinding]:
     return list(check_plesk(recon))
 
 
-@tool("DirectAdmin Check")
+class _DirectadminArgs(BaseModel):
+    """Explicit args_schema for the DirectAdmin Check tool (#147)."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. Fire when"
+            " open_ports shows 2222 on a target that appears to be shared"
+            " hosting."
+        ),
+    )
+
+
+@typed_tool("DirectAdmin Check", args_schema=_DirectadminArgs)
 def directadmin_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed DirectAdmin hosting control panel on port 2222.
@@ -993,7 +1162,19 @@ def directadmin_tool(recon_path: str) -> list[RawFinding]:
     return list(check_directadmin(recon))
 
 
-@tool("Webmin Check")
+class _WebminArgs(BaseModel):
+    """Explicit args_schema for the Webmin Check tool (#147)."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. Fire when"
+            " open_ports shows 10000, or when the target is a self-hosted"
+            " Linux server."
+        ),
+    )
+
+
+@typed_tool("Webmin Check", args_schema=_WebminArgs)
 def webmin_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed Webmin Linux server administration panel on port 10000.
@@ -1004,7 +1185,20 @@ def webmin_tool(recon_path: str) -> list[RawFinding]:
     return list(check_webmin(recon))
 
 
-@tool("Grafana Check")
+class _GrafanaArgs(BaseModel):
+    """Explicit args_schema for the Grafana Check tool (#147)."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. Fire when"
+            " open_ports shows 3000, technologies mention Grafana, or the"
+            " target is a DevOps / SRE-heavy organisation. Also probes"
+            " /grafana reverse-proxy paths on existing endpoints."
+        ),
+    )
+
+
+@typed_tool("Grafana Check", args_schema=_GrafanaArgs)
 def grafana_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed Grafana metrics dashboard on port 3000 and via /grafana
@@ -1017,7 +1211,20 @@ def grafana_tool(recon_path: str) -> list[RawFinding]:
     return list(check_grafana(recon))
 
 
-@tool("Kibana Check")
+class _KibanaArgs(BaseModel):
+    """Explicit args_schema for the Kibana Check tool (#147)."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. Fire when"
+            " open_ports shows 5601 or 9200 (Elasticsearch stack), or when"
+            " technologies mention Kibana or Elasticsearch. Also probes"
+            " /kibana reverse-proxy paths on existing endpoints."
+        ),
+    )
+
+
+@typed_tool("Kibana Check", args_schema=_KibanaArgs)
 def kibana_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed Kibana log/data visualisation dashboard on port 5601 and
@@ -1030,7 +1237,20 @@ def kibana_tool(recon_path: str) -> list[RawFinding]:
     return list(check_kibana(recon))
 
 
-@tool("Portainer Check")
+class _PortainerArgs(BaseModel):
+    """Explicit args_schema for the Portainer Check tool (#147)."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. Fire when"
+            " open_ports shows 9000, or when technologies mention Docker /"
+            " containerised infrastructure. Also probes /portainer"
+            " reverse-proxy paths on existing endpoints."
+        ),
+    )
+
+
+@typed_tool("Portainer Check", args_schema=_PortainerArgs)
 def portainer_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed Portainer Docker management UI on port 9000 and via
@@ -1043,7 +1263,21 @@ def portainer_tool(recon_path: str) -> list[RawFinding]:
     return list(check_portainer(recon))
 
 
-@tool("Consul/Vault Check")
+class _ConsulVaultArgs(BaseModel):
+    """Explicit args_schema for the Consul/Vault Check tool (#147)."""
+
+    recon_path: str = Field(
+        description=(
+            "Relative path to recon.json in the run directory. Fire when"
+            " open_ports shows 8500 (Consul) or 8200 (Vault), or when the"
+            " target is a cloud-native / microservices environment. Also"
+            " probes /consul/ui and /vault/ui reverse-proxy paths on"
+            " existing endpoints."
+        ),
+    )
+
+
+@typed_tool("Consul/Vault Check", args_schema=_ConsulVaultArgs)
 def consul_vault_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed HashiCorp Consul UI (port 8500) or Vault UI (port 8200),

--- a/tests/test_pt_args_schemas.py
+++ b/tests/test_pt_args_schemas.py
@@ -1,24 +1,33 @@
 """
-tests/test_pentest_args_schemas.py - contract tests for the explicit
-Pydantic ``args_schema`` every pentest probe carries (closes #143).
+tests/test_pt_args_schemas.py - contract tests for the explicit Pydantic
+``args_schema`` every Penetration Tester ``@typed_tool`` / ``@pentest_tool``
+wrapper carries.
 
-The PT agent's pentest probes hit live programmes; a mis-call costs money
-and noise. The ``args_schema`` is the per-tool contract the LLM is shown
-when picking the tool, so the rules below enforce two things in CI:
+Started life under #143/#146 covering the 25 ``@pentest_tool`` probes;
+#147 extended it to cover the 18 cloud / infra ``@typed_tool`` wrappers on
+the same agent. Both decorators go through the same ``typed_tool`` helper
+so the contract is identical: the schema class is hand-written, every
+field carries a non-empty ``description``, and ``args_schema`` on the
+registered ``Tool`` ``is`` (identity) the explicit class - not the
+title-cased one CrewAI synthesises from the function signature.
 
-  1. Every probe carries an explicit, underscore-prefixed schema class
-     (one we wrote by hand, not the title-cased class CrewAI synthesises
-     from the function signature).
+The PT agent's tools hit live programmes; a mis-call costs money and
+noise. The ``args_schema`` is the per-tool contract the LLM is shown when
+picking the tool, so the rules below enforce three things in CI:
+
+  1. Every PT tool with a hand-written schema is in ``_PT_SCHEMAS``, and
+     every entry in ``_PT_SCHEMAS`` resolves to a registered tool with the
+     expected schema. Closed-world check: a new PT typed-tool added
+     without a mapping entry fires this test before review.
   2. Every field on every schema carries a non-empty ``description`` -
      the explicit path can address fields individually and the inferred
      path cannot, so we make sure the new capability is actually used.
+  3. Schemas with StrEnum filter parameters reject unknown values;
+     required-field schemas reject missing fields. The contract is
+     enforced upstream of any HTTP request.
 
-Per-probe accept/reject coverage lives in ``TestSchemaAcceptReject``.
-Schemas with StrEnum filter parameters get a known-good / unknown-value
-case; required-field schemas get a missing-field rejection; endpoint-
-taking schemas get a wrong-shape rejection. The existing behavioural
-tests (``test_ssrf.py``, ``test_idor.py`` etc.) cover probe behaviour
-separately and are unchanged.
+The existing behavioural tests (``test_ssrf.py``, ``test_idor.py`` etc.)
+cover probe behaviour separately and are unchanged.
 """
 
 from __future__ import annotations
@@ -28,29 +37,47 @@ from pydantic import BaseModel, ValidationError
 
 from squad.penetration_tester import (
     MEMBER,
+    _AdminPanelsArgs,
+    _AzureStorageCheckArgs,
     _CmdInjectionArgs,
+    _ConsulVaultArgs,
     _CookieCheckArgs,
     _CorsCheckArgs,
+    _CouchdbCheckArgs,
+    _CpanelArgs,
     _CsrfCheckArgs,
+    _DirectadminArgs,
+    _ElasticsearchCheckArgs,
     _ErrorDisclosureArgs,
+    _GrafanaArgs,
     _HeaderInjectionArgs,
     _HeaderXssArgs,
     _HostHeaderArgs,
     _HppArgs,
     _IdorArgs,
     _JwtCheckArgs,
+    _KibanaArgs,
     _LdapInjectionArgs,
+    _MongodbCheckArgs,
+    _MysqlCheckArgs,
     _NosqliArgs,
     _NucleiScanArgs,
     _OpenRedirectArgs,
     _PathTraversalArgs,
+    _PleskArgs,
+    _PortainerArgs,
+    _PostgresqlCheckArgs,
     _PromptInjectionArgs,
     _PrototypePollutionArgs,
+    _RedisCheckArgs,
+    _S3CheckArgs,
+    _SensitiveFilesArgs,
     _SourceMapsArgs,
     _SqlmapArgs,
     _SriCheckArgs,
     _SsrfArgs,
     _SstiArgs,
+    _WebminArgs,
     _XssArgs,
     _XxeArgs,
 )
@@ -58,10 +85,13 @@ from squad.penetration_tester import (
 pytestmark = pytest.mark.unit
 
 
-# Tool-name -> explicit schema class. Every entry is a pentest probe;
-# the cloud / recon / write / workspace tools on the PT agent are out of
-# scope for #143 and intentionally absent.
-_PROBE_SCHEMAS: dict[str, type[BaseModel]] = {
+# Tool-name -> explicit schema class. Covers every PT @typed_tool /
+# @pentest_tool wrapper. Recon / write / workspace tools that intentionally
+# keep the signature-inferred schema (Recon Subdomains, Recon Endpoints,
+# Recon Open Ports, Save Findings, plus the three workspace readers) are
+# absent: they are out of scope for #143 / #147, and #150 covers them.
+_PT_SCHEMAS: dict[str, type[BaseModel]] = {
+    # @pentest_tool probes (#143 / #146)
     "Nuclei Scan": _NucleiScanArgs,
     "SQLMap Injection Scan": _SqlmapArgs,
     "Cookie Security Check": _CookieCheckArgs,
@@ -87,7 +117,47 @@ _PROBE_SCHEMAS: dict[str, type[BaseModel]] = {
     "Prototype Pollution Check": _PrototypePollutionArgs,
     "IDOR Probe": _IdorArgs,
     "JWT Vulnerability Check": _JwtCheckArgs,
+    # @typed_tool cloud / infra wrappers (#147)
+    "S3 Bucket Check": _S3CheckArgs,
+    "Azure Blob Storage Check": _AzureStorageCheckArgs,
+    "Unauthenticated Elasticsearch Check": _ElasticsearchCheckArgs,
+    "Unauthenticated CouchDB Check": _CouchdbCheckArgs,
+    "Unauthenticated Redis Check": _RedisCheckArgs,
+    "Unauthenticated MongoDB Check": _MongodbCheckArgs,
+    "Exposed PostgreSQL Check": _PostgresqlCheckArgs,
+    "Exposed MySQL/MariaDB Check": _MysqlCheckArgs,
+    "Sensitive Files Check": _SensitiveFilesArgs,
+    "Admin Panels Check": _AdminPanelsArgs,
+    "cPanel/WHM Check": _CpanelArgs,
+    "Plesk Check": _PleskArgs,
+    "DirectAdmin Check": _DirectadminArgs,
+    "Webmin Check": _WebminArgs,
+    "Grafana Check": _GrafanaArgs,
+    "Kibana Check": _KibanaArgs,
+    "Portainer Check": _PortainerArgs,
+    "Consul/Vault Check": _ConsulVaultArgs,
 }
+
+# Cloud / infra wrappers that take ``recon_path: str``. Used by the
+# missing-required-field parametrize below.
+_RECON_PATH_CLOUD_SCHEMAS: list[type[BaseModel]] = [
+    _S3CheckArgs,
+    _AzureStorageCheckArgs,
+    _ElasticsearchCheckArgs,
+    _CouchdbCheckArgs,
+    _RedisCheckArgs,
+    _MongodbCheckArgs,
+    _PostgresqlCheckArgs,
+    _MysqlCheckArgs,
+    _CpanelArgs,
+    _PleskArgs,
+    _DirectadminArgs,
+    _WebminArgs,
+    _GrafanaArgs,
+    _KibanaArgs,
+    _PortainerArgs,
+    _ConsulVaultArgs,
+]
 
 
 def _tools_by_name() -> dict[str, object]:
@@ -95,23 +165,23 @@ def _tools_by_name() -> dict[str, object]:
     return {t.name: t for t in MEMBER.tools}
 
 
-class TestPentestArgsSchemaContracts:
-    @pytest.mark.parametrize("tool_name", sorted(_PROBE_SCHEMAS))
-    def test_probe_wires_explicit_schema(self, tool_name: str) -> None:
-        """Every probe registers the explicit schema class on its Tool."""
+class TestPtArgsSchemaContracts:
+    @pytest.mark.parametrize("tool_name", sorted(_PT_SCHEMAS))
+    def test_tool_wires_explicit_schema(self, tool_name: str) -> None:
+        """Every PT typed tool registers the explicit schema class on its Tool."""
         tool_obj = _tools_by_name()[tool_name]
-        expected = _PROBE_SCHEMAS[tool_name]
+        expected = _PT_SCHEMAS[tool_name]
         assert tool_obj.args_schema is expected, (  # type: ignore[attr-defined]
             f"{tool_name} args_schema is {tool_obj.args_schema!r}; expected {expected!r}"  # type: ignore[attr-defined]
         )
 
     @pytest.mark.parametrize(
         ("tool_name", "schema_cls"),
-        sorted(_PROBE_SCHEMAS.items()),
-        ids=sorted(_PROBE_SCHEMAS),
+        sorted(_PT_SCHEMAS.items()),
+        ids=sorted(_PT_SCHEMAS),
     )
     def test_every_field_has_description(self, tool_name: str, schema_cls: type[BaseModel]) -> None:
-        """Per #143: every field on every probe schema carries a description."""
+        """Per #143 / #147: every field on every PT typed-tool schema carries a description."""
         for field_name, field_info in schema_cls.model_fields.items():
             desc = field_info.description
             assert desc, f"{tool_name}::{field_name} missing Field(description=...)"
@@ -119,14 +189,14 @@ class TestPentestArgsSchemaContracts:
                 f"{tool_name}::{field_name} description is blank"
             )
 
-    def test_every_probe_in_squad_has_schema_mapping(self) -> None:
-        """The mapping above must cover every @pentest_tool wrapper.
+    def test_every_pt_typed_tool_has_schema_mapping(self) -> None:
+        """The mapping above must cover every PT ``@typed_tool`` / ``@pentest_tool``.
 
-        If a new pentest probe is added without a schema, this test fires
-        before reviewers see the PR. The check is structural: every probe
-        whose Tool exposes a private (``_*``) args_schema class name is in
-        the mapping; every entry in the mapping resolves to a registered
-        tool on the PT agent.
+        Closed-world structural check: every PT tool whose Tool exposes a
+        private (``_*``) args_schema class name is in ``_PT_SCHEMAS``;
+        every entry in ``_PT_SCHEMAS`` resolves to a registered tool.
+        A new typed tool added without a mapping entry fires this test
+        before reviewers see the PR.
         """
         tools = _tools_by_name()
         private_schema_tools = {
@@ -134,15 +204,14 @@ class TestPentestArgsSchemaContracts:
             for name, t in tools.items()
             if getattr(getattr(t, "args_schema", None), "__name__", "").startswith("_")
         }
-        assert private_schema_tools == set(_PROBE_SCHEMAS), (
-            "Mismatch between PT @pentest_tool wrappers and _PROBE_SCHEMAS: "
-            f"in registry but not mapping = {private_schema_tools - set(_PROBE_SCHEMAS)}; "
-            f"in mapping but not registry = {set(_PROBE_SCHEMAS) - private_schema_tools}"
+        assert private_schema_tools == set(_PT_SCHEMAS), (
+            "Mismatch between PT typed-tool wrappers and _PT_SCHEMAS: "
+            f"in registry but not mapping = {private_schema_tools - set(_PT_SCHEMAS)}; "
+            f"in mapping but not registry = {set(_PT_SCHEMAS) - private_schema_tools}"
         )
 
 
 class TestSchemaAcceptReject:
-    # Each entry: (tool_name, valid_kwargs, invalid_kwargs, invalid_match)
     # Schemas with a StrEnum filter parameter get a known-good acceptance
     # and an unknown-value rejection. Required-field schemas get a missing-
     # field rejection. Endpoint-taking schemas get a wrong-shape rejection.
@@ -150,6 +219,7 @@ class TestSchemaAcceptReject:
     @pytest.mark.parametrize(
         ("schema_cls", "kwargs"),
         [
+            # @pentest_tool acceptance cases
             (_SsrfArgs, {"endpoints": [], "payloads": ["aws-imds"]}),
             (_SsrfArgs, {"endpoints": []}),
             (_HeaderXssArgs, {"endpoints": [], "header_names": ["User-Agent"]}),
@@ -186,6 +256,25 @@ class TestSchemaAcceptReject:
             (_HostHeaderArgs, {"recon_path": "recon.json"}),
             (_SourceMapsArgs, {"recon_path": "recon.json"}),
             (_SriCheckArgs, {"recon_path": "recon.json"}),
+            # @typed_tool cloud / infra acceptance cases (#147)
+            (_S3CheckArgs, {"recon_path": "recon.json"}),
+            (_AzureStorageCheckArgs, {"recon_path": "recon.json"}),
+            (_ElasticsearchCheckArgs, {"recon_path": "recon.json"}),
+            (_CouchdbCheckArgs, {"recon_path": "recon.json"}),
+            (_RedisCheckArgs, {"recon_path": "recon.json"}),
+            (_MongodbCheckArgs, {"recon_path": "recon.json"}),
+            (_PostgresqlCheckArgs, {"recon_path": "recon.json"}),
+            (_MysqlCheckArgs, {"recon_path": "recon.json"}),
+            (_SensitiveFilesArgs, {"endpoints": []}),
+            (_AdminPanelsArgs, {"endpoints": []}),
+            (_CpanelArgs, {"recon_path": "recon.json"}),
+            (_PleskArgs, {"recon_path": "recon.json"}),
+            (_DirectadminArgs, {"recon_path": "recon.json"}),
+            (_WebminArgs, {"recon_path": "recon.json"}),
+            (_GrafanaArgs, {"recon_path": "recon.json"}),
+            (_KibanaArgs, {"recon_path": "recon.json"}),
+            (_PortainerArgs, {"recon_path": "recon.json"}),
+            (_ConsulVaultArgs, {"recon_path": "recon.json"}),
         ],
     )
     def test_schema_accepts_known_input(
@@ -247,10 +336,13 @@ class TestSchemaAcceptReject:
             _XssArgs,
             _HppArgs,
             _ErrorDisclosureArgs,
+            # @typed_tool cloud wrappers that take endpoints (#147)
+            _SensitiveFilesArgs,
+            _AdminPanelsArgs,
         ],
     )
     def test_missing_required_endpoints_rejected(self, schema_cls: type[BaseModel]) -> None:
-        """``endpoints`` is required on every endpoint-taking probe schema."""
+        """``endpoints`` is required on every endpoint-taking PT typed-tool schema."""
         with pytest.raises(ValidationError):
             schema_cls.model_validate({})
 
@@ -264,10 +356,11 @@ class TestSchemaAcceptReject:
             _HostHeaderArgs,
             _SourceMapsArgs,
             _SriCheckArgs,
+            *_RECON_PATH_CLOUD_SCHEMAS,
         ],
     )
     def test_missing_required_recon_path_rejected(self, schema_cls: type[BaseModel]) -> None:
-        """``recon_path`` is required on every recon-path-taking schema."""
+        """``recon_path`` is required on every recon-path-taking PT typed-tool schema."""
         with pytest.raises(ValidationError):
             schema_cls.model_validate({})
 


### PR DESCRIPTION
## Summary

Closes #147. Extends the #143/#146 `args_schema` discipline from `@pentest_tool` probes to the 18 cloud / infra `@tool` wrappers on the Penetration Tester. The "live programmes, mis-call costs money" argument that motivated the pentest sweep applies identically to these wrappers - they all fire HTTP / TCP probes at recon-surfaced hosts.

The work also extracts a shared `@typed_tool` helper into `squad/__init__.py` so the schema-override mechanism is no longer pentest-specific. `@pentest_tool` and (eventually) `@research_brief_tool` compose on top of it; their specialist layers (OWASP injection, brief formatting) stay where they belong.

## What landed

### `@typed_tool` helper (`squad/__init__.py`)

The blessed replacement for bare `crewai.tools.tool`. Keyword-required `args_schema`, overrides the inferred schema CrewAI would build from the function signature. `@pentest_tool` now calls `typed_tool` underneath rather than `tool` directly, so the schema-enforcement code path is shared end-to-end. Exported via `__all__`.

### 18 cloud / infra schemas (`squad/penetration_tester/__init__.py`)

Each `@tool("...")` cloud / infra wrapper became `@typed_tool("...", args_schema=_<Name>Args)` with the schema class inline directly above the decorator, in the same shape as the pentest probe schemas:

| Group | Wrappers |
|---|---|
| Cloud storage | S3 Bucket Check, Azure Blob Storage Check |
| Unauthenticated databases | Elasticsearch, CouchDB, Redis, MongoDB, PostgreSQL, MySQL/MariaDB |
| Endpoint-walking | Sensitive Files Check, Admin Panels Check |
| Branded panels | cPanel/WHM, Plesk, DirectAdmin, Webmin, Grafana, Kibana, Portainer, Consul/Vault |

Field descriptions are written as agent-facing targeting guidance: which open port to look for, which technology tag, which subdomain pattern. The cloud / infra surface is largely `recon_path: str` shaped, so the descriptions are where the per-tool selection signal lives.

### Contract test (`tests/test_pt_args_schemas.py`)

Renamed from `test_pentest_args_schemas.py` (git rename preserves history) and expanded to cover all 43 PT typed-tool schemas. `_PROBE_SCHEMAS` -> `_PT_SCHEMAS` with both `@pentest_tool` probes and `@typed_tool` cloud wrappers in one mapping. Closed-world structural check holds: every PT private-prefix schema is in the mapping, every mapping entry resolves to a registered tool, a new typed tool added without an entry fires the test before review.

Accept/reject parametrize lists extended with the 18 cloud schemas:
- All 18 get a known-good acceptance case.
- 16 `recon_path`-shaped schemas get the missing-required-field rejection.
- 2 `endpoints`-shaped schemas (Sensitive Files, Admin Panels) join the existing endpoint-required rejection list.

### Skill update (`.claude/skills/cybersquad-tool/SKILL.md`)

`@typed_tool` documented as the universal `@tool` replacement, with the `_<ToolName>Args` naming convention, `Field(description=...)` requirement, and the "schema lives inline above the wrapper" rule. The "Type the parameters too" example refreshed to include `args_schema=`. Anti-patterns now call out "bare `@tool` for a new wrapper" and "empty `Field` description" explicitly. Canonical-examples section updated to point at the PT module as the fully-migrated reference; the cross-agent rollout is parked on #148-#150.

## Out of scope

The 4 PT `@tool` wrappers that stay inferred-path:
- `Recon Subdomains`, `Recon Endpoints`, `Recon Open Ports` - recon queries against the local `recon.json`, no network
- `Save Findings` - workspace writer

These were explicitly out per #147's scope. Workspace readers (`Read Attack Plan`, `List Run Files`, `Read Run File`) declared in `squad/workspace_tools.py` also stay inferred and are covered by #150.

## Test plan

- [x] `ruff check .` - clean
- [x] `ruff format --check .` - clean
- [x] `mypy . --ignore-missing-imports` - clean
- [x] `pylint .` - 9.87/10 (no regression vs base)
- [x] `pytest -m unit --cov` - 1196 passed, 91.66% coverage (above 90% floor)
- [x] `bandit -c pyproject.toml -r . -q` - clean
- [x] PT registry post-sweep: 43 explicit schemas, 7 inferred (4 PT recon/write + 3 workspace readers, all out of scope)

## Follow-ups

`@typed_tool` is now in `squad/__init__.py` ready to be picked up by:
- #148 (OSINT recon tools)
- #149 (HackerOne API tools)
- #150 (VR / TA / workspace tools + `@research_brief_tool` extension)

Each can land independently; the helper does not need to evolve for them.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Y6J78aD8zhcr71Ap3kKD6)_