### PR TITLE
refactor(osint): explicit args_schema on every OSINT recon tool (#148)

### DIFF
--- a/.claude/skills/cybersquad-pentest-tool/SKILL.md
+++ b/.claude/skills/cybersquad-pentest-tool/SKILL.md
@@ -117,12 +117,12 @@ class _SsrfArgs(BaseModel):
 
 Rules:
 
-- Class name: underscore-prefixed `_<ToolName>Args`. The leading underscore marks it as module-private; the contract test in `tests/test_pentest_args_schemas.py` uses the prefix to discover all schemas.
+- Class name: underscore-prefixed `_<ToolName>Args`. The leading underscore marks it as module-private; the contract test in `tests/test_pt_args_schemas.py` uses the prefix to discover all schemas.
 - Every field gets a `Field(description=...)`. Phrase descriptions as targeting guidance the agent uses to pick inputs, not type information the schema already encodes.
 - Field types mirror the wrapper signature exactly. StrEnum variants stay as `list[<StrEnum>] | None` (not `list[str]`) - the schema validation then rejects unknown values upstream of the wrapper, before any request fires.
 - The schema lives in `squad/penetration_tester/__init__.py` directly above the wrapper it decorates. Co-locate, do not import from a separate module.
 
-When you add a new probe, add a matching entry to `_PROBE_SCHEMAS` in `tests/test_pentest_args_schemas.py`. The structural check there will refuse the PR if the registry and the mapping disagree.
+When you add a new probe, add a matching entry to `_PT_SCHEMAS` in `tests/test_pt_args_schemas.py`. The structural check there will refuse the PR if the registry and the mapping disagree.
 
 ## Anti-patterns to catch
 

--- a/.claude/skills/cybersquad-tool/SKILL.md
+++ b/.claude/skills/cybersquad-tool/SKILL.md
@@ -1,19 +1,19 @@
 ---
 name: cybersquad-tool
-description: Universal rules for every CrewAI `@tool`-wrapped function in cybersquad. Pydantic return shape, typed parameters, explicit `args_schema` via `@typed_tool`, writer/reader workspace pair. Load before editing any `@tool` wrapper.
+description: Universal rules for every CrewAI `@tool`-wrapped function in cybersquad. Pydantic return shape, typed parameters, explicit `args_schema` via `@cyber_tool`, writer/reader workspace pair. Load before editing any `@tool` wrapper.
 ---
 
 # cybersquad @tool conventions
 
 Every CrewAI `@tool`-wrapped function the agents see follows these rules. They are universal; `cybersquad-pentest-tool` is a specialisation that adds OWASP + StrEnum + `@pentest_tool` on top of this baseline. If you are touching a pentest probe wrapper, load both.
 
-## Use `@typed_tool`, not bare `@tool`
+## Use `@cyber_tool`, not bare `@tool`
 
-`@typed_tool(name, args_schema=...)` lives in `squad/__init__.py` and is the blessed replacement for `crewai.tools.tool`. It accepts a keyword-required `args_schema` Pydantic class that overrides the schema CrewAI would otherwise infer from the function signature.
+`@cyber_tool(name, args_schema=...)` lives in `squad/__init__.py` and is the blessed replacement for `crewai.tools.tool`. It accepts a keyword-required `args_schema` Pydantic class that overrides the schema CrewAI would otherwise infer from the function signature.
 
 ```python
 from pydantic import BaseModel, Field
-from squad import typed_tool
+from squad import cyber_tool
 
 class _S3CheckArgs(BaseModel):
     """Explicit args_schema for the S3 Bucket Check tool."""
@@ -27,7 +27,7 @@ class _S3CheckArgs(BaseModel):
     )
 
 
-@typed_tool("S3 Bucket Check", args_schema=_S3CheckArgs)
+@cyber_tool("S3 Bucket Check", args_schema=_S3CheckArgs)
 def s3_check_tool(recon_path: str) -> list[RawFinding]:
     ...
 ```
@@ -41,7 +41,7 @@ Rules:
 - Field types mirror the wrapper signature exactly. StrEnum filters stay typed (`list[<StrEnum>] | None`), never `list[str]`.
 - Schema lives inline in the same module as the wrapper, directly above the decorator. Do not import from a separate file.
 
-`@pentest_tool` composes on top of `@typed_tool`: pentest probes still use `@pentest_tool` so the OWASP injection layer runs, and the `args_schema=` argument flows through. `@research_brief_tool` will compose the same way once #150 lands.
+`@pentest_tool` composes on top of `@cyber_tool`: pentest probes still use `@pentest_tool` so the OWASP injection layer runs, and the `args_schema=` argument flows through. `@research_brief_tool` will compose the same way once #150 lands.
 
 ## Return a pydantic model, or `list[<Model>]`
 
@@ -115,7 +115,7 @@ The reader returns the typed model; downstream agents work against the schema, n
 - `[f.model_dump() for f in check_X(...)]` in any wrapper body - drop the comprehension, just `return list(check_X(...))`.
 - Return annotation of `dict` for a structured payload that has a pydantic shape already.
 - Bare `list` (no inner type) as a return annotation - either it is `list[str]` for a flat handle list, or it is `list[<Model>]` for structured rows.
-- `@tool("...")` from `crewai.tools` for a new wrapper. Use `@typed_tool` (or `@pentest_tool` for probes) so `args_schema` is enforced. Bare `@tool` survives only on the recon / write / workspace wrappers still on the #148-#150 backlog.
+- `@tool("...")` from `crewai.tools` for a new wrapper. Use `@cyber_tool` (or `@pentest_tool` for probes) so `args_schema` is enforced. Bare `@tool` survives only on the recon / write / workspace wrappers still on the #148-#150 backlog.
 - An `args_schema` class with a field that lacks `Field(description=...)`. The whole point of the explicit path is per-field guidance; an empty description is the same gap the inferred path had.
 - New workspace writer with no typed reader.
 - `from squad.workspace_tools import ...` in a consumer instead of `from squad import ...` - the re-export exists so the import path stays stable when shared tools move.
@@ -124,7 +124,7 @@ The reader returns the typed model; downstream agents work against the schema, n
 
 Cross-agent intent matters: this skill applies to every agent's `@tool` wrappers, not just the pentester's. The codebase is mid-migration (#139 typed returns, #143/#146/#147 explicit args_schemas) - the PT agent is fully migrated, the other four are on the #148-#150 backlog.
 
-- `squad/penetration_tester/__init__.py` is the migration's tip. Every `@typed_tool` and `@pentest_tool` carries an explicit `_<ToolName>Args` schema directly above the wrapper, with `Field(description=...)` on every field. Pentest probes (`ssrf_probe_tool`, `idor_probe_tool`) are the shortest examples; cloud / infra wrappers (`s3_check_tool`, `mongodb_tool`) show the `recon_path: str` shape.
+- `squad/penetration_tester/__init__.py` is the migration's tip. Every `@cyber_tool` and `@pentest_tool` carries an explicit `_<ToolName>Args` schema directly above the wrapper, with `Field(description=...)` on every field. Pentest probes (`ssrf_probe_tool`, `idor_probe_tool`) are the shortest examples; cloud / infra wrappers (`s3_check_tool`, `mongodb_tool`) show the `recon_path: str` shape.
 - `squad/penetration_tester/__init__.py` `recon_endpoints_tool` returns `EndpointPage` - the canonical typed-return example. The wrapper lives on PT but it reads OSINT's recon output, so the pattern is cross-agent.
 - The workspace-handle string family demonstrates the `str` exception (writer returns the filename, next agent passes it to a typed reader):
   - `Finalise Recon` (`squad/osint_analyst/__init__.py`) -> `"recon.json"`

--- a/.claude/skills/cybersquad-tool/SKILL.md
+++ b/.claude/skills/cybersquad-tool/SKILL.md
@@ -36,22 +36,33 @@ Why this matters: every tool's contract is what the LLM reads when picking the t
 
 Rules:
 
-- Class name is underscore-prefixed `_<ToolName>Args`. The contract test in `tests/test_pt_args_schemas.py` discovers PT-agent schemas via this prefix. Other agents will get parallel `_<X>_SCHEMAS` test mappings as #148/#149/#150 land.
+- Class name is underscore-prefixed `_<ToolName>Args`. The per-agent contract tests (`tests/test_pt_args_schemas.py`, `tests/test_osint_args_schemas.py`, and the parallel `_<AGENT>_SCHEMAS` mappings #149 / #150 will add) discover schemas via this prefix.
 - Every field carries a `Field(description=...)` phrased as agent-facing targeting guidance ("fire when open_ports shows X", "prioritise endpoints where Y"), not type information the schema already encodes.
-- Field types mirror the wrapper signature exactly. StrEnum filters stay typed (`list[<StrEnum>] | None`), never `list[str]`.
+- Field types mirror the wrapper signature exactly. StrEnum filters stay typed (`list[<StrEnum>] | None`), never `list[str]`. Hostname-shaped fields use the `Hostname` typed-string from `models.primitives`, never bare `str` (see "Typed string primitives" below).
 - Schema lives inline in the same module as the wrapper, directly above the decorator. Do not import from a separate file.
 
 `@pentest_tool` composes on top of `@cyber_tool`: pentest probes still use `@pentest_tool` so the OWASP injection layer runs, and the `args_schema=` argument flows through. `@research_brief_tool` will compose the same way once #150 lands.
+
+## Typed string primitives
+
+`models.primitives` carries the typed-string layer every higher-level model composes:
+
+- `Hostname` - `Annotated[str, AfterValidator(...)]`. RFC 1123 hostname check: lowercases, strips, rejects schemes (`://`), ports (`:`), paths (`/`), oversized labels (>63 chars), oversized total (>253 chars), garbage characters. Use it on any field whose value is supposed to be a bare hostname; the agent occasionally hands us a URL and the strict reject is the signal that surfaces the mismatch.
+- `HttpUrl` - same shape, validates a parseable http / https URL with a `Hostname`-valid host underneath. Runtime type stays `str` so `.startswith(...)` and string comparisons keep working. Use on any field whose value is supposed to be an HTTP/S URL.
+
+Composition rule: when a higher-level model carries a field that is conceptually a hostname or URL, type it through the primitive. `HostInsight.hostname: Hostname` rather than `: str`; `Endpoint.url: HttpUrl` rather than `: str`; `dict[Hostname, list[int]]` rather than `dict[str, list[int]]` for hostname-keyed dicts. The primitive's validator fires per-field at model construction time, so mis-shaped values reject upstream of every downstream consumer.
+
+FIXME comments in `primitives.py` and `asset.py` flag the eventual move to Pydantic's built-in `HttpUrl` (stronger contract, exposes `.host` / `.scheme` / `.port` properties, but runtime type stops being `str` so every consumer needs auditing first).
 
 ## Return a pydantic model, or `list[<Model>]`
 
 ```python
 # correct - the agent sees a schema
-@tool("Read Attack Plan")
+@cyber_tool("Read Attack Plan", args_schema=_ReadAttackPlanArgs)
 def read_attack_plan_tool() -> AttackPlan:
     return load_attack_plan(attack_plan_path())
 
-@tool("Reflected XSS Probe")
+@pentest_tool("Reflected XSS Probe", check_fn=check_reflected_xss, args_schema=_XssArgs)
 def xss_probe_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     return list(check_reflected_xss(_parse_endpoints(endpoints)))
 ```
@@ -59,12 +70,12 @@ def xss_probe_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
 ```python
 # wrong - the agent sees a JSON-shaped dict and has to reconstitute the schema
 # from the docstring
-@tool("Reflected XSS Probe")
+@cyber_tool("Reflected XSS Probe", args_schema=_XssArgs)
 def xss_probe_tool(endpoints_json: str) -> list[dict]:
     return [f.model_dump() for f in check_reflected_xss(...)]
 ```
 
-Never `dict`, `list[dict]`, or bare `list` (no inner type). CrewAI serialises pydantic models to JSON on its own; calling `.model_dump()` in the wrapper just strips the schema. If the underlying helper does not have a typed return yet, add the model before wiring the `@tool` - the model is the contract.
+Never `dict`, `list[dict]`, or bare `list` (no inner type). CrewAI serialises pydantic models to JSON on its own; calling `.model_dump()` in the wrapper just strips the schema. If the underlying helper does not have a typed return yet, add the model before wiring the `@cyber_tool` - the model is the contract.
 
 ### The one exception: workspace-handle strings
 
@@ -87,7 +98,7 @@ def ssrf_probe_tool(
 def ssrf_probe_tool(endpoints: list[Endpoint], payloads: list[str] | None = None) -> ...:
 ```
 
-The legacy `endpoints_json: str` pattern was retired in #139 once CrewAI's args-schema validation grew up enough to accept `list[<Model>]` directly. Today the LLM-side wire format is still JSON, but `args_schema.model_validate(kwargs).model_dump()` happens inside CrewAI before the function is called, so the wrapper just receives `list[dict]` and re-validates via `_parse_endpoints`. The agent sees a typed Endpoint schema instead of "pass a JSON string" - never reintroduce the JSON-string parameter for structured data.
+The legacy `endpoints_json: str` pattern was retired in #139 once CrewAI's args-schema validation grew up enough to accept `list[<Model>]` directly; the last surviving instance (OSINT's `llm_detection_tool`) was migrated in #148. Today the LLM-side wire format is still JSON, but `args_schema.model_validate(kwargs).model_dump()` happens inside CrewAI before the function is called, so the wrapper just receives `list[dict]` and re-validates via `_parse_endpoints`. The agent sees a typed Endpoint schema instead of "pass a JSON string" - never reintroduce the JSON-string parameter for structured data.
 
 ## Workspace artifacts: writer and reader ship together
 
@@ -103,8 +114,25 @@ The reader returns the typed model; downstream agents work against the schema, n
 
 ## Where tools live
 
-- **Per-agent**: `squad/<agent>/__init__.py`. Each `@tool` is added to that agent's `MEMBER.tools` list.
+- **Per-agent**: `squad/<agent>/__init__.py`. Each `@cyber_tool` / `@pentest_tool` is added to that agent's `MEMBER.tools` list.
 - **Shared between agents**: `squad/workspace_tools.py`. Re-export through `squad/__init__.py` (`__all__` and the explicit re-export) so consumers `from squad import read_attack_plan_tool`, not from the deeper path.
+
+## Where models live
+
+`models/` is split per domain so the module that owns each shape is obvious at import time. Put a new model in the matching module; do not extend `models/__init__.py` (which is now pure re-exports for backward compat).
+
+| Module | Contents |
+|---|---|
+| `models.primitives` | `Severity`, `Hostname`, `HttpUrl` - the typed-string and enum layer |
+| `models.finding` | `RawFinding`, `VerifiedVulnerability`, `RawFindingSummary` |
+| `models.asset` | `Endpoint`, `EndpointPage`, `HostRole`, `HostPriority`, `HostInsight`, `OpenPortsMap`, `LlmEndpoint`, `ReconResult` |
+| `models.workspace` | `RunFile`, `RunFileContent` |
+| `models.cve` | `CveEntry` |
+| `models.metrics` | `RunMetrics` |
+| `models.h1` | HackerOne API shapes (incl. `ProgrammeReportSummary`) |
+| `models.attack` | `AttackPlan`, `AttackPlanItem` |
+
+Dependency layers flow `primitives -> finding -> h1 -> asset`; modules import only from layers below them. Consumers can still `from models import X` (re-exports preserve the public surface) but inside the package, prefer the per-module path so circular-import dances stay out of reach.
 
 ## The `SquadMember.tools` registry
 
@@ -115,23 +143,26 @@ The reader returns the typed model; downstream agents work against the schema, n
 - `[f.model_dump() for f in check_X(...)]` in any wrapper body - drop the comprehension, just `return list(check_X(...))`.
 - Return annotation of `dict` for a structured payload that has a pydantic shape already.
 - Bare `list` (no inner type) as a return annotation - either it is `list[str]` for a flat handle list, or it is `list[<Model>]` for structured rows.
-- `@tool("...")` from `crewai.tools` for a new wrapper. Use `@cyber_tool` (or `@pentest_tool` for probes) so `args_schema` is enforced. Bare `@tool` survives only on the recon / write / workspace wrappers still on the #148-#150 backlog.
+- `@tool("...")` from `crewai.tools` for a new wrapper. Use `@cyber_tool` (or `@pentest_tool` for probes) so `args_schema` is enforced. Bare `@tool` survives only on workspace wrappers still on the #149 / #150 backlog.
 - An `args_schema` class with a field that lacks `Field(description=...)`. The whole point of the explicit path is per-field guidance; an empty description is the same gap the inferred path had.
+- A field typed `str` whose value is a hostname (`hostname: str`, `host: str`, `domain: str`) or a URL (`url: str`, `endpoint: str`). Use `Hostname` / `HttpUrl` from `models.primitives` - the typed primitives reject mis-shaped values upstream.
+- A `dict[str, ...]` whose keys are hostnames - type the key as `dict[Hostname, ...]` so the validator fires on the keys too.
+- Adding a new model directly to `models/__init__.py`. The package is split per domain; put it in the matching module and let the re-export carry it.
 - New workspace writer with no typed reader.
 - `from squad.workspace_tools import ...` in a consumer instead of `from squad import ...` - the re-export exists so the import path stays stable when shared tools move.
 
 ## Canonical examples
 
-Cross-agent intent matters: this skill applies to every agent's `@tool` wrappers, not just the pentester's. The codebase is mid-migration (#139 typed returns, #143/#146/#147 explicit args_schemas) - the PT agent is fully migrated, the other four are on the #148-#150 backlog.
+Cross-agent intent matters: this skill applies to every agent's `@cyber_tool` / `@pentest_tool` wrappers, not just the pentester's. The codebase is mid-migration (#139 typed returns, #143 / #146 / #147 / #148 explicit args_schemas) - PT and OSINT are fully migrated; PM, DC, VR, TA are on the #149 / #150 backlog.
 
-- `squad/penetration_tester/__init__.py` is the migration's tip. Every `@cyber_tool` and `@pentest_tool` carries an explicit `_<ToolName>Args` schema directly above the wrapper, with `Field(description=...)` on every field. Pentest probes (`ssrf_probe_tool`, `idor_probe_tool`) are the shortest examples; cloud / infra wrappers (`s3_check_tool`, `mongodb_tool`) show the `recon_path: str` shape.
+- `squad/penetration_tester/__init__.py` and `squad/osint_analyst/__init__.py` are the migration's tip. Every `@cyber_tool` and `@pentest_tool` carries an explicit `_<ToolName>Args` schema directly above the wrapper, with `Field(description=...)` on every field. Pentest probes (`ssrf_probe_tool`, `idor_probe_tool`) are the shortest StrEnum examples; cloud / infra wrappers (`s3_check_tool`, `mongodb_tool`) show the bare `recon_path: str`; OSINT (`probe_hostnames_tool`, `annotate_host_tool`) show the `Hostname` composition.
 - `squad/penetration_tester/__init__.py` `recon_endpoints_tool` returns `EndpointPage` - the canonical typed-return example. The wrapper lives on PT but it reads OSINT's recon output, so the pattern is cross-agent.
+- `squad/workspace_tools.py` `read_attack_plan_tool` returns `AttackPlan` - mirror this shape on any new workspace reader (typed return, no `dict`).
 - The workspace-handle string family demonstrates the `str` exception (writer returns the filename, next agent passes it to a typed reader):
   - `Finalise Recon` (`squad/osint_analyst/__init__.py`) -> `"recon.json"`
   - `Finalise Research` (`squad/vulnerability_researcher/__init__.py`) -> `"attack_plan.json"`
   - `Finalise Triage` (`squad/vulnerability_researcher/__init__.py`) -> `"verified.json"`
   - `Finalise Reports` (`squad/technical_author/__init__.py`) -> the reports manifest filename
-- `squad/workspace_tools.py` `read_attack_plan_tool` is on the #139 backlog - it should return `AttackPlan` but currently returns a `dict` shape. Cite it as the *target* of the typed-reader pattern, not the example to mirror today.
 
 ## Upstream alignment
 

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -15,10 +15,12 @@ fails.
 
 from __future__ import annotations
 
+import re
 from datetime import UTC, datetime
 from enum import StrEnum
+from typing import Annotated
 
-from pydantic import BaseModel, Field
+from pydantic import AfterValidator, BaseModel, Field
 
 # Enumerations
 
@@ -29,6 +31,54 @@ class Severity(StrEnum):
     MEDIUM = "medium"
     HIGH = "high"
     CRITICAL = "critical"
+
+
+# Typed string primitives
+#
+# ``Hostname`` is the typed string every scope-guard input flows through.
+# Using ``Annotated[str, AfterValidator(...)]`` keeps the runtime type as
+# ``str`` (anything expecting ``str`` keeps working) while pydantic applies
+# the validator at model_validate time - so the schema rejects URLs / ports /
+# paths / garbage upstream of any DNS or HTTP request.
+#
+# The validator is intentionally strict: it rejects a value the moment it
+# stops looking like a bare RFC 1123 hostname. The agent occasionally hands
+# us a URL where we asked for a hostname; the strict reject is the signal
+# that surfaces the mismatch, instead of the scope filter silently dropping
+# the value and the run going quiet.
+
+_HOSTNAME_LABEL_RE = re.compile(r"^[a-z0-9]([a-z0-9\-]{0,61}[a-z0-9])?$")
+
+
+def _validate_hostname(value: str) -> str:
+    """Normalise and validate a hostname per RFC 1123.
+
+    Lowercases and strips, then enforces: non-empty, no scheme (``://``),
+    no path (``/``), no port (``:``), total <= 253 chars, every dot-
+    separated label is 1-63 chars of alphanumerics or hyphens with no
+    leading or trailing hyphen. Returns the normalised value so downstream
+    comparisons are case-insensitive without each call site re-lowering.
+    """
+    if not isinstance(value, str):
+        raise ValueError(f"hostname must be a string, got {type(value).__name__}")
+    cleaned = value.strip().lower()
+    if not cleaned:
+        raise ValueError("hostname cannot be empty")
+    if "://" in cleaned:
+        raise ValueError(f"hostname must not include a scheme: {value!r}")
+    if "/" in cleaned:
+        raise ValueError(f"hostname must not include a path: {value!r}")
+    if ":" in cleaned:
+        raise ValueError(f"hostname must not include a port: {value!r}")
+    if len(cleaned) > 253:
+        raise ValueError(f"hostname too long ({len(cleaned)} > 253 chars)")
+    for label in cleaned.split("."):
+        if not _HOSTNAME_LABEL_RE.match(label):
+            raise ValueError(f"invalid hostname label {label!r} in {value!r}")
+    return cleaned
+
+
+Hostname = Annotated[str, AfterValidator(_validate_hostname)]
 
 
 # Vulnerability findings (Penetration Tester -> Vulnerability Researcher)

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -2,318 +2,65 @@
 models - Pydantic data models shared across the entire pipeline.
 
 Each model represents a discrete artefact that agents pass to one another.
-H1-specific shapes (programme catalog, scope, submission payloads) live in
-models.h1; everything else stays here until a similar size/concern split is
-warranted.
+The package is split into per-domain modules; this ``__init__`` is the
+public re-export surface so ``from models import X`` continues to work
+across every consumer.
 
-Declaration order is tweaked from the natural pipeline order (recon ->
-findings -> report) so that the types models.h1 depends on (Severity,
-VerifiedVulnerability) are defined before the `from models.h1 import ...`
-line. Without this, h1 hits a partially-initialised package and the import
-fails.
+| Module | Contents |
+|---|---|
+| ``models.primitives`` | ``Severity``, ``Hostname``, ``HttpUrl`` |
+| ``models.finding`` | ``RawFinding``, ``VerifiedVulnerability``, ``RawFindingSummary`` |
+| ``models.asset`` | ``Endpoint``, ``EndpointPage``, ``HostRole``, ``HostPriority``, |
+|                  | ``HostInsight``, ``OpenPortsMap``, ``LlmEndpoint``, ``ReconResult`` |
+| ``models.workspace`` | ``RunFile``, ``RunFileContent`` |
+| ``models.cve`` | ``CveEntry`` |
+| ``models.metrics`` | ``RunMetrics`` |
+| ``models.h1`` | HackerOne shapes incl. ``ProgrammeReportSummary`` |
+| ``models.attack`` | ``AttackPlan``, ``AttackPlanItem`` |
+
+The per-domain modules import only from layers below them in the
+dependency graph: primitives -> finding -> h1 -> asset. No module imports
+from this ``__init__`` to avoid the partially-initialised-package gotcha
+that the pre-split layout had to dance around.
 """
 
 from __future__ import annotations
 
-import re
-from datetime import UTC, datetime
-from enum import StrEnum
-from typing import Annotated
-
-from pydantic import AfterValidator, BaseModel, Field
-
-# Enumerations
-
-
-class Severity(StrEnum):
-    INFORMATIONAL = "informational"
-    LOW = "low"
-    MEDIUM = "medium"
-    HIGH = "high"
-    CRITICAL = "critical"
-
-
-# Typed string primitives
-#
-# ``Hostname`` is the typed string every scope-guard input flows through.
-# Using ``Annotated[str, AfterValidator(...)]`` keeps the runtime type as
-# ``str`` (anything expecting ``str`` keeps working) while pydantic applies
-# the validator at model_validate time - so the schema rejects URLs / ports /
-# paths / garbage upstream of any DNS or HTTP request.
-#
-# The validator is intentionally strict: it rejects a value the moment it
-# stops looking like a bare RFC 1123 hostname. The agent occasionally hands
-# us a URL where we asked for a hostname; the strict reject is the signal
-# that surfaces the mismatch, instead of the scope filter silently dropping
-# the value and the run going quiet.
-
-_HOSTNAME_LABEL_RE = re.compile(r"^[a-z0-9]([a-z0-9\-]{0,61}[a-z0-9])?$")
-
-
-def _validate_hostname(value: str) -> str:
-    """Normalise and validate a hostname per RFC 1123.
-
-    Lowercases and strips, then enforces: non-empty, no scheme (``://``),
-    no path (``/``), no port (``:``), total <= 253 chars, every dot-
-    separated label is 1-63 chars of alphanumerics or hyphens with no
-    leading or trailing hyphen. Returns the normalised value so downstream
-    comparisons are case-insensitive without each call site re-lowering.
-    """
-    if not isinstance(value, str):
-        raise ValueError(f"hostname must be a string, got {type(value).__name__}")
-    cleaned = value.strip().lower()
-    if not cleaned:
-        raise ValueError("hostname cannot be empty")
-    if "://" in cleaned:
-        raise ValueError(f"hostname must not include a scheme: {value!r}")
-    if "/" in cleaned:
-        raise ValueError(f"hostname must not include a path: {value!r}")
-    if ":" in cleaned:
-        raise ValueError(f"hostname must not include a port: {value!r}")
-    if len(cleaned) > 253:
-        raise ValueError(f"hostname too long ({len(cleaned)} > 253 chars)")
-    for label in cleaned.split("."):
-        if not _HOSTNAME_LABEL_RE.match(label):
-            raise ValueError(f"invalid hostname label {label!r} in {value!r}")
-    return cleaned
-
-
-Hostname = Annotated[str, AfterValidator(_validate_hostname)]
-
-
-# Vulnerability findings (Penetration Tester -> Vulnerability Researcher)
-#
-# Defined ahead of the H1 import below because models.h1 needs
-# VerifiedVulnerability for DisclosureReport.vulnerability, and RawFinding is
-# referenced by ReconResult further down.
-
-
-class RawFinding(BaseModel):
-    """An unverified potential vulnerability from automated tooling."""
-
-    title: str
-    vuln_class: str
-    target: str
-    evidence: str
-    tool: str
-    severity_hint: Severity = Severity.MEDIUM
-
-
-class VerifiedVulnerability(BaseModel):
-    """A confirmed, in-scope vulnerability after Vulnerability Researcher triage."""
-
-    title: str
-    vuln_class: str
-    target: str
-    severity: Severity
-    cvss_score: float
-    cvss_vector: str
-    description: str
-    steps_to_reproduce: list[str]
-    evidence: str
-    impact: str
-    remediation: str
-    in_scope: bool = True
-    confirmed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
-
-
-# H1 import - models.h1 imports Severity and VerifiedVulnerability from above;
-# Programme is referenced by ReconResult below as a pydantic field type, which
-# pydantic resolves against this module's globals at class-definition time.
-from models.h1 import Programme  # noqa: E402
-
-# Recon (OSINT Analyst -> Penetration Tester)
-
-
-class Endpoint(BaseModel):
-    """A discovered HTTP/S endpoint."""
-
-    url: str
-    status_code: int | None = None
-    technologies: list[str] = Field(default_factory=list)
-    parameters: list[str] = Field(default_factory=list)
-
-
-class EndpointPage(BaseModel):
-    """Paginated slice of Endpoint results from a recon query."""
-
-    total: int
-    offset: int
-    returned: int
-    endpoints: list[Endpoint]
-
-
-class HostRole(StrEnum):
-    """The role a host plays in the programme's attack surface.
-
-    Drives priority decisions downstream: an ``ADMIN`` host with a known
-    framework is a higher-value pentest target than a ``CDN`` host that
-    serves static assets.
-    """
-
-    ADMIN = "admin"  # admin / control-plane UIs
-    API = "api"  # REST / GraphQL / SOAP endpoints
-    AUTH = "auth"  # SSO, OAuth, login, password reset
-    APP = "app"  # main user-facing application
-    CDN = "cdn"  # static asset delivery, edge caches
-    STATIC = "static"  # purely static content (marketing, blog, docs)
-    MAIL = "mail"  # SMTP / IMAP / MX hosts
-    INFRA = "infra"  # name servers, monitoring, IaaS
-    DEV = "dev"  # dev / staging / beta surfaces
-    UNKNOWN = "unknown"
-
-
-class HostPriority(StrEnum):
-    """The OSINT Analyst's curation signal for downstream agents.
-
-    The Penetration Tester biases probe budget toward ``HIGH`` hosts; the
-    Vulnerability Researcher prioritises CVE / report-history research for
-    them. ``SKIP`` is a hard signal not to probe (third-party-managed, known
-    decoy, etc.)."""
-
-    HIGH = "high"
-    MEDIUM = "medium"
-    LOW = "low"
-    SKIP = "skip"
-
-
-class HostInsight(BaseModel):
-    """One OSINT Analyst-authored annotation for a single host.
-
-    The sweep produces ``subdomains`` / ``endpoints`` / ``open_ports`` /
-    ``technologies`` as raw inventory; ``HostInsight`` is the agent's
-    curation layer that tells downstream agents WHERE to look first and
-    WHY.
-    """
-
-    hostname: str
-    role: HostRole
-    priority: HostPriority
-    notes: str  # agent-authored, >= 30 chars
-    detected_tech: list[str] = Field(default_factory=list)  # ideally with versions
-    annotated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
-
-
-class ReconResult(BaseModel):
-    """Everything the OSINT Analyst found about a programme's attack surface."""
-
-    programme: Programme
-    subdomains: list[str] = Field(default_factory=list)
-    endpoints: list[Endpoint] = Field(default_factory=list)
-    open_ports: dict[str, list[int]] = Field(default_factory=dict)
-    technologies: list[str] = Field(default_factory=list)
-    notes: str = ""
-    # Findings collected passively during recon (TLS issues, DNS misconfigs, etc.)
-    # Available to all downstream agents without requiring a separate pentest pass.
-    passive_findings: list[RawFinding] = Field(default_factory=list)
-    # hostname -> ordered list of public hop IPs from traceroute.
-    # Useful for identifying origin IPs behind CDNs/WAFs (CDN bypass vector).
-    network_hops: dict[str, list[str]] = Field(default_factory=dict)
-    # Per-host curation the OSINT Analyst authors via Annotate Host. Empty on
-    # the OA's internal sweep.json; populated on the final recon.json.
-    host_insights: list[HostInsight] = Field(default_factory=list)
-    completed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
-
-
-# Workspace artefacts (shared @tool wrapper return shapes)
-
-
-class RunFile(BaseModel):
-    """One file in the per-run shared workspace."""
-
-    name: str  # path relative to the run directory
-    size_bytes: int
-
-
-class RunFileContent(BaseModel):
-    """The full contents of one run-directory file."""
-
-    name: str
-    size_bytes: int
-    content: str
-
-
-# Recon-derived tool return shapes
-
-
-class OpenPortsMap(BaseModel):
-    """The recon-derived port map keyed by host.
-
-    Lives as its own model rather than ``dict[str, list[int]]`` so the
-    Penetration Tester sees a documented shape it can pattern-match on
-    when deciding which port-specific probes to run.
-    """
-
-    hosts: dict[str, list[int]] = Field(default_factory=dict)
-
-
-class LlmEndpoint(BaseModel):
-    """An endpoint flagged as LLM-backed by ``detect_llm_endpoints``.
-
-    A thin wrapper over ``Endpoint`` so the OSINT Analyst tool surface
-    carries the LLM-detection intent at the type level (the field set is
-    identical, but the model name marks the contract).
-    """
-
-    url: str
-    status_code: int | None = None
-    technologies: list[str] = Field(default_factory=list)
-    parameters: list[str] = Field(default_factory=list)
-
-
-# Triage / report / OSINT tool return shapes
-#
-# These wrap a workspace path plus the validation report produced by the
-# underlying tool. Keeping the path and the validation grouped on the same
-# model means the agent does not have to guess which keys to read on a
-# bare dict.
-
-
-class RawFindingSummary(BaseModel):
-    """Compact summary of one raw finding, returned by List Raw Findings."""
-
-    index: int
-    title: str
-    vuln_class: str
-    target: str
-    severity_hint: Severity
-    evidence_bytes: int
-
-
-class ProgrammeReportSummary(BaseModel):
-    """Compact summary of one HackerOne report listed against a programme."""
-
-    report_id: str | None = None
-    title: str | None = None
-    severity: str | None = None
-    state: str | None = None
-
-
-class CveEntry(BaseModel):
-    """One NVD CVE record, returned by NVD CVE Lookup."""
-
-    id: str
-    cvss_score: float | None = None
-    cvss_vector: str | None = None
-    description: str = ""
-
-
-# Operational metrics (emitted after every pipeline run)
-
-
-class RunMetrics(BaseModel):
-    """Token usage, cost, and effectiveness summary for one pipeline run."""
-
-    run_id: str
-    started_at: datetime
-    completed_at: datetime
-    duration_seconds: float
-    llm_model: str
-    programme_handle: str | None = None
-    input_tokens: int = 0
-    output_tokens: int = 0
-    total_tokens: int = 0
-    estimated_cost_usd: float = 0.0
-    findings_raw: int = 0
-    findings_verified: int = 0
-    submitted: bool = False
+from models.asset import (
+    Endpoint,
+    EndpointPage,
+    HostInsight,
+    HostPriority,
+    HostRole,
+    LlmEndpoint,
+    OpenPortsMap,
+    ReconResult,
+)
+from models.cve import CveEntry
+from models.finding import RawFinding, RawFindingSummary, VerifiedVulnerability
+from models.h1 import ProgrammeReportSummary
+from models.metrics import RunMetrics
+from models.primitives import Hostname, HttpUrl, Severity
+from models.workspace import RunFile, RunFileContent
+
+__all__ = [
+    "CveEntry",
+    "Endpoint",
+    "EndpointPage",
+    "HostInsight",
+    "HostPriority",
+    "HostRole",
+    "Hostname",
+    "HttpUrl",
+    "LlmEndpoint",
+    "OpenPortsMap",
+    "ProgrammeReportSummary",
+    "RawFinding",
+    "RawFindingSummary",
+    "ReconResult",
+    "RunFile",
+    "RunFileContent",
+    "RunMetrics",
+    "Severity",
+    "VerifiedVulnerability",
+]

--- a/models/asset.py
+++ b/models/asset.py
@@ -116,6 +116,19 @@ class LlmEndpoint(BaseModel):
     A thin wrapper over ``Endpoint`` so the OSINT Analyst tool surface
     carries the LLM-detection intent at the type level (the field set is
     identical, but the model name marks the contract).
+
+    FIXME(#144 / #83): this class is on the way to becoming ``DiscoveredMCP``.
+    The intent the original author was reaching for - "this endpoint
+    exposes an LLM" - has a more useful concrete shape now that the MCP
+    threat model is clear: MCP servers advertise tool lists, capability
+    bits, init handshakes, and schemas, and that structured surface is
+    what the PT would actually probe against. The right move is to
+    promote this into ``models/framework.py`` (per #83) as
+    ``DiscoveredMCP`` carrying the advertised tool inventory, the
+    suspicious-docstring flags, and the schema-laxness markers that the
+    #144 MCP-discipline conversation called out. Until then this class
+    exists as an intent marker and a placeholder; do not extend it as a
+    generic LLM endpoint shape.
     """
 
     url: HttpUrl

--- a/models/asset.py
+++ b/models/asset.py
@@ -1,0 +1,145 @@
+"""
+models.asset - the recon-output inventory shapes (OSINT Analyst -> PT).
+
+What the OSINT Analyst's sweep / annotation / finalisation produces:
+endpoints discovered, hostnames classified by role and priority, open
+ports per host, LLM-backed endpoint flags, and the bundled ``ReconResult``
+that wraps the lot for downstream agents.
+
+Hostname-typed fields compose the ``Hostname`` primitive (#152) so
+mis-shaped hostnames reject upstream of any downstream consumer rather
+than silently flowing through the scope filter.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+from models.finding import RawFinding
+from models.h1 import Programme
+from models.primitives import Hostname, HttpUrl
+
+
+class Endpoint(BaseModel):
+    """A discovered HTTP/S endpoint.
+
+    ``url`` is validated as a parseable HTTP / HTTPS URL with a valid
+    ``Hostname`` underneath; the runtime type stays ``str`` so existing
+    consumers that ``.startswith(...)`` / compare against literals keep
+    working. FIXME(#152 follow-up): migrate to Pydantic ``HttpUrl`` once
+    every call site is ready for the ``Url`` runtime type.
+    """
+
+    url: HttpUrl
+    status_code: int | None = None
+    technologies: list[str] = Field(default_factory=list)
+    parameters: list[str] = Field(default_factory=list)
+
+
+class EndpointPage(BaseModel):
+    """Paginated slice of Endpoint results from a recon query."""
+
+    total: int
+    offset: int
+    returned: int
+    endpoints: list[Endpoint]
+
+
+class HostRole(StrEnum):
+    """The role a host plays in the programme's attack surface.
+
+    Drives priority decisions downstream: an ``ADMIN`` host with a known
+    framework is a higher-value pentest target than a ``CDN`` host that
+    serves static assets.
+    """
+
+    ADMIN = "admin"  # admin / control-plane UIs
+    API = "api"  # REST / GraphQL / SOAP endpoints
+    AUTH = "auth"  # SSO, OAuth, login, password reset
+    APP = "app"  # main user-facing application
+    CDN = "cdn"  # static asset delivery, edge caches
+    STATIC = "static"  # purely static content (marketing, blog, docs)
+    MAIL = "mail"  # SMTP / IMAP / MX hosts
+    INFRA = "infra"  # name servers, monitoring, IaaS
+    DEV = "dev"  # dev / staging / beta surfaces
+    UNKNOWN = "unknown"
+
+
+class HostPriority(StrEnum):
+    """The OSINT Analyst's curation signal for downstream agents.
+
+    The Penetration Tester biases probe budget toward ``HIGH`` hosts; the
+    Vulnerability Researcher prioritises CVE / report-history research for
+    them. ``SKIP`` is a hard signal not to probe (third-party-managed, known
+    decoy, etc.)."""
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    SKIP = "skip"
+
+
+class HostInsight(BaseModel):
+    """One OSINT Analyst-authored annotation for a single host.
+
+    The sweep produces ``subdomains`` / ``endpoints`` / ``open_ports`` /
+    ``technologies`` as raw inventory; ``HostInsight`` is the agent's
+    curation layer that tells downstream agents WHERE to look first and
+    WHY.
+    """
+
+    hostname: Hostname
+    role: HostRole
+    priority: HostPriority
+    notes: str  # agent-authored, >= 30 chars
+    detected_tech: list[str] = Field(default_factory=list)  # ideally with versions
+    annotated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class OpenPortsMap(BaseModel):
+    """The recon-derived port map keyed by host.
+
+    Lives as its own model rather than ``dict[Hostname, list[int]]`` so the
+    Penetration Tester sees a documented shape it can pattern-match on
+    when deciding which port-specific probes to run.
+    """
+
+    hosts: dict[Hostname, list[int]] = Field(default_factory=dict)
+
+
+class LlmEndpoint(BaseModel):
+    """An endpoint flagged as LLM-backed by ``detect_llm_endpoints``.
+
+    A thin wrapper over ``Endpoint`` so the OSINT Analyst tool surface
+    carries the LLM-detection intent at the type level (the field set is
+    identical, but the model name marks the contract).
+    """
+
+    url: HttpUrl
+    status_code: int | None = None
+    technologies: list[str] = Field(default_factory=list)
+    parameters: list[str] = Field(default_factory=list)
+
+
+class ReconResult(BaseModel):
+    """Everything the OSINT Analyst found about a programme's attack surface."""
+
+    programme: Programme
+    subdomains: list[Hostname] = Field(default_factory=list)
+    endpoints: list[Endpoint] = Field(default_factory=list)
+    open_ports: dict[Hostname, list[int]] = Field(default_factory=dict)
+    technologies: list[str] = Field(default_factory=list)
+    notes: str = ""
+    # Findings collected passively during recon (TLS issues, DNS misconfigs, etc.)
+    # Available to all downstream agents without requiring a separate pentest pass.
+    passive_findings: list[RawFinding] = Field(default_factory=list)
+    # hostname -> ordered list of public hop IPs from traceroute.
+    # Useful for identifying origin IPs behind CDNs/WAFs (CDN bypass vector).
+    network_hops: dict[Hostname, list[str]] = Field(default_factory=dict)
+    # Per-host curation the OSINT Analyst authors via Annotate Host. Empty on
+    # the OA's internal sweep.json; populated on the final recon.json.
+    host_insights: list[HostInsight] = Field(default_factory=list)
+    completed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/models/cve.py
+++ b/models/cve.py
@@ -1,0 +1,20 @@
+"""
+models.cve - the NVD CVE record shape, returned by VR's NVD CVE Lookup.
+
+Pairs with ``tools/cwe_data.py`` and ``tools/owasp_data.py`` as the
+external-vocabulary lookups the VR uses during triage; this is the only
+one wired to a live NVD query rather than a vendored catalogue.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class CveEntry(BaseModel):
+    """One NVD CVE record, returned by NVD CVE Lookup."""
+
+    id: str
+    cvss_score: float | None = None
+    cvss_vector: str | None = None
+    description: str = ""

--- a/models/finding.py
+++ b/models/finding.py
@@ -1,0 +1,57 @@
+"""
+models.finding - the vuln-pipeline data shapes (PT -> VR -> TA).
+
+``RawFinding`` is the unverified output of an automated probe;
+``VerifiedVulnerability`` is the post-triage shape the Technical Author
+turns into a report; ``RawFindingSummary`` is the compact slice the VR's
+List Raw Findings tool returns. All three carry a ``Severity`` (from
+``models.primitives``).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pydantic import BaseModel, Field
+
+from models.primitives import Severity
+
+
+class RawFinding(BaseModel):
+    """An unverified potential vulnerability from automated tooling."""
+
+    title: str
+    vuln_class: str
+    target: str
+    evidence: str
+    tool: str
+    severity_hint: Severity = Severity.MEDIUM
+
+
+class VerifiedVulnerability(BaseModel):
+    """A confirmed, in-scope vulnerability after Vulnerability Researcher triage."""
+
+    title: str
+    vuln_class: str
+    target: str
+    severity: Severity
+    cvss_score: float
+    cvss_vector: str
+    description: str
+    steps_to_reproduce: list[str]
+    evidence: str
+    impact: str
+    remediation: str
+    in_scope: bool = True
+    confirmed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class RawFindingSummary(BaseModel):
+    """Compact summary of one raw finding, returned by List Raw Findings."""
+
+    index: int
+    title: str
+    vuln_class: str
+    target: str
+    severity_hint: Severity
+    evidence_bytes: int

--- a/models/h1.py
+++ b/models/h1.py
@@ -9,7 +9,8 @@ these types directly with the H1 API via tools/h1_api.py:
   - Programme is the hydrated detail shape;
   - DisclosureReport is the POST /reports payload (Technical Author -> Disclosure Coordinator);
   - SubmissionStatus enumerates H1's report state taxonomy;
-  - SubmissionResult is the outcome of POSTing a report to /reports.
+  - SubmissionResult is the outcome of POSTing a report to /reports;
+  - ProgrammeReportSummary is the compact slice returned by List Programme Reports.
 """
 
 from __future__ import annotations
@@ -19,7 +20,8 @@ from enum import StrEnum
 
 from pydantic import BaseModel, Field
 
-from models import Severity, VerifiedVulnerability
+from models.finding import VerifiedVulnerability
+from models.primitives import Severity
 
 
 class ScopeType(StrEnum):
@@ -141,3 +143,18 @@ class SubmissionResult(BaseModel):
     h1_url: str | None = None
     submitted_at: datetime | None = None
     error: str | None = None
+
+
+class ProgrammeReportSummary(BaseModel):
+    """Compact summary of one HackerOne report listed against a programme.
+
+    Lives in models.h1 rather than models.finding because the shape mirrors
+    H1's /reports listing payload (every field is verbatim from the API)
+    and the consumer is the Technical Author's List Programme Reports tool
+    which already speaks h1-shape.
+    """
+
+    report_id: str | None = None
+    title: str | None = None
+    severity: str | None = None
+    state: str | None = None

--- a/models/metrics.py
+++ b/models/metrics.py
@@ -1,0 +1,32 @@
+"""
+models.metrics - per-run operational metrics emitted after every pipeline
+run.
+
+Token usage, cost, and finding-funnel summary. Lives apart from the data
+models so the metrics shape can evolve without touching the artefact
+graph.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class RunMetrics(BaseModel):
+    """Token usage, cost, and effectiveness summary for one pipeline run."""
+
+    run_id: str
+    started_at: datetime
+    completed_at: datetime
+    duration_seconds: float
+    llm_model: str
+    programme_handle: str | None = None
+    input_tokens: int = 0
+    output_tokens: int = 0
+    total_tokens: int = 0
+    estimated_cost_usd: float = 0.0
+    findings_raw: int = 0
+    findings_verified: int = 0
+    submitted: bool = False

--- a/models/primitives.py
+++ b/models/primitives.py
@@ -1,0 +1,118 @@
+"""
+models.primitives - foundational typed-string and enum primitives shared
+across the model graph.
+
+Both ``Severity`` and ``Hostname`` are leaf dependencies - they have no
+forward references into other model modules - so they live in the
+deepest layer of the package. ``models.finding``, ``models.asset``,
+``models.h1`` and the rest depend on them; nothing here depends on the
+others.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import StrEnum
+from typing import Annotated
+
+from pydantic import AfterValidator
+
+
+class Severity(StrEnum):
+    INFORMATIONAL = "informational"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+# ``Hostname`` is the typed string every scope-guard input flows through.
+# Using ``Annotated[str, AfterValidator(...)]`` keeps the runtime type as
+# ``str`` (anything expecting ``str`` keeps working) while pydantic applies
+# the validator at model_validate time - so the schema rejects URLs / ports /
+# paths / garbage upstream of any DNS or HTTP request.
+#
+# The validator is intentionally strict: it rejects a value the moment it
+# stops looking like a bare RFC 1123 hostname. The agent occasionally hands
+# us a URL where we asked for a hostname; the strict reject is the signal
+# that surfaces the mismatch, instead of the scope filter silently dropping
+# the value and the run going quiet.
+
+_HOSTNAME_LABEL_RE = re.compile(r"^[a-z0-9]([a-z0-9\-]{0,61}[a-z0-9])?$")
+
+
+def _validate_hostname(value: str) -> str:
+    """Normalise and validate a hostname per RFC 1123.
+
+    Lowercases and strips, then enforces: non-empty, no scheme (``://``),
+    no path (``/``), no port (``:``), total <= 253 chars, every dot-
+    separated label is 1-63 chars of alphanumerics or hyphens with no
+    leading or trailing hyphen. Returns the normalised value so downstream
+    comparisons are case-insensitive without each call site re-lowering.
+    """
+    if not isinstance(value, str):
+        raise ValueError(f"hostname must be a string, got {type(value).__name__}")
+    cleaned = value.strip().lower()
+    if not cleaned:
+        raise ValueError("hostname cannot be empty")
+    if "://" in cleaned:
+        raise ValueError(f"hostname must not include a scheme: {value!r}")
+    if "/" in cleaned:
+        raise ValueError(f"hostname must not include a path: {value!r}")
+    if ":" in cleaned:
+        raise ValueError(f"hostname must not include a port: {value!r}")
+    if len(cleaned) > 253:
+        raise ValueError(f"hostname too long ({len(cleaned)} > 253 chars)")
+    for label in cleaned.split("."):
+        if not _HOSTNAME_LABEL_RE.match(label):
+            raise ValueError(f"invalid hostname label {label!r} in {value!r}")
+    return cleaned
+
+
+Hostname = Annotated[str, AfterValidator(_validate_hostname)]
+
+
+# ``HttpUrl`` validator - light flavour. Parses with ``urlparse``, enforces
+# http / https scheme + a Hostname-valid host underneath. Keeps the runtime
+# type as ``str`` so every call site that does ``endpoint.url.startswith(...)``
+# or compares against a string literal keeps working. The agent sees "this
+# is a string" in the JSON schema but mis-shaped URLs still reject at
+# model_validate time.
+#
+# FIXME: migrate to Pydantic's built-in ``HttpUrl`` once the call sites that
+# do ``endpoint.url.startswith(...)`` / ``endpoint.url == "..."`` style
+# comparisons have been audited. ``HttpUrl`` exposes ``.host`` / ``.scheme``
+# / ``.port`` properties that would let consumers stop reaching for
+# ``urlparse`` ad-hoc, but the runtime type would stop being ``str`` and
+# the diff across the codebase needs care.
+
+
+def _validate_endpoint_url(value: str) -> str:
+    """Validate that ``value`` is a parseable HTTP / HTTPS URL with a valid
+    ``Hostname`` underneath.
+
+    Keeps the input as ``str`` (no canonicalisation - the caller already
+    constructed the URL deliberately and we do not want to silently rewrite
+    it). The hostname component runs through ``_validate_hostname`` so the
+    RFC 1123 contract is enforced at the URL layer too: a malformed
+    hostname inside the URL rejects the same as a bare malformed hostname.
+    """
+    from urllib.parse import urlparse  # local import: only fires at validation time
+
+    if not isinstance(value, str):
+        raise ValueError(f"url must be a string, got {type(value).__name__}")
+    cleaned = value.strip()
+    if not cleaned:
+        raise ValueError("url cannot be empty")
+    parsed = urlparse(cleaned)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"url must use http or https scheme: {value!r}")
+    if not parsed.hostname:
+        raise ValueError(f"url must include a hostname: {value!r}")
+    # Validate the hostname through the same RFC 1123 contract Hostname uses;
+    # this catches mis-shaped hosts inside an otherwise URL-shaped string.
+    _validate_hostname(parsed.hostname)
+    return cleaned
+
+
+HttpUrl = Annotated[str, AfterValidator(_validate_endpoint_url)]

--- a/models/workspace.py
+++ b/models/workspace.py
@@ -1,0 +1,26 @@
+"""
+models.workspace - shared @tool return shapes for the per-run workspace.
+
+Lives alongside ``squad.workspace_tools``: the readers there return one of
+these models so consumers work against a typed shape instead of a bare
+``dict``.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class RunFile(BaseModel):
+    """One file in the per-run shared workspace."""
+
+    name: str  # path relative to the run directory
+    size_bytes: int
+
+
+class RunFileContent(BaseModel):
+    """The full contents of one run-directory file."""
+
+    name: str
+    size_bytes: int
+    content: str

--- a/squad/__init__.py
+++ b/squad/__init__.py
@@ -48,7 +48,7 @@ SQUAD_SKILLS_DIR = Path(__file__).parent / "skills"
 class CrewAITool(Protocol):
     """The shape every ``MEMBER.tools`` entry conforms to.
 
-    The decorators in use - the bare ``@tool``, ``@typed_tool``,
+    The decorators in use - the bare ``@tool``, ``@cyber_tool``,
     ``@pentest_tool``, ``@research_brief_tool`` - all produce CrewAI ``Tool``
     instances that carry ``name``, ``description``, and ``func``. This
     Protocol is the single shared surface those decorators expose, so the
@@ -70,7 +70,7 @@ class CrewAITool(Protocol):
     def func(self) -> Callable[..., object]: ...
 
 
-def typed_tool(
+def cyber_tool(
     name: str, *, args_schema: type[BaseModel]
 ) -> Callable[[Callable[..., object]], CrewAITool]:
     """The blessed cybersquad replacement for bare ``@crewai.tools.tool``.
@@ -83,10 +83,10 @@ def typed_tool(
     descriptions when picking the tool.
 
     ``pentest_tool`` and ``research_brief_tool`` compose on top of this
-    helper: they call ``typed_tool`` underneath and then layer their own
+    helper: they call ``cyber_tool`` underneath and then layer their own
     docstring-injection (OWASP categories for the pentest wrapper, brief
     formatting for the research one). Anything that does not need a
-    specialist wrapper uses ``@typed_tool`` directly.
+    specialist wrapper uses ``@cyber_tool`` directly.
     """
 
     def decorator(fn: Callable[..., object]) -> CrewAITool:
@@ -178,5 +178,5 @@ __all__ = [
     "read_attack_plan_tool",
     "read_run_filelist_tool",
     "read_run_file_tool",
-    "typed_tool",
+    "cyber_tool",
 ]

--- a/squad/osint_analyst/__init__.py
+++ b/squad/osint_analyst/__init__.py
@@ -9,6 +9,7 @@ from models import (
     Endpoint,
     EndpointPage,
     HostInsight,
+    Hostname,
     HostPriority,
     HostRole,
     LlmEndpoint,
@@ -204,18 +205,21 @@ class _ReconOpenPortsArgs(BaseModel):
         default="sweep.json",
         description="Relative path to the OA's sweep file. Defaults to ``sweep.json``.",
     )
-    host: str | None = Field(
+    host: Hostname | None = Field(
         default=None,
         description=(
             "Exact hostname to restrict the result to (no wildcards, no"
-            " substring). Omit or pass null to get the full per-host port"
-            " map. Use to look up a single host before annotating."
+            " substring). Validated as an RFC 1123 hostname - URLs / ports"
+            " / paths reject upstream. Omit or pass null to get the full"
+            " per-host port map."
         ),
     )
 
 
 @cyber_tool("Recon Open Ports", args_schema=_ReconOpenPortsArgs)
-def recon_open_ports_tool(sweep_path: str = "sweep.json", host: str | None = None) -> OpenPortsMap:
+def recon_open_ports_tool(
+    sweep_path: str = "sweep.json", host: Hostname | None = None
+) -> OpenPortsMap:
     """
     Return the open-port map per host from the sweep. Passing a ``host``
     restricts the result to that single host. Use to surface non-HTTP
@@ -228,11 +232,11 @@ def recon_open_ports_tool(sweep_path: str = "sweep.json", host: str | None = Non
 class _CertTransparencyArgs(BaseModel):
     """Explicit args_schema for the Certificate Transparency Lookup tool (#148)."""
 
-    domain: str = Field(
+    domain: Hostname = Field(
         description=(
             "Apex domain to look up in crt.sh certificate transparency logs"
-            " (e.g. 'example.com'). Returns historical subdomains across all"
-            " certificates issued for the domain. Pass an apex, not a"
+            " (e.g. 'example.com'). Validated as an RFC 1123 hostname"
+            " (URLs / ports / paths reject upstream). Pass an apex, not a"
             " subdomain - crt.sh returns the broader set when queried on"
             " the apex."
         ),
@@ -240,7 +244,7 @@ class _CertTransparencyArgs(BaseModel):
 
 
 @cyber_tool("Certificate Transparency Lookup", args_schema=_CertTransparencyArgs)
-def cert_transparency_tool(domain: str) -> list[str]:
+def cert_transparency_tool(domain: Hostname) -> list[str]:
     """
     Query crt.sh certificate transparency logs to discover subdomains not
     found by active enumeration. Returns deduplicated hostnames. Feed
@@ -252,18 +256,19 @@ def cert_transparency_tool(domain: str) -> list[str]:
 class _HistoricalUrlsArgs(BaseModel):
     """Explicit args_schema for the Historical URL Discovery tool (#148)."""
 
-    domain: str = Field(
+    domain: Hostname = Field(
         description=(
-            "Domain to query waybackurls for (apex or subdomain). Returns"
-            " historical URLs the Wayback Machine has archived. Many paths"
-            " will be 404s today; feed candidates to Probe Hostnames to"
-            " confirm liveness before annotating."
+            "Domain to query waybackurls for (apex or subdomain). Validated"
+            " as an RFC 1123 hostname (URLs / ports / paths reject"
+            " upstream). Returns historical URLs the Wayback Machine has"
+            " archived. Many paths will be 404s today; feed candidates to"
+            " Probe Hostnames to confirm liveness before annotating."
         ),
     )
 
 
 @cyber_tool("Historical URL Discovery", args_schema=_HistoricalUrlsArgs)
-def historical_urls_tool(domain: str) -> list[str]:
+def historical_urls_tool(domain: Hostname) -> list[str]:
     """
     Use waybackurls to find historical endpoints for a domain from the
     Wayback Machine. Surfaces paths that may no longer be linked but still
@@ -305,15 +310,17 @@ def llm_detection_tool(endpoints: list[Endpoint]) -> list[LlmEndpoint]:
 class _ProbeHostnamesArgs(BaseModel):
     """Explicit args_schema for the Probe Hostnames tool (#148)."""
 
-    hostnames: list[str] = Field(
+    hostnames: list[Hostname] = Field(
         description=(
             "Hostnames to re-probe with httpx for liveness, status code,"
-            " and technology fingerprinting. Typically the net-new ones"
-            " surfaced by Certificate Transparency or Historical URL"
-            " Discovery that were missed by the initial sweep. Each"
-            " hostname is scope-filtered against the programme before"
-            " any HTTP traffic fires - out-of-scope hostnames are"
-            " dropped silently."
+            " and technology fingerprinting. Each entry is validated as an"
+            " RFC 1123 hostname; URLs / ports / paths reject upstream"
+            " (catches the common 'agent handed us a URL when we asked for"
+            " a hostname' case before the scope filter silently drops it)."
+            " Typically the net-new ones surfaced by Certificate"
+            " Transparency or Historical URL Discovery that were missed by"
+            " the initial sweep. After this, each hostname is scope-"
+            "filtered against the programme before any HTTP traffic fires."
         ),
     )
     programme_handle: str = Field(
@@ -327,7 +334,7 @@ class _ProbeHostnamesArgs(BaseModel):
 
 
 @cyber_tool("Probe Hostnames", args_schema=_ProbeHostnamesArgs)
-def probe_hostnames_tool(hostnames: list[str], programme_handle: str) -> list[Endpoint]:
+def probe_hostnames_tool(hostnames: list[Hostname], programme_handle: str) -> list[Endpoint]:
     """
     Re-probe a list of hostnames with httpx to confirm liveness, capture
     status codes, and fingerprint technologies. Use this on hostnames
@@ -352,13 +359,15 @@ def probe_hostnames_tool(hostnames: list[str], programme_handle: str) -> list[En
 class _DetectTakeoverCandidatesArgs(BaseModel):
     """Explicit args_schema for the Detect Takeover Candidates tool (#148)."""
 
-    hostnames: list[str] = Field(
+    hostnames: list[Hostname] = Field(
         description=(
             "Hostnames to resolve via dnsx and flag for subdomain takeover."
-            " A candidate fires when the CNAME points to a known-vulnerable"
-            " provider (AWS S3, Heroku, GitHub Pages, Azure, Vercel,"
-            " Netlify, ...) or when the CNAME chain dangles. Hostnames are"
-            " scope-filtered before any DNS traffic fires."
+            " Each entry is validated as an RFC 1123 hostname; URLs / ports"
+            " / paths reject upstream. A candidate fires when the CNAME"
+            " points to a known-vulnerable provider (AWS S3, Heroku,"
+            " GitHub Pages, Azure, Vercel, Netlify, ...) or when the CNAME"
+            " chain dangles. Hostnames are scope-filtered before any DNS"
+            " traffic fires."
         ),
     )
     programme_handle: str = Field(
@@ -372,7 +381,7 @@ class _DetectTakeoverCandidatesArgs(BaseModel):
 
 @cyber_tool("Detect Takeover Candidates", args_schema=_DetectTakeoverCandidatesArgs)
 def detect_takeover_candidates_tool(
-    hostnames: list[str], programme_handle: str
+    hostnames: list[Hostname], programme_handle: str
 ) -> list[TakeoverCandidate]:
     """
     Resolve each hostname via dnsx and flag subdomain-takeover candidates.
@@ -452,11 +461,12 @@ def lookup_owasp_tool(query: str) -> list[OWASPEntry]:
 class _AnnotateHostArgs(BaseModel):
     """Explicit args_schema for the Annotate Host tool (#148)."""
 
-    hostname: str = Field(
+    hostname: Hostname = Field(
         description=(
             "Hostname to annotate. Must already be in the sweep, or have"
             " been surfaced by Certificate Transparency / Historical URL"
-            " Discovery / Probe Hostnames. Lowercased before save."
+            " Discovery / Probe Hostnames. Validated as an RFC 1123"
+            " hostname (URLs / ports / paths reject upstream)."
         ),
     )
     role: HostRole = Field(
@@ -509,7 +519,7 @@ class _AnnotateHostArgs(BaseModel):
 
 @cyber_tool("Annotate Host", args_schema=_AnnotateHostArgs)
 def annotate_host_tool(
-    hostname: str,
+    hostname: Hostname,
     role: HostRole,
     priority: HostPriority,
     notes: str,

--- a/squad/osint_analyst/__init__.py
+++ b/squad/osint_analyst/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from crewai.tools import tool
+from pydantic import BaseModel, Field
 
 import runtime
 from models import (
@@ -18,7 +18,7 @@ from models import (
     OpenPortsMap,
 )
 from models.h1 import Programme
-from squad import SquadMember, read_run_file_tool, read_run_filelist_tool
+from squad import SquadMember, cyber_tool, read_run_file_tool, read_run_filelist_tool
 from tools import http
 from tools.cwe_data import CWEEntry
 from tools.cwe_data import lookup as cwe_lookup
@@ -52,7 +52,21 @@ from tools.recon_insights import (
 )
 
 
-@tool("Run Initial Sweep")
+class _RunInitialSweepArgs(BaseModel):
+    """Explicit args_schema for the Run Initial Sweep tool (#148)."""
+
+    programme_handle: str = Field(
+        description=(
+            "Exact HackerOne programme handle as it appears in the URL"
+            " (lowercase, no slashes, no spaces). The sweep runs subfinder,"
+            " httpx, nmap, ffuf, and passive TLS / DNS checks against the"
+            " programme's structured scope - the handle is the authoritative"
+            " key the H1 API uses to look the scope up."
+        ),
+    )
+
+
+@cyber_tool("Run Initial Sweep", args_schema=_RunInitialSweepArgs)
 def run_initial_sweep_tool(programme_handle: str) -> str:
     """
     Run the initial OSINT sweep against the in-scope assets of the given
@@ -77,7 +91,30 @@ def run_initial_sweep_tool(programme_handle: str) -> str:
     return "sweep.json"
 
 
-@tool("Recon Subdomains")
+class _ReconSubdomainsArgs(BaseModel):
+    """Explicit args_schema for the OSINT Recon Subdomains tool (#148)."""
+
+    sweep_path: str = Field(
+        default="sweep.json",
+        description=(
+            "Relative path to the OA's in-progress sweep file. Defaults to"
+            " ``sweep.json`` (the canonical name written by Run Initial"
+            " Sweep). Override only when re-inspecting a sweep written"
+            " under a different name."
+        ),
+    )
+    host_filter: str | None = Field(
+        default=None,
+        description=(
+            "Case-insensitive substring match against each subdomain"
+            " (e.g. 'api' returns every subdomain containing 'api',"
+            " regardless of position). Omit or pass null to get the full"
+            " list. Useful for scoping a per-role annotation pass."
+        ),
+    )
+
+
+@cyber_tool("Recon Subdomains", args_schema=_ReconSubdomainsArgs)
 def recon_subdomains_tool(
     sweep_path: str = "sweep.json", host_filter: str | None = None
 ) -> list[str]:
@@ -90,7 +127,54 @@ def recon_subdomains_tool(
     return recon_subdomains(sweep_path, host_filter=host_filter)
 
 
-@tool("Recon Endpoints")
+class _ReconEndpointsArgs(BaseModel):
+    """Explicit args_schema for the OSINT Recon Endpoints tool (#148)."""
+
+    sweep_path: str = Field(
+        default="sweep.json",
+        description="Relative path to the OA's sweep file. Defaults to ``sweep.json``.",
+    )
+    status: int | None = Field(
+        default=None,
+        description=(
+            "Exact HTTP status code to filter by (e.g. 200 for live, 401 /"
+            " 403 for auth-shaped, 301 / 302 for redirectors). Omit or pass"
+            " null for any status."
+        ),
+    )
+    tech: str | None = Field(
+        default=None,
+        description=(
+            "Case-insensitive substring match against each endpoint's"
+            " technologies list (e.g. 'wordpress' matches 'WordPress 6.4')."
+            " Use when scoping a per-stack annotation pass."
+        ),
+    )
+    host_contains: str | None = Field(
+        default=None,
+        description=(
+            "Case-insensitive substring match against the endpoint URL. Use"
+            " to narrow to a hostname or path family."
+        ),
+    )
+    offset: int = Field(
+        default=0,
+        description=(
+            "Zero-based row offset for paging. Use with ``limit`` to walk large result sets."
+        ),
+    )
+    limit: int = Field(
+        default=50,
+        description=(
+            "Maximum number of endpoints to return in this page. The OA's"
+            " context budget rewards small pages; default 50 is usually"
+            " right - go larger only when the conjunctive filters above"
+            " already narrowed the result heavily."
+        ),
+    )
+
+
+@cyber_tool("Recon Endpoints", args_schema=_ReconEndpointsArgs)
 def recon_endpoints_tool(
     sweep_path: str = "sweep.json",
     status: int | None = None,
@@ -116,7 +200,24 @@ def recon_endpoints_tool(
     )
 
 
-@tool("Recon Open Ports")
+class _ReconOpenPortsArgs(BaseModel):
+    """Explicit args_schema for the OSINT Recon Open Ports tool (#148)."""
+
+    sweep_path: str = Field(
+        default="sweep.json",
+        description="Relative path to the OA's sweep file. Defaults to ``sweep.json``.",
+    )
+    host: str | None = Field(
+        default=None,
+        description=(
+            "Exact hostname to restrict the result to (no wildcards, no"
+            " substring). Omit or pass null to get the full per-host port"
+            " map. Use to look up a single host before annotating."
+        ),
+    )
+
+
+@cyber_tool("Recon Open Ports", args_schema=_ReconOpenPortsArgs)
 def recon_open_ports_tool(sweep_path: str = "sweep.json", host: str | None = None) -> OpenPortsMap:
     """
     Return the open-port map per host from the sweep. Passing a ``host``
@@ -127,7 +228,21 @@ def recon_open_ports_tool(sweep_path: str = "sweep.json", host: str | None = Non
     return OpenPortsMap(hosts=recon_open_ports(sweep_path, host=host))
 
 
-@tool("Certificate Transparency Lookup")
+class _CertTransparencyArgs(BaseModel):
+    """Explicit args_schema for the Certificate Transparency Lookup tool (#148)."""
+
+    domain: str = Field(
+        description=(
+            "Apex domain to look up in crt.sh certificate transparency logs"
+            " (e.g. 'example.com'). Returns historical subdomains across all"
+            " certificates issued for the domain. Pass an apex, not a"
+            " subdomain - crt.sh returns the broader set when queried on"
+            " the apex."
+        ),
+    )
+
+
+@cyber_tool("Certificate Transparency Lookup", args_schema=_CertTransparencyArgs)
 def cert_transparency_tool(domain: str) -> list[str]:
     """
     Query crt.sh certificate transparency logs to discover subdomains not
@@ -137,7 +252,20 @@ def cert_transparency_tool(domain: str) -> list[str]:
     return cert_transparency(domain)
 
 
-@tool("Historical URL Discovery")
+class _HistoricalUrlsArgs(BaseModel):
+    """Explicit args_schema for the Historical URL Discovery tool (#148)."""
+
+    domain: str = Field(
+        description=(
+            "Domain to query waybackurls for (apex or subdomain). Returns"
+            " historical URLs the Wayback Machine has archived. Many paths"
+            " will be 404s today; feed candidates to Probe Hostnames to"
+            " confirm liveness before annotating."
+        ),
+    )
+
+
+@cyber_tool("Historical URL Discovery", args_schema=_HistoricalUrlsArgs)
 def historical_urls_tool(domain: str) -> list[str]:
     """
     Use waybackurls to find historical endpoints for a domain from the
@@ -147,7 +275,25 @@ def historical_urls_tool(domain: str) -> list[str]:
     return historical_urls(domain)
 
 
-@tool("LLM Endpoint Detection")
+# TODO: switch ``endpoints_json: str`` to ``endpoints: list[Endpoint]`` per the
+# #139 / cybersquad-tool convention. Out of scope for #148 (args_schema sweep);
+# tracked as a separate cleanup.
+class _LlmDetectionArgs(BaseModel):
+    """Explicit args_schema for the LLM Endpoint Detection tool (#148)."""
+
+    endpoints_json: str = Field(
+        description=(
+            "JSON-encoded list of Endpoint objects from the sweep (or a"
+            " filtered subset). Each entry needs ``url`` and ideally"
+            " ``technologies``; ``status_code`` is honoured if present."
+            " Note: this is the legacy stringified-JSON pattern retired by"
+            " #139 for the PT wrappers - a follow-up will migrate this to"
+            " ``list[Endpoint]``."
+        ),
+    )
+
+
+@cyber_tool("LLM Endpoint Detection", args_schema=_LlmDetectionArgs)
 def llm_detection_tool(endpoints_json: str) -> list[LlmEndpoint]:
     """
     Scan a set of live endpoints for signals that they are backed by an LLM
@@ -161,7 +307,31 @@ def llm_detection_tool(endpoints_json: str) -> list[LlmEndpoint]:
     return [LlmEndpoint.model_validate(ep.model_dump()) for ep in detect_llm_endpoints(endpoints)]
 
 
-@tool("Probe Hostnames")
+class _ProbeHostnamesArgs(BaseModel):
+    """Explicit args_schema for the Probe Hostnames tool (#148)."""
+
+    hostnames: list[str] = Field(
+        description=(
+            "Hostnames to re-probe with httpx for liveness, status code,"
+            " and technology fingerprinting. Typically the net-new ones"
+            " surfaced by Certificate Transparency or Historical URL"
+            " Discovery that were missed by the initial sweep. Each"
+            " hostname is scope-filtered against the programme before"
+            " any HTTP traffic fires - out-of-scope hostnames are"
+            " dropped silently."
+        ),
+    )
+    programme_handle: str = Field(
+        description=(
+            "Exact HackerOne programme handle for the scope guard. Required"
+            " so the scope filter has the structured scope to check against;"
+            " the scope guard never probes outside scope, even for"
+            " fingerprinting."
+        ),
+    )
+
+
+@cyber_tool("Probe Hostnames", args_schema=_ProbeHostnamesArgs)
 def probe_hostnames_tool(hostnames: list[str], programme_handle: str) -> list[Endpoint]:
     """
     Re-probe a list of hostnames with httpx to confirm liveness, capture
@@ -184,7 +354,28 @@ def probe_hostnames_tool(hostnames: list[str], programme_handle: str) -> list[En
     return list(probe_endpoints_impl(in_scope))
 
 
-@tool("Detect Takeover Candidates")
+class _DetectTakeoverCandidatesArgs(BaseModel):
+    """Explicit args_schema for the Detect Takeover Candidates tool (#148)."""
+
+    hostnames: list[str] = Field(
+        description=(
+            "Hostnames to resolve via dnsx and flag for subdomain takeover."
+            " A candidate fires when the CNAME points to a known-vulnerable"
+            " provider (AWS S3, Heroku, GitHub Pages, Azure, Vercel,"
+            " Netlify, ...) or when the CNAME chain dangles. Hostnames are"
+            " scope-filtered before any DNS traffic fires."
+        ),
+    )
+    programme_handle: str = Field(
+        description=(
+            "Exact HackerOne programme handle for the scope guard. The"
+            " resolver does not query outside the programme's structured"
+            " scope - the handle is the authoritative key."
+        ),
+    )
+
+
+@cyber_tool("Detect Takeover Candidates", args_schema=_DetectTakeoverCandidatesArgs)
 def detect_takeover_candidates_tool(
     hostnames: list[str], programme_handle: str
 ) -> list[TakeoverCandidate]:
@@ -214,7 +405,21 @@ def detect_takeover_candidates_tool(
     return list(detect_takeover_candidates(in_scope))
 
 
-@tool("Lookup CWE")
+class _OsintLookupCweArgs(BaseModel):
+    """Explicit args_schema for the OSINT Lookup CWE tool (#148)."""
+
+    query: str = Field(
+        description=(
+            "Free-text query against the Common Weakness Enumeration index."
+            " Matches CWE id, name, or description (case-insensitive"
+            " substring). Useful when annotating a host whose detected tech"
+            " has a well-known weakness class (e.g. 'WordPress' -> XSS /"
+            " SQLi; 'Spring Boot' -> SSTI / RCE)."
+        ),
+    )
+
+
+@cyber_tool("Lookup CWE", args_schema=_OsintLookupCweArgs)
 def lookup_cwe_tool(query: str) -> list[CWEEntry]:
     """
     Find Common Weakness Enumeration entries that match a query - useful
@@ -226,7 +431,20 @@ def lookup_cwe_tool(query: str) -> list[CWEEntry]:
     return list(cwe_lookup(query))
 
 
-@tool("Lookup OWASP Guidance")
+class _OsintLookupOwaspArgs(BaseModel):
+    """Explicit args_schema for the OSINT Lookup OWASP Guidance tool (#148)."""
+
+    query: str = Field(
+        description=(
+            "Free-text query against the OWASP Cheat Sheet index. Matches"
+            " on cheatsheet title and topic (case-insensitive substring)."
+            " Use to surface guidance the downstream VR can reason against"
+            " when building the attack plan."
+        ),
+    )
+
+
+@cyber_tool("Lookup OWASP Guidance", args_schema=_OsintLookupOwaspArgs)
 def lookup_owasp_tool(query: str) -> list[OWASPEntry]:
     """
     Find OWASP Cheat Sheet entries for a vuln class or topic - hint for
@@ -236,7 +454,63 @@ def lookup_owasp_tool(query: str) -> list[OWASPEntry]:
     return list(owasp_lookup(query))
 
 
-@tool("Annotate Host")
+class _AnnotateHostArgs(BaseModel):
+    """Explicit args_schema for the Annotate Host tool (#148)."""
+
+    hostname: str = Field(
+        description=(
+            "Hostname to annotate. Must already be in the sweep, or have"
+            " been surfaced by Certificate Transparency / Historical URL"
+            " Discovery / Probe Hostnames. Lowercased before save."
+        ),
+    )
+    role: str = Field(
+        description=(
+            "One of: admin, api, auth, app, cdn, static, mail, infra, dev,"
+            " unknown. Drives downstream prioritisation - admin / auth"
+            " hosts attract more probe budget than static / cdn ones."
+        ),
+    )
+    priority: str = Field(
+        description=(
+            "One of: high, medium, low, skip. The curation signal the PT"
+            " uses to allocate probe budget. ``high`` means 'spend probes"
+            " here'; ``skip`` means 'do not probe this even if reachable'."
+            " Must match the threat model in the notes."
+        ),
+    )
+    notes: str = Field(
+        description=(
+            ">= 30 characters (>= 60 for high-priority). Explain what the"
+            " host is, what tech runs on it, and why it matters (or why"
+            " not). Quality gate fires below the length threshold and"
+            " when the priority does not match the prose."
+        ),
+    )
+    detected_tech: list[str] | None = Field(
+        default=None,
+        description=(
+            "Ideally with versions ('Spring Boot 2.6.3' beats 'Spring"
+            " Boot'). The quality gate warns when the sweep saw tech the"
+            " annotation drops - the annotation is meant to be a curation"
+            " of what was seen, not an alternate inventory."
+        ),
+    )
+    sweep_path: str = Field(
+        default="sweep.json",
+        description="Relative path to the OA's sweep file. Defaults to ``sweep.json``.",
+    )
+    programme_handle: str | None = Field(
+        default=None,
+        description=(
+            "Exact HackerOne programme handle. Required - the scope guard"
+            " in ``validate_insight`` needs a real Programme to check"
+            " against. ``None`` raises ValueError."
+        ),
+    )
+
+
+@cyber_tool("Annotate Host", args_schema=_AnnotateHostArgs)
 def annotate_host_tool(
     hostname: str,
     role: str,
@@ -283,7 +557,21 @@ def annotate_host_tool(
     )
 
 
-@tool("Uncovered Hosts")
+class _UncoveredHostsArgs(BaseModel):
+    """Explicit args_schema for the Uncovered Hosts tool (#148)."""
+
+    sweep_path: str = Field(
+        default="sweep.json",
+        description=(
+            "Relative path to the OA's sweep file. Defaults to"
+            " ``sweep.json``. Returns interesting-status hostnames (200,"
+            " 301, 302, 401, 403, ...) in the sweep that have no insight"
+            " yet - use as a checklist before Finalise Recon."
+        ),
+    )
+
+
+@cyber_tool("Uncovered Hosts", args_schema=_UncoveredHostsArgs)
 def uncovered_hosts_tool(sweep_path: str = "sweep.json") -> list[str]:
     """
     Return interesting-status hostnames in the sweep (200, 301, 302, 401,
@@ -296,7 +584,24 @@ def uncovered_hosts_tool(sweep_path: str = "sweep.json") -> list[str]:
     return uncovered_interesting_hosts(sweep, insights)
 
 
-@tool("Finalise Recon")
+class _FinaliseReconArgs(BaseModel):
+    """Explicit args_schema for the Finalise Recon tool (#148)."""
+
+    programme_handle: str = Field(
+        description=(
+            "Exact HackerOne programme handle. The scope guard re-validates"
+            " every insight against the programme's structured scope before"
+            " writing recon.json - a mismatch raises and the workspace"
+            " handle is not produced."
+        ),
+    )
+    sweep_path: str = Field(
+        default="sweep.json",
+        description="Relative path to the OA's sweep file. Defaults to ``sweep.json``.",
+    )
+
+
+@cyber_tool("Finalise Recon", args_schema=_FinaliseReconArgs)
 def finalise_recon_tool(
     programme_handle: str,
     sweep_path: str = "sweep.json",

--- a/squad/osint_analyst/__init__.py
+++ b/squad/osint_analyst/__init__.py
@@ -1,8 +1,5 @@
 """OSINT Analyst - maps the in-scope attack surface."""
 
-from __future__ import annotations
-
-import json
 from pathlib import Path
 
 from pydantic import BaseModel, Field
@@ -275,36 +272,34 @@ def historical_urls_tool(domain: str) -> list[str]:
     return historical_urls(domain)
 
 
-# TODO: switch ``endpoints_json: str`` to ``endpoints: list[Endpoint]`` per the
-# #139 / cybersquad-tool convention. Out of scope for #148 (args_schema sweep);
-# tracked as a separate cleanup.
 class _LlmDetectionArgs(BaseModel):
     """Explicit args_schema for the LLM Endpoint Detection tool (#148)."""
 
-    endpoints_json: str = Field(
+    endpoints: list[Endpoint] = Field(
         description=(
-            "JSON-encoded list of Endpoint objects from the sweep (or a"
-            " filtered subset). Each entry needs ``url`` and ideally"
-            " ``technologies``; ``status_code`` is honoured if present."
-            " Note: this is the legacy stringified-JSON pattern retired by"
-            " #139 for the PT wrappers - a follow-up will migrate this to"
-            " ``list[Endpoint]``."
+            "Live endpoint objects from the sweep (or a filtered subset)."
+            " Each entry needs ``url`` and ideally ``technologies``;"
+            " ``status_code`` is honoured if present. Pass the typed list"
+            " straight through from Recon Endpoints - do not stringify."
         ),
     )
 
 
 @cyber_tool("LLM Endpoint Detection", args_schema=_LlmDetectionArgs)
-def llm_detection_tool(endpoints_json: str) -> list[LlmEndpoint]:
+def llm_detection_tool(endpoints: list[Endpoint]) -> list[LlmEndpoint]:
     """
     Scan a set of live endpoints for signals that they are backed by an LLM
     or AI assistant (URL path heuristics, OpenAI-format response keys,
     EventSource content-type, self-identification phrases). Pass the
-    sweep's endpoint list (or a filtered subset) as JSON. Returned hits
-    deserve a HIGH-priority annotation and a note pointing the Penetration
-    Tester at prompt-injection probes.
+    sweep's endpoint list (or a filtered subset) straight through from
+    Recon Endpoints. Returned hits deserve a HIGH-priority annotation and
+    a note pointing the Penetration Tester at prompt-injection probes.
     """
-    endpoints = [Endpoint.model_validate(e) for e in json.loads(endpoints_json)]
-    return [LlmEndpoint.model_validate(ep.model_dump()) for ep in detect_llm_endpoints(endpoints)]
+    # CrewAI's args_schema validation produces list[dict] from the LLM JSON
+    # before invoking us; re-validate so we always see ``Endpoint`` instances
+    # regardless of whether the caller is the runtime or a direct test invocation.
+    parsed = [Endpoint.model_validate(e) for e in endpoints]
+    return [LlmEndpoint.model_validate(ep.model_dump()) for ep in detect_llm_endpoints(parsed)]
 
 
 class _ProbeHostnamesArgs(BaseModel):

--- a/squad/osint_analyst/__init__.py
+++ b/squad/osint_analyst/__init__.py
@@ -459,19 +459,21 @@ class _AnnotateHostArgs(BaseModel):
             " Discovery / Probe Hostnames. Lowercased before save."
         ),
     )
-    role: str = Field(
+    role: HostRole = Field(
         description=(
-            "One of: admin, api, auth, app, cdn, static, mail, infra, dev,"
-            " unknown. Drives downstream prioritisation - admin / auth"
-            " hosts attract more probe budget than static / cdn ones."
+            "Functional role this host plays. Drives downstream"
+            " prioritisation - admin / auth hosts attract more probe"
+            " budget than static / cdn ones. The schema enforces the"
+            " enum upstream so an unknown role rejects before the"
+            " wrapper body runs."
         ),
     )
-    priority: str = Field(
+    priority: HostPriority = Field(
         description=(
-            "One of: high, medium, low, skip. The curation signal the PT"
-            " uses to allocate probe budget. ``high`` means 'spend probes"
-            " here'; ``skip`` means 'do not probe this even if reachable'."
-            " Must match the threat model in the notes."
+            "Curation signal the PT uses to allocate probe budget."
+            " ``high`` means 'spend probes here'; ``skip`` means 'do not"
+            " probe this even if reachable'. Must match the threat model"
+            " in the notes; the quality gate checks both."
         ),
     )
     notes: str = Field(
@@ -508,8 +510,8 @@ class _AnnotateHostArgs(BaseModel):
 @cyber_tool("Annotate Host", args_schema=_AnnotateHostArgs)
 def annotate_host_tool(
     hostname: str,
-    role: str,
-    priority: str,
+    role: HostRole,
+    priority: HostPriority,
     notes: str,
     detected_tech: list[str] | None = None,
     sweep_path: str = "sweep.json",

--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -12,10 +12,10 @@ from models import Endpoint, EndpointPage, OpenPortsMap, RawFinding, ReconResult
 from squad import (
     CrewAITool,
     SquadMember,
+    cyber_tool,
     read_attack_plan_tool,
     read_run_file_tool,
     read_run_filelist_tool,
-    typed_tool,
 )
 from tools import http
 from tools.cloud import (
@@ -87,12 +87,12 @@ def pentest_tool(
     check_fn: object = None,
     args_schema: type[BaseModel],
 ) -> Callable[[_PentestFn], _PentestTool]:
-    """Pentest-specialised wrapper. Composes ``typed_tool`` plus OWASP injection.
+    """Pentest-specialised wrapper. Composes ``cyber_tool`` plus OWASP injection.
 
-    ``typed_tool`` handles the schema override; ``pentest_tool`` layers the
+    ``cyber_tool`` handles the schema override; ``pentest_tool`` layers the
     OWASP categories from ``check_fn.owasp_categories`` into the agent-facing
     docstring. Every pentest probe goes through this wrapper, never bare
-    ``@tool`` and never raw ``@typed_tool`` - the OWASP framing is what the
+    ``@tool`` and never raw ``@cyber_tool`` - the OWASP framing is what the
     PT agent's role.md teaches it to reason against.
     """
 
@@ -102,7 +102,7 @@ def pentest_tool(
             if cats:
                 lines = "\n".join(f"  - {c}" for c in cats)
                 fn.__doc__ = (fn.__doc__ or "").rstrip() + f"\n\nOWASP Top 10:\n{lines}\n"
-        wrapped = typed_tool(name, args_schema=args_schema)(fn)
+        wrapped = cyber_tool(name, args_schema=args_schema)(fn)
         return cast(_PentestTool, wrapped)
 
     return decorator
@@ -817,7 +817,7 @@ class _S3CheckArgs(BaseModel):
     )
 
 
-@typed_tool("S3 Bucket Check", args_schema=_S3CheckArgs)
+@cyber_tool("S3 Bucket Check", args_schema=_S3CheckArgs)
 def s3_check_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for publicly accessible or listable AWS S3 buckets derived from the
@@ -842,7 +842,7 @@ class _AzureStorageCheckArgs(BaseModel):
     )
 
 
-@typed_tool("Azure Blob Storage Check", args_schema=_AzureStorageCheckArgs)
+@cyber_tool("Azure Blob Storage Check", args_schema=_AzureStorageCheckArgs)
 def azure_storage_check_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for publicly accessible Azure Blob Storage containers and exposed SAS
@@ -867,7 +867,7 @@ class _ElasticsearchCheckArgs(BaseModel):
     )
 
 
-@typed_tool("Unauthenticated Elasticsearch Check", args_schema=_ElasticsearchCheckArgs)
+@cyber_tool("Unauthenticated Elasticsearch Check", args_schema=_ElasticsearchCheckArgs)
 def elasticsearch_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an unauthenticated Elasticsearch instance on port 9200.
@@ -895,7 +895,7 @@ class _CouchdbCheckArgs(BaseModel):
     )
 
 
-@typed_tool("Unauthenticated CouchDB Check", args_schema=_CouchdbCheckArgs)
+@cyber_tool("Unauthenticated CouchDB Check", args_schema=_CouchdbCheckArgs)
 def couchdb_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an unauthenticated CouchDB instance on port 5984.
@@ -923,7 +923,7 @@ class _RedisCheckArgs(BaseModel):
     )
 
 
-@typed_tool("Unauthenticated Redis Check", args_schema=_RedisCheckArgs)
+@cyber_tool("Unauthenticated Redis Check", args_schema=_RedisCheckArgs)
 def redis_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an unauthenticated Redis instance on port 6379 via a PING command.
@@ -952,7 +952,7 @@ class _MongodbCheckArgs(BaseModel):
     )
 
 
-@typed_tool("Unauthenticated MongoDB Check", args_schema=_MongodbCheckArgs)
+@cyber_tool("Unauthenticated MongoDB Check", args_schema=_MongodbCheckArgs)
 def mongodb_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an unauthenticated MongoDB instance on port 27017.
@@ -983,7 +983,7 @@ class _PostgresqlCheckArgs(BaseModel):
     )
 
 
-@typed_tool("Exposed PostgreSQL Check", args_schema=_PostgresqlCheckArgs)
+@cyber_tool("Exposed PostgreSQL Check", args_schema=_PostgresqlCheckArgs)
 def postgresql_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for PostgreSQL on port 5432. Returns CRITICAL if trust authentication
@@ -1013,7 +1013,7 @@ class _MysqlCheckArgs(BaseModel):
     )
 
 
-@typed_tool("Exposed MySQL/MariaDB Check", args_schema=_MysqlCheckArgs)
+@cyber_tool("Exposed MySQL/MariaDB Check", args_schema=_MysqlCheckArgs)
 def mysql_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for MySQL or MariaDB on port 3306. Returns MEDIUM if the port is
@@ -1044,7 +1044,7 @@ class _SensitiveFilesArgs(BaseModel):
     )
 
 
-@typed_tool("Sensitive Files Check", args_schema=_SensitiveFilesArgs)
+@cyber_tool("Sensitive Files Check", args_schema=_SensitiveFilesArgs)
 def sensitive_files_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     """
     Probe for exposed .git/HEAD, .env, phpinfo.php, Apache server-status, and
@@ -1073,7 +1073,7 @@ class _AdminPanelsArgs(BaseModel):
     )
 
 
-@typed_tool("Admin Panels Check", args_schema=_AdminPanelsArgs)
+@cyber_tool("Admin Panels Check", args_schema=_AdminPanelsArgs)
 def admin_panels_tool(endpoints: list[Endpoint]) -> list[RawFinding]:
     """
     Probe common admin panel paths: /admin, /wp-admin, /phpmyadmin, /adminer,
@@ -1101,7 +1101,7 @@ class _CpanelArgs(BaseModel):
     )
 
 
-@typed_tool("cPanel/WHM Check", args_schema=_CpanelArgs)
+@cyber_tool("cPanel/WHM Check", args_schema=_CpanelArgs)
 def cpanel_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed cPanel hosting control panel (ports 2082/2083) and
@@ -1127,7 +1127,7 @@ class _PleskArgs(BaseModel):
     )
 
 
-@typed_tool("Plesk Check", args_schema=_PleskArgs)
+@cyber_tool("Plesk Check", args_schema=_PleskArgs)
 def plesk_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed Plesk web hosting control panel on ports 8880 (HTTP)
@@ -1151,7 +1151,7 @@ class _DirectadminArgs(BaseModel):
     )
 
 
-@typed_tool("DirectAdmin Check", args_schema=_DirectadminArgs)
+@cyber_tool("DirectAdmin Check", args_schema=_DirectadminArgs)
 def directadmin_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed DirectAdmin hosting control panel on port 2222.
@@ -1174,7 +1174,7 @@ class _WebminArgs(BaseModel):
     )
 
 
-@typed_tool("Webmin Check", args_schema=_WebminArgs)
+@cyber_tool("Webmin Check", args_schema=_WebminArgs)
 def webmin_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed Webmin Linux server administration panel on port 10000.
@@ -1198,7 +1198,7 @@ class _GrafanaArgs(BaseModel):
     )
 
 
-@typed_tool("Grafana Check", args_schema=_GrafanaArgs)
+@cyber_tool("Grafana Check", args_schema=_GrafanaArgs)
 def grafana_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed Grafana metrics dashboard on port 3000 and via /grafana
@@ -1224,7 +1224,7 @@ class _KibanaArgs(BaseModel):
     )
 
 
-@typed_tool("Kibana Check", args_schema=_KibanaArgs)
+@cyber_tool("Kibana Check", args_schema=_KibanaArgs)
 def kibana_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed Kibana log/data visualisation dashboard on port 5601 and
@@ -1250,7 +1250,7 @@ class _PortainerArgs(BaseModel):
     )
 
 
-@typed_tool("Portainer Check", args_schema=_PortainerArgs)
+@cyber_tool("Portainer Check", args_schema=_PortainerArgs)
 def portainer_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed Portainer Docker management UI on port 9000 and via
@@ -1277,7 +1277,7 @@ class _ConsulVaultArgs(BaseModel):
     )
 
 
-@typed_tool("Consul/Vault Check", args_schema=_ConsulVaultArgs)
+@cyber_tool("Consul/Vault Check", args_schema=_ConsulVaultArgs)
 def consul_vault_tool(recon_path: str) -> list[RawFinding]:
     """
     Check for an exposed HashiCorp Consul UI (port 8500) or Vault UI (port 8200),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ValidationError
 from models import (
     Endpoint,
     Hostname,
+    HttpUrl,
     RawFinding,
     ReconResult,
     Severity,
@@ -176,6 +177,55 @@ class TestHostname:
     def test_rejects_non_string(self):
         with pytest.raises(ValidationError):
             _HostnameProbe.model_validate({"value": 42})
+
+
+class _HttpUrlProbe(BaseModel):
+    """Thin probe model used to drive the HttpUrl validator in isolation."""
+
+    value: HttpUrl
+
+
+class TestHttpUrl:
+    def test_accepts_victim_url(self, victim_url):
+        assert _HttpUrlProbe(value=victim_url).value == victim_url
+
+    def test_accepts_victim_url_with_path(self, victim_url):
+        url = f"{victim_url}/api/users?id=1"
+        assert _HttpUrlProbe(value=url).value == url
+
+    def test_accepts_http_scheme(self, victim_url):
+        url = victim_url.replace("https://", "http://")
+        assert _HttpUrlProbe(value=url).value == url
+
+    def test_rejects_malformed(self, victim_url):
+        """Walks the malformed corpus, deriving each case from victim_url so
+        intent ("a deliberately broken URL based on the in-scope target") is
+        readable at the call site. The Hostname-component check inside
+        HttpUrl is exercised by the leading-hyphen case - a URL whose host
+        fails Hostname validation rejects too.
+        """
+        from urllib.parse import urlparse
+
+        host = urlparse(victim_url).hostname or ""
+        cases: list[tuple[str, str]] = [
+            ("", "empty"),
+            ("   ", "whitespace only"),
+            (host, "no scheme - bare hostname"),
+            (f"ftp://{host}", "non-http scheme"),
+            ("javascript:alert(1)", "javascript scheme"),
+            ("file:///etc/passwd", "file scheme"),
+            ("https://", "scheme with no host"),
+            ("https:///path", "scheme + path with no host"),
+            (f"https://-{host}", "hostname inside URL fails RFC 1123"),
+        ]
+        for value, label in cases:
+            with pytest.raises(ValidationError):
+                _HttpUrlProbe.model_validate({"value": value})
+            del label
+
+    def test_preserves_path_and_query(self, victim_url):
+        url = f"{victim_url}/search?q=hello&page=2#top"
+        assert _HttpUrlProbe(value=url).value == url
 
 
 class TestReconResult:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,10 +5,11 @@ tests/test_models.py - unit tests for models.py
 from __future__ import annotations
 
 import pytest
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from models import (
     Endpoint,
+    Hostname,
     RawFinding,
     ReconResult,
     Severity,
@@ -88,6 +89,72 @@ class TestEndpoint:
         assert ep.status_code is None
         assert ep.technologies == []
         assert ep.parameters == []
+
+
+# Hostname is exercised through a throwaway pydantic model so the validator
+# fires the same way it does when carried on a real schema field. Stick to
+# pytest.raises(ValidationError) rather than the lower-level ValueError so
+# the test mirrors what schema callers will see.
+class _HostnameProbe(BaseModel):
+    """Thin probe model used to drive the Hostname validator in isolation."""
+
+    value: Hostname
+
+
+class TestHostname:
+    def test_accepts_apex(self):
+        assert _HostnameProbe(value="example.com").value == "example.com"
+
+    def test_accepts_subdomain_from_victim_fixture(self, victim_url):
+        # urlparse hostname is the canonical way to derive a Hostname-shaped
+        # string from a URL fixture; using the fixture keeps test intent
+        # ("the in-scope target") readable at the call site.
+        from urllib.parse import urlparse
+
+        host = urlparse(victim_url).hostname or ""
+        assert _HostnameProbe(value=host).value == host
+
+    def test_accepts_single_label(self):
+        assert _HostnameProbe(value="localhost").value == "localhost"
+
+    def test_accepts_numeric_labels(self):
+        # 10.0.0.1 looks IP-shaped but parses as a valid hostname per RFC 1123
+        # label rules (digits are allowed). The scope filter is the next layer
+        # that decides whether to accept it as an in-scope target.
+        assert _HostnameProbe(value="10.0.0.1").value == "10.0.0.1"
+
+    def test_lowercases(self):
+        assert _HostnameProbe(value="API.Example.COM").value == "api.example.com"
+
+    def test_strips_whitespace(self):
+        assert _HostnameProbe(value="  api.example.com  ").value == "api.example.com"
+
+    @pytest.mark.parametrize(
+        "garbage",
+        [
+            "",
+            "   ",
+            "https://example.com",  # scheme
+            "ftp://example.com",  # scheme
+            "example.com:8080",  # port
+            "example.com/path",  # path
+            "example.com/",  # trailing slash
+            "-example.com",  # leading hyphen
+            "example.com-",  # trailing hyphen on label
+            "exa..mple.com",  # empty label
+            "a" * 64 + ".com",  # label > 63 chars
+            ".".join(["a"] * 200),  # total > 253 chars
+            "exa mple.com",  # space in label
+            "example.com\nextra",  # newline injection
+        ],
+    )
+    def test_rejects_malformed(self, garbage):
+        with pytest.raises(ValidationError):
+            _HostnameProbe(value=garbage)
+
+    def test_rejects_non_string(self):
+        with pytest.raises(ValidationError):
+            _HostnameProbe.model_validate({"value": 42})
 
 
 class TestReconResult:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -102,19 +102,25 @@ class _HostnameProbe(BaseModel):
 
 
 class TestHostname:
-    def test_accepts_apex(self):
-        assert _HostnameProbe(value="example.com").value == "example.com"
-
-    def test_accepts_subdomain_from_victim_fixture(self, victim_url):
+    def test_accepts_victim_apex(self, victim_url):
         # urlparse hostname is the canonical way to derive a Hostname-shaped
         # string from a URL fixture; using the fixture keeps test intent
         # ("the in-scope target") readable at the call site.
         from urllib.parse import urlparse
 
         host = urlparse(victim_url).hostname or ""
+        apex = host.split(".", 1)[-1]  # "example.com" from "victim.example.com"
+        assert _HostnameProbe(value=apex).value == apex
+
+    def test_accepts_victim_subdomain(self, victim_url):
+        from urllib.parse import urlparse
+
+        host = urlparse(victim_url).hostname or ""
         assert _HostnameProbe(value=host).value == host
 
     def test_accepts_single_label(self):
+        # ``localhost`` is the canonical single-label hostname; no URL fixture
+        # exposes one because the rest of the codebase doesn't reach for it.
         assert _HostnameProbe(value="localhost").value == "localhost"
 
     def test_accepts_numeric_labels(self):
@@ -123,34 +129,49 @@ class TestHostname:
         # that decides whether to accept it as an in-scope target.
         assert _HostnameProbe(value="10.0.0.1").value == "10.0.0.1"
 
-    def test_lowercases(self):
-        assert _HostnameProbe(value="API.Example.COM").value == "api.example.com"
+    def test_lowercases_victim_host(self, victim_url):
+        from urllib.parse import urlparse
 
-    def test_strips_whitespace(self):
-        assert _HostnameProbe(value="  api.example.com  ").value == "api.example.com"
+        host = urlparse(victim_url).hostname or ""
+        assert _HostnameProbe(value=host.upper()).value == host
 
-    @pytest.mark.parametrize(
-        "garbage",
-        [
-            "",
-            "   ",
-            "https://example.com",  # scheme
-            "ftp://example.com",  # scheme
-            "example.com:8080",  # port
-            "example.com/path",  # path
-            "example.com/",  # trailing slash
-            "-example.com",  # leading hyphen
-            "example.com-",  # trailing hyphen on label
-            "exa..mple.com",  # empty label
-            "a" * 64 + ".com",  # label > 63 chars
-            ".".join(["a"] * 200),  # total > 253 chars
-            "exa mple.com",  # space in label
-            "example.com\nextra",  # newline injection
-        ],
-    )
-    def test_rejects_malformed(self, garbage):
-        with pytest.raises(ValidationError):
-            _HostnameProbe(value=garbage)
+    def test_strips_whitespace_around_victim_host(self, victim_url):
+        from urllib.parse import urlparse
+
+        host = urlparse(victim_url).hostname or ""
+        assert _HostnameProbe(value=f"  {host}  ").value == host
+
+    def test_rejects_malformed(self, victim_url):
+        """Walks the malformed corpus, deriving each case from victim_url
+        so test intent ("a deliberately broken version of the in-scope
+        target") is readable. Pytest parametrize literals cannot consume
+        fixtures, so a single dedicated method loops the corpus instead.
+        """
+        from urllib.parse import urlparse
+
+        host = urlparse(victim_url).hostname or ""
+        cases: list[tuple[str, str]] = [
+            ("", "empty"),
+            ("   ", "whitespace only"),
+            (f"https://{host}", "scheme present"),
+            (f"ftp://{host}", "non-http scheme"),
+            (f"{host}:8080", "port present"),
+            (f"{host}/path", "path present"),
+            (f"{host}/", "trailing slash"),
+            (f"-{host}", "leading hyphen"),
+            (f"{host}-", "trailing hyphen on label"),
+            (host.replace(".", "..", 1), "empty label"),
+            ("a" * 64 + f".{host}", "label > 63 chars"),
+            (".".join(["a"] * 200), "total > 253 chars"),
+            (host.replace(".", " .", 1), "space in label"),
+            (f"{host}\nextra", "newline injection"),
+        ]
+        for value, label in cases:
+            with pytest.raises(ValidationError, match=r".*"):
+                _HostnameProbe.model_validate({"value": value})
+            # ``label`` is unused at the assertion level but appears in the
+            # case tuple so a future debugger can identify which case failed.
+            del label
 
     def test_rejects_non_string(self):
         with pytest.raises(ValidationError):

--- a/tests/test_osint_args_schemas.py
+++ b/tests/test_osint_args_schemas.py
@@ -288,3 +288,50 @@ class TestSchemaAcceptReject:
             _AnnotateHostArgs.model_validate({**base, "role": "not-a-real-role"})
         with pytest.raises(ValidationError):
             _AnnotateHostArgs.model_validate({**base, "priority": "urgent"})
+
+    # Hostname-typed fields (#148 review feedback). Every schema below
+    # carries at least one ``Hostname`` field; passing a URL / port / path
+    # rejects upstream, before the scope filter sees the value.
+    # test_models.py's TestHostname covers the validator exhaustively;
+    # these cases assert the OSINT schemas actually wire it.
+    @pytest.mark.parametrize(
+        ("schema_cls", "field", "value", "base"),
+        [
+            (_CertTransparencyArgs, "domain", "https://example.com", {}),
+            (_HistoricalUrlsArgs, "domain", "example.com:8080", {}),
+            (_ReconOpenPortsArgs, "host", "example.com/path", {}),
+            (
+                _ProbeHostnamesArgs,
+                "hostnames",
+                ["https://api.example.com"],
+                {"programme_handle": "example"},
+            ),
+            (
+                _DetectTakeoverCandidatesArgs,
+                "hostnames",
+                ["legacy.example.com:9000"],
+                {"programme_handle": "example"},
+            ),
+        ],
+    )
+    def test_hostname_field_rejects_malformed_input(
+        self,
+        schema_cls: type[BaseModel],
+        field: str,
+        value: object,
+        base: dict[str, object],
+    ) -> None:
+        """Malformed hostname inputs reject at schema validation time."""
+        with pytest.raises(ValidationError):
+            schema_cls.model_validate({**base, field: value})
+
+    def test_annotate_host_hostname_rejects_url(self, victim_url: str) -> None:
+        """Annotate Host's hostname is Hostname-typed; passing the full URL fails."""
+        with pytest.raises(ValidationError):
+            _AnnotateHostArgs.model_validate(_annotate_host_base(victim_url))
+
+    def test_hostname_fields_lowercase_input(self, victim_url: str) -> None:
+        """Hostname validator lowercases - the schema returns the normalised form."""
+        host = (urlparse(victim_url).hostname or "").upper()
+        validated = _AnnotateHostArgs.model_validate(_annotate_host_base(host))
+        assert validated.hostname == host.lower()

--- a/tests/test_osint_args_schemas.py
+++ b/tests/test_osint_args_schemas.py
@@ -293,37 +293,32 @@ class TestSchemaAcceptReject:
     # carries at least one ``Hostname`` field; passing a URL / port / path
     # rejects upstream, before the scope filter sees the value.
     # test_models.py's TestHostname covers the validator exhaustively;
-    # these cases assert the OSINT schemas actually wire it.
-    @pytest.mark.parametrize(
-        ("schema_cls", "field", "value", "base"),
-        [
-            (_CertTransparencyArgs, "domain", "https://example.com", {}),
-            (_HistoricalUrlsArgs, "domain", "example.com:8080", {}),
-            (_ReconOpenPortsArgs, "host", "example.com/path", {}),
+    # this method asserts the OSINT schemas actually wire it, with each
+    # malformed case derived from ``victim_url`` so the deliberately broken
+    # input is recognisably "the in-scope target, mis-shaped" rather than
+    # an opaque literal.
+    def test_hostname_field_rejects_malformed_input(self, victim_url: str) -> None:
+        host = urlparse(victim_url).hostname or ""
+        cases: list[tuple[type[BaseModel], str, object, dict[str, object]]] = [
+            (_CertTransparencyArgs, "domain", f"https://{host}", {}),
+            (_HistoricalUrlsArgs, "domain", f"{host}:8080", {}),
+            (_ReconOpenPortsArgs, "host", f"{host}/path", {}),
             (
                 _ProbeHostnamesArgs,
                 "hostnames",
-                ["https://api.example.com"],
+                [f"https://{host}"],
                 {"programme_handle": "example"},
             ),
             (
                 _DetectTakeoverCandidatesArgs,
                 "hostnames",
-                ["legacy.example.com:9000"],
+                [f"{host}:9000"],
                 {"programme_handle": "example"},
             ),
-        ],
-    )
-    def test_hostname_field_rejects_malformed_input(
-        self,
-        schema_cls: type[BaseModel],
-        field: str,
-        value: object,
-        base: dict[str, object],
-    ) -> None:
-        """Malformed hostname inputs reject at schema validation time."""
-        with pytest.raises(ValidationError):
-            schema_cls.model_validate({**base, field: value})
+        ]
+        for schema_cls, field, value, base in cases:
+            with pytest.raises(ValidationError):
+                schema_cls.model_validate({**base, field: value})
 
     def test_annotate_host_hostname_rejects_url(self, victim_url: str) -> None:
         """Annotate Host's hostname is Hostname-typed; passing the full URL fails."""

--- a/tests/test_osint_args_schemas.py
+++ b/tests/test_osint_args_schemas.py
@@ -23,6 +23,8 @@ scope here - #150 covers them.
 
 from __future__ import annotations
 
+from urllib.parse import urlparse
+
 import pytest
 from pydantic import BaseModel, ValidationError
 
@@ -74,6 +76,20 @@ def _tools_by_name() -> dict[str, object]:
     return {t.name: t for t in MEMBER.tools}
 
 
+def _annotate_host_base(hostname: str) -> dict[str, object]:
+    """Minimal valid kwargs for _AnnotateHostArgs, parameterised by hostname.
+
+    Centralised so the fixture-derived hostname flows in from one place and
+    each rejection test stays focused on the field it is exercising.
+    """
+    return {
+        "hostname": hostname,
+        "role": "api",
+        "priority": "high",
+        "notes": "Production REST API surface; warrants careful probing.",
+    }
+
+
 class TestOsintArgsSchemaContracts:
     @pytest.mark.parametrize("tool_name", sorted(_OSINT_SCHEMAS))
     def test_tool_wires_explicit_schema(self, tool_name: str) -> None:
@@ -121,6 +137,15 @@ class TestOsintArgsSchemaContracts:
 
 
 class TestSchemaAcceptReject:
+    """Accept / reject contract per schema.
+
+    The parametrize below carries cases that do not involve a hostname or
+    URL - those use the conftest ``victim_url`` / ``bystander_url`` /
+    ``callback_url`` domain fixtures via the dedicated test methods further
+    down, so test intent ("this is the in-scope target") is readable at the
+    call site rather than via opaque ``example.com`` literals.
+    """
+
     @pytest.mark.parametrize(
         ("schema_cls", "kwargs"),
         [
@@ -133,30 +158,8 @@ class TestSchemaAcceptReject:
                 {"status": 200, "tech": "wordpress", "host_contains": "admin", "limit": 25},
             ),
             (_ReconOpenPortsArgs, {}),
-            (_ReconOpenPortsArgs, {"host": "victim.example.com"}),
-            (_CertTransparencyArgs, {"domain": "example.com"}),
-            (_HistoricalUrlsArgs, {"domain": "example.com"}),
-            (
-                _ProbeHostnamesArgs,
-                {"hostnames": ["api.example.com"], "programme_handle": "example"},
-            ),
-            (
-                _DetectTakeoverCandidatesArgs,
-                {"hostnames": ["legacy.example.com"], "programme_handle": "example"},
-            ),
             (_OsintLookupCweArgs, {"query": "xss"}),
             (_OsintLookupOwaspArgs, {"query": "csrf"}),
-            (
-                _AnnotateHostArgs,
-                {
-                    "hostname": "api.example.com",
-                    "role": "api",
-                    "priority": "high",
-                    "notes": "Production REST API surface; warrants careful probing.",
-                    "detected_tech": ["nginx"],
-                    "programme_handle": "example",
-                },
-            ),
             (_UncoveredHostsArgs, {}),
             (_FinaliseReconArgs, {"programme_handle": "example"}),
         ],
@@ -167,6 +170,74 @@ class TestSchemaAcceptReject:
         """Known-good shapes pass model_validate without raising."""
         instance = schema_cls.model_validate(kwargs)
         assert isinstance(instance, schema_cls)
+
+    # URL / hostname-taking schemas use the conftest domain fixtures so test
+    # intent is readable at the call site. Each schema below has a dedicated
+    # method rather than a parametrize entry because parametrize literals
+    # cannot consume fixtures.
+
+    def test_recon_open_ports_accepts_victim_host(self, victim_url: str) -> None:
+        """Recon Open Ports accepts a real hostname filter."""
+        host = urlparse(victim_url).hostname
+        _ReconOpenPortsArgs.model_validate({"host": host})
+
+    def test_cert_transparency_accepts_victim_apex(self, victim_url: str) -> None:
+        """Certificate Transparency takes the apex domain of the in-scope target."""
+        host = urlparse(victim_url).hostname or ""
+        apex = host.split(".", 1)[-1] if "." in host else host
+        _CertTransparencyArgs.model_validate({"domain": apex})
+
+    def test_historical_urls_accepts_victim_apex(self, victim_url: str) -> None:
+        """Historical URL Discovery takes the apex domain of the in-scope target."""
+        host = urlparse(victim_url).hostname or ""
+        apex = host.split(".", 1)[-1] if "." in host else host
+        _HistoricalUrlsArgs.model_validate({"domain": apex})
+
+    def test_probe_hostnames_accepts_victim_hostname(self, victim_url: str) -> None:
+        """Probe Hostnames takes a list of hostnames plus the programme handle."""
+        _ProbeHostnamesArgs.model_validate(
+            {
+                "hostnames": [urlparse(victim_url).hostname],
+                "programme_handle": "example",
+            }
+        )
+
+    def test_detect_takeover_candidates_accepts_bystander_hostname(
+        self, bystander_url: str
+    ) -> None:
+        """Detect Takeover Candidates models the case where a CNAME dangles to a
+        bystander - the ``bystander_url`` fixture is the conventional handle
+        for an out-of-scope target."""
+        _DetectTakeoverCandidatesArgs.model_validate(
+            {
+                "hostnames": [urlparse(bystander_url).hostname],
+                "programme_handle": "example",
+            }
+        )
+
+    def test_annotate_host_accepts_victim_hostname(self, victim_url: str) -> None:
+        """Annotate Host takes a hostname plus role / priority / notes / tech."""
+        host = urlparse(victim_url).hostname or ""
+        _AnnotateHostArgs.model_validate(
+            {
+                **_annotate_host_base(host),
+                "detected_tech": ["nginx"],
+                "programme_handle": "example",
+            }
+        )
+
+    def test_llm_detection_accepts_populated_endpoint_list(self, endpoint) -> None:
+        """LLM Endpoint Detection accepts the realistic ``Endpoint`` shape.
+
+        The conftest ``endpoint`` fixture is the canonical Endpoint instance;
+        using it here exercises the Endpoint model's own validation path as
+        part of the schema contract.
+        """
+        instance = _LlmDetectionArgs.model_validate(
+            {"endpoints": [endpoint.model_dump(mode="json")]}
+        )
+        assert len(instance.endpoints) == 1
+        assert instance.endpoints[0].url == endpoint.url
 
     # Required-field rejections. Each schema below has at least one
     # required field; missing it must fail validation.
@@ -190,52 +261,29 @@ class TestSchemaAcceptReject:
         with pytest.raises(ValidationError):
             schema_cls.model_validate({})
 
-    def test_probe_hostnames_requires_both_hostnames_and_handle(self) -> None:
+    def test_probe_hostnames_requires_both_hostnames_and_handle(self, victim_url: str) -> None:
         """Both hostnames and programme_handle are required - one alone fails."""
+        host = urlparse(victim_url).hostname
         with pytest.raises(ValidationError):
-            _ProbeHostnamesArgs.model_validate({"hostnames": ["api.example.com"]})
+            _ProbeHostnamesArgs.model_validate({"hostnames": [host]})
         with pytest.raises(ValidationError):
             _ProbeHostnamesArgs.model_validate({"programme_handle": "example"})
 
-    def test_annotate_host_requires_core_fields(self) -> None:
+    def test_annotate_host_requires_core_fields(self, victim_url: str) -> None:
         """hostname / role / priority / notes are all required for Annotate Host."""
-        base: dict[str, object] = {
-            "hostname": "api.example.com",
-            "role": "api",
-            "priority": "high",
-            "notes": "Production REST API surface; warrants careful probing.",
-        }
+        base = _annotate_host_base(urlparse(victim_url).hostname or "")
         for missing in ("hostname", "role", "priority", "notes"):
             kwargs = {k: v for k, v in base.items() if k != missing}
             with pytest.raises(ValidationError):
                 _AnnotateHostArgs.model_validate(kwargs)
 
-    def test_llm_detection_accepts_populated_endpoint_list(self, endpoint) -> None:
-        """LLM Endpoint Detection schema accepts the realistic ``Endpoint`` shape.
-
-        The parametrize cases above cover empty-list and missing-field paths;
-        this one exercises a populated list with a real ``Endpoint`` (via the
-        canonical conftest fixture) so the Endpoint model's own validation
-        path is part of the contract test.
-        """
-        instance = _LlmDetectionArgs.model_validate(
-            {"endpoints": [endpoint.model_dump(mode="json")]}
-        )
-        assert len(instance.endpoints) == 1
-        assert instance.endpoints[0].url == endpoint.url
-
-    def test_annotate_host_rejects_unknown_role_and_priority(self) -> None:
+    def test_annotate_host_rejects_unknown_role_and_priority(self, victim_url: str) -> None:
         """role and priority are typed as HostRole / HostPriority StrEnums.
 
         Unknown values reject upstream of the wrapper rather than in the
         body's ``HostRole(role)`` / ``HostPriority(priority)`` coercion.
         """
-        base: dict[str, object] = {
-            "hostname": "api.example.com",
-            "role": "api",
-            "priority": "high",
-            "notes": "Production REST API surface; warrants careful probing.",
-        }
+        base = _annotate_host_base(urlparse(victim_url).hostname or "")
         with pytest.raises(ValidationError):
             _AnnotateHostArgs.model_validate({**base, "role": "not-a-real-role"})
         with pytest.raises(ValidationError):

--- a/tests/test_osint_args_schemas.py
+++ b/tests/test_osint_args_schemas.py
@@ -136,7 +136,6 @@ class TestSchemaAcceptReject:
             (_ReconOpenPortsArgs, {"host": "victim.example.com"}),
             (_CertTransparencyArgs, {"domain": "example.com"}),
             (_HistoricalUrlsArgs, {"domain": "example.com"}),
-            (_LlmDetectionArgs, {"endpoints": []}),
             (
                 _ProbeHostnamesArgs,
                 {"hostnames": ["api.example.com"], "programme_handle": "example"},
@@ -210,3 +209,34 @@ class TestSchemaAcceptReject:
             kwargs = {k: v for k, v in base.items() if k != missing}
             with pytest.raises(ValidationError):
                 _AnnotateHostArgs.model_validate(kwargs)
+
+    def test_llm_detection_accepts_populated_endpoint_list(self, endpoint) -> None:
+        """LLM Endpoint Detection schema accepts the realistic ``Endpoint`` shape.
+
+        The parametrize cases above cover empty-list and missing-field paths;
+        this one exercises a populated list with a real ``Endpoint`` (via the
+        canonical conftest fixture) so the Endpoint model's own validation
+        path is part of the contract test.
+        """
+        instance = _LlmDetectionArgs.model_validate(
+            {"endpoints": [endpoint.model_dump(mode="json")]}
+        )
+        assert len(instance.endpoints) == 1
+        assert instance.endpoints[0].url == endpoint.url
+
+    def test_annotate_host_rejects_unknown_role_and_priority(self) -> None:
+        """role and priority are typed as HostRole / HostPriority StrEnums.
+
+        Unknown values reject upstream of the wrapper rather than in the
+        body's ``HostRole(role)`` / ``HostPriority(priority)`` coercion.
+        """
+        base: dict[str, object] = {
+            "hostname": "api.example.com",
+            "role": "api",
+            "priority": "high",
+            "notes": "Production REST API surface; warrants careful probing.",
+        }
+        with pytest.raises(ValidationError):
+            _AnnotateHostArgs.model_validate({**base, "role": "not-a-real-role"})
+        with pytest.raises(ValidationError):
+            _AnnotateHostArgs.model_validate({**base, "priority": "urgent"})

--- a/tests/test_osint_args_schemas.py
+++ b/tests/test_osint_args_schemas.py
@@ -1,0 +1,212 @@
+"""
+tests/test_osint_args_schemas.py - contract tests for the explicit Pydantic
+``args_schema`` every OSINT Analyst ``@cyber_tool`` wrapper carries.
+
+Sibling of ``test_pt_args_schemas.py``: same shape of structural and
+accept/reject checks, scoped to the OSINT Analyst's tool surface. Closes
+#148.
+
+OSINT tools fire external recon (subfinder, httpx, nmap, testssl.sh,
+ffuf, crt.sh, waybackurls, dnsx, LLM endpoint detection) against in-scope
+hosts. The "live programmes, mis-call costs money" framing that motivated
+#143 / #146 / #147 applies identically here, plus a scope-leak risk that
+is specific to recon: a mis-targeted ``host_filter`` or wrong
+``host_contains`` substring can pull a sibling programme's endpoints
+into the run and silently corrupt every downstream stage. Filter-
+parameter discipline is the bulk of what the per-field descriptions are
+doing.
+
+The workspace tools on the OSINT Analyst (``List Run Files``, ``Read Run
+File``) intentionally keep the signature-inferred schema and are out of
+scope here - #150 covers them.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from squad.osint_analyst import (
+    MEMBER,
+    _AnnotateHostArgs,
+    _CertTransparencyArgs,
+    _DetectTakeoverCandidatesArgs,
+    _FinaliseReconArgs,
+    _HistoricalUrlsArgs,
+    _LlmDetectionArgs,
+    _OsintLookupCweArgs,
+    _OsintLookupOwaspArgs,
+    _ProbeHostnamesArgs,
+    _ReconEndpointsArgs,
+    _ReconOpenPortsArgs,
+    _ReconSubdomainsArgs,
+    _RunInitialSweepArgs,
+    _UncoveredHostsArgs,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# Tool-name -> explicit schema class. Covers every OSINT @cyber_tool
+# wrapper. The workspace readers (List Run Files, Read Run File) on the
+# OSINT Analyst keep the inferred schema and are out of scope - #150 owns
+# them.
+_OSINT_SCHEMAS: dict[str, type[BaseModel]] = {
+    "Run Initial Sweep": _RunInitialSweepArgs,
+    "Recon Subdomains": _ReconSubdomainsArgs,
+    "Recon Endpoints": _ReconEndpointsArgs,
+    "Recon Open Ports": _ReconOpenPortsArgs,
+    "Certificate Transparency Lookup": _CertTransparencyArgs,
+    "Historical URL Discovery": _HistoricalUrlsArgs,
+    "LLM Endpoint Detection": _LlmDetectionArgs,
+    "Probe Hostnames": _ProbeHostnamesArgs,
+    "Detect Takeover Candidates": _DetectTakeoverCandidatesArgs,
+    "Lookup CWE": _OsintLookupCweArgs,
+    "Lookup OWASP Guidance": _OsintLookupOwaspArgs,
+    "Annotate Host": _AnnotateHostArgs,
+    "Uncovered Hosts": _UncoveredHostsArgs,
+    "Finalise Recon": _FinaliseReconArgs,
+}
+
+
+def _tools_by_name() -> dict[str, object]:
+    """Look up MEMBER.tools by display name once, share across tests."""
+    return {t.name: t for t in MEMBER.tools}
+
+
+class TestOsintArgsSchemaContracts:
+    @pytest.mark.parametrize("tool_name", sorted(_OSINT_SCHEMAS))
+    def test_tool_wires_explicit_schema(self, tool_name: str) -> None:
+        """Every OSINT typed tool registers the explicit schema class on its Tool."""
+        tool_obj = _tools_by_name()[tool_name]
+        expected = _OSINT_SCHEMAS[tool_name]
+        assert tool_obj.args_schema is expected, (  # type: ignore[attr-defined]
+            f"{tool_name} args_schema is {tool_obj.args_schema!r}; expected {expected!r}"  # type: ignore[attr-defined]
+        )
+
+    @pytest.mark.parametrize(
+        ("tool_name", "schema_cls"),
+        sorted(_OSINT_SCHEMAS.items()),
+        ids=sorted(_OSINT_SCHEMAS),
+    )
+    def test_every_field_has_description(self, tool_name: str, schema_cls: type[BaseModel]) -> None:
+        """Per #148: every field on every OSINT typed-tool schema carries a description."""
+        for field_name, field_info in schema_cls.model_fields.items():
+            desc = field_info.description
+            assert desc, f"{tool_name}::{field_name} missing Field(description=...)"
+            assert isinstance(desc, str) and desc.strip(), (
+                f"{tool_name}::{field_name} description is blank"
+            )
+
+    def test_every_osint_cyber_tool_has_schema_mapping(self) -> None:
+        """The mapping above must cover every OSINT ``@cyber_tool`` wrapper.
+
+        Closed-world structural check: every OSINT tool whose Tool exposes
+        a private (``_*``) args_schema class name is in ``_OSINT_SCHEMAS``;
+        every entry in ``_OSINT_SCHEMAS`` resolves to a registered tool.
+        A new typed tool added without a mapping entry fires this test
+        before reviewers see the PR.
+        """
+        tools = _tools_by_name()
+        private_schema_tools = {
+            name
+            for name, t in tools.items()
+            if getattr(getattr(t, "args_schema", None), "__name__", "").startswith("_")
+        }
+        assert private_schema_tools == set(_OSINT_SCHEMAS), (
+            "Mismatch between OSINT typed-tool wrappers and _OSINT_SCHEMAS: "
+            f"in registry but not mapping = {private_schema_tools - set(_OSINT_SCHEMAS)}; "
+            f"in mapping but not registry = {set(_OSINT_SCHEMAS) - private_schema_tools}"
+        )
+
+
+class TestSchemaAcceptReject:
+    @pytest.mark.parametrize(
+        ("schema_cls", "kwargs"),
+        [
+            (_RunInitialSweepArgs, {"programme_handle": "example"}),
+            (_ReconSubdomainsArgs, {}),
+            (_ReconSubdomainsArgs, {"sweep_path": "sweep.json", "host_filter": "api"}),
+            (_ReconEndpointsArgs, {}),
+            (
+                _ReconEndpointsArgs,
+                {"status": 200, "tech": "wordpress", "host_contains": "admin", "limit": 25},
+            ),
+            (_ReconOpenPortsArgs, {}),
+            (_ReconOpenPortsArgs, {"host": "victim.example.com"}),
+            (_CertTransparencyArgs, {"domain": "example.com"}),
+            (_HistoricalUrlsArgs, {"domain": "example.com"}),
+            (_LlmDetectionArgs, {"endpoints_json": "[]"}),
+            (
+                _ProbeHostnamesArgs,
+                {"hostnames": ["api.example.com"], "programme_handle": "example"},
+            ),
+            (
+                _DetectTakeoverCandidatesArgs,
+                {"hostnames": ["legacy.example.com"], "programme_handle": "example"},
+            ),
+            (_OsintLookupCweArgs, {"query": "xss"}),
+            (_OsintLookupOwaspArgs, {"query": "csrf"}),
+            (
+                _AnnotateHostArgs,
+                {
+                    "hostname": "api.example.com",
+                    "role": "api",
+                    "priority": "high",
+                    "notes": "Production REST API surface; warrants careful probing.",
+                    "detected_tech": ["nginx"],
+                    "programme_handle": "example",
+                },
+            ),
+            (_UncoveredHostsArgs, {}),
+            (_FinaliseReconArgs, {"programme_handle": "example"}),
+        ],
+    )
+    def test_schema_accepts_known_input(
+        self, schema_cls: type[BaseModel], kwargs: dict[str, object]
+    ) -> None:
+        """Known-good shapes pass model_validate without raising."""
+        instance = schema_cls.model_validate(kwargs)
+        assert isinstance(instance, schema_cls)
+
+    # Required-field rejections. Each schema below has at least one
+    # required field; missing it must fail validation.
+    @pytest.mark.parametrize(
+        "schema_cls",
+        [
+            _RunInitialSweepArgs,  # programme_handle required
+            _CertTransparencyArgs,  # domain required
+            _HistoricalUrlsArgs,  # domain required
+            _LlmDetectionArgs,  # endpoints_json required
+            _ProbeHostnamesArgs,  # hostnames + programme_handle required
+            _DetectTakeoverCandidatesArgs,  # hostnames + programme_handle required
+            _OsintLookupCweArgs,  # query required
+            _OsintLookupOwaspArgs,  # query required
+            _AnnotateHostArgs,  # hostname / role / priority / notes required
+            _FinaliseReconArgs,  # programme_handle required
+        ],
+    )
+    def test_missing_required_field_rejected(self, schema_cls: type[BaseModel]) -> None:
+        """At least one required field is missing: model_validate must fail."""
+        with pytest.raises(ValidationError):
+            schema_cls.model_validate({})
+
+    def test_probe_hostnames_requires_both_hostnames_and_handle(self) -> None:
+        """Both hostnames and programme_handle are required - one alone fails."""
+        with pytest.raises(ValidationError):
+            _ProbeHostnamesArgs.model_validate({"hostnames": ["api.example.com"]})
+        with pytest.raises(ValidationError):
+            _ProbeHostnamesArgs.model_validate({"programme_handle": "example"})
+
+    def test_annotate_host_requires_core_fields(self) -> None:
+        """hostname / role / priority / notes are all required for Annotate Host."""
+        base: dict[str, object] = {
+            "hostname": "api.example.com",
+            "role": "api",
+            "priority": "high",
+            "notes": "Production REST API surface; warrants careful probing.",
+        }
+        for missing in ("hostname", "role", "priority", "notes"):
+            kwargs = {k: v for k, v in base.items() if k != missing}
+            with pytest.raises(ValidationError):
+                _AnnotateHostArgs.model_validate(kwargs)

--- a/tests/test_osint_args_schemas.py
+++ b/tests/test_osint_args_schemas.py
@@ -136,7 +136,7 @@ class TestSchemaAcceptReject:
             (_ReconOpenPortsArgs, {"host": "victim.example.com"}),
             (_CertTransparencyArgs, {"domain": "example.com"}),
             (_HistoricalUrlsArgs, {"domain": "example.com"}),
-            (_LlmDetectionArgs, {"endpoints_json": "[]"}),
+            (_LlmDetectionArgs, {"endpoints": []}),
             (
                 _ProbeHostnamesArgs,
                 {"hostnames": ["api.example.com"], "programme_handle": "example"},
@@ -177,7 +177,7 @@ class TestSchemaAcceptReject:
             _RunInitialSweepArgs,  # programme_handle required
             _CertTransparencyArgs,  # domain required
             _HistoricalUrlsArgs,  # domain required
-            _LlmDetectionArgs,  # endpoints_json required
+            _LlmDetectionArgs,  # endpoints required
             _ProbeHostnamesArgs,  # hostnames + programme_handle required
             _DetectTakeoverCandidatesArgs,  # hostnames + programme_handle required
             _OsintLookupCweArgs,  # query required

--- a/tests/test_pt_args_schemas.py
+++ b/tests/test_pt_args_schemas.py
@@ -1,11 +1,11 @@
 """
 tests/test_pt_args_schemas.py - contract tests for the explicit Pydantic
-``args_schema`` every Penetration Tester ``@typed_tool`` / ``@pentest_tool``
+``args_schema`` every Penetration Tester ``@cyber_tool`` / ``@pentest_tool``
 wrapper carries.
 
 Started life under #143/#146 covering the 25 ``@pentest_tool`` probes;
-#147 extended it to cover the 18 cloud / infra ``@typed_tool`` wrappers on
-the same agent. Both decorators go through the same ``typed_tool`` helper
+#147 extended it to cover the 18 cloud / infra ``@cyber_tool`` wrappers on
+the same agent. Both decorators go through the same ``cyber_tool`` helper
 so the contract is identical: the schema class is hand-written, every
 field carries a non-empty ``description``, and ``args_schema`` on the
 registered ``Tool`` ``is`` (identity) the explicit class - not the
@@ -85,7 +85,7 @@ from squad.penetration_tester import (
 pytestmark = pytest.mark.unit
 
 
-# Tool-name -> explicit schema class. Covers every PT @typed_tool /
+# Tool-name -> explicit schema class. Covers every PT @cyber_tool /
 # @pentest_tool wrapper. Recon / write / workspace tools that intentionally
 # keep the signature-inferred schema (Recon Subdomains, Recon Endpoints,
 # Recon Open Ports, Save Findings, plus the three workspace readers) are
@@ -117,7 +117,7 @@ _PT_SCHEMAS: dict[str, type[BaseModel]] = {
     "Prototype Pollution Check": _PrototypePollutionArgs,
     "IDOR Probe": _IdorArgs,
     "JWT Vulnerability Check": _JwtCheckArgs,
-    # @typed_tool cloud / infra wrappers (#147)
+    # @cyber_tool cloud / infra wrappers (#147)
     "S3 Bucket Check": _S3CheckArgs,
     "Azure Blob Storage Check": _AzureStorageCheckArgs,
     "Unauthenticated Elasticsearch Check": _ElasticsearchCheckArgs,
@@ -189,8 +189,8 @@ class TestPtArgsSchemaContracts:
                 f"{tool_name}::{field_name} description is blank"
             )
 
-    def test_every_pt_typed_tool_has_schema_mapping(self) -> None:
-        """The mapping above must cover every PT ``@typed_tool`` / ``@pentest_tool``.
+    def test_every_pt_cyber_tool_has_schema_mapping(self) -> None:
+        """The mapping above must cover every PT ``@cyber_tool`` / ``@pentest_tool``.
 
         Closed-world structural check: every PT tool whose Tool exposes a
         private (``_*``) args_schema class name is in ``_PT_SCHEMAS``;
@@ -256,7 +256,7 @@ class TestSchemaAcceptReject:
             (_HostHeaderArgs, {"recon_path": "recon.json"}),
             (_SourceMapsArgs, {"recon_path": "recon.json"}),
             (_SriCheckArgs, {"recon_path": "recon.json"}),
-            # @typed_tool cloud / infra acceptance cases (#147)
+            # @cyber_tool cloud / infra acceptance cases (#147)
             (_S3CheckArgs, {"recon_path": "recon.json"}),
             (_AzureStorageCheckArgs, {"recon_path": "recon.json"}),
             (_ElasticsearchCheckArgs, {"recon_path": "recon.json"}),
@@ -336,7 +336,7 @@ class TestSchemaAcceptReject:
             _XssArgs,
             _HppArgs,
             _ErrorDisclosureArgs,
-            # @typed_tool cloud wrappers that take endpoints (#147)
+            # @cyber_tool cloud wrappers that take endpoints (#147)
             _SensitiveFilesArgs,
             _AdminPanelsArgs,
         ],

--- a/tests/test_recon_insights.py
+++ b/tests/test_recon_insights.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 
 import pytest
+from pydantic import ValidationError
 
 from models import (
     Endpoint,
@@ -86,10 +87,14 @@ class TestValidateInsight:
         assert report.ok is True
         assert all(i.severity != "error" for i in report.issues)
 
-    def test_rejects_empty_hostname(self, sweep, programme):
-        report = validate_insight(_good_insight(hostname=""), sweep, programme)
-        assert report.ok is False
-        assert any(i.section == "hostname" for i in report.issues)
+    def test_rejects_empty_hostname(self):
+        # Hostname is a typed-string with an upstream validator now, so the
+        # empty-hostname check fires at HostInsight construction time rather
+        # than inside validate_insight. The test asserts the contract has
+        # moved one layer up rather than re-asserting the (now-redundant)
+        # validate_insight branch.
+        with pytest.raises(ValidationError):
+            _good_insight(hostname="")
 
     def test_rejects_out_of_scope_hostname(self, sweep, programme, bystander_url):
         from urllib.parse import urlparse
@@ -167,12 +172,18 @@ class TestPersistence:
         loaded = HostInsight.model_validate_json(path.read_text())
         assert loaded.hostname == "api.example.com"
 
-    def test_save_insight_handles_special_chars_in_hostname(self, tmp_path, monkeypatch):
+    def test_insight_path_sanitises_special_chars(self, tmp_path, monkeypatch):
         monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)
-        # Hostnames in practice are RFC 1123, but defensively sanitise unusual chars.
-        ins = _good_insight(hostname="weird host/name.example.com")
-        path = save_insight(ins)
-        assert path.exists()
+        # HostInsight.hostname is now typed as Hostname so weird chars cannot
+        # reach save_insight through the model path - but insight_path itself
+        # still takes a bare ``str`` argument (used directly elsewhere), and
+        # its filesystem sanitisation contract is what this test guards.
+        from tools.recon_insights import insight_path
+
+        path = insight_path("weird host/name.example.com")
+        # / is sanitised to _ so the path stays inside the host_insights dir.
+        assert "/" not in path.name
+        assert path.parent.name == "host_insights"
 
     def test_load_insights_orders_by_hostname(self, tmp_path, monkeypatch):
         monkeypatch.setattr("tools.recon_insights.runtime.run_dir", lambda: tmp_path)

--- a/tests/test_squad_osint_analyst.py
+++ b/tests/test_squad_osint_analyst.py
@@ -9,7 +9,6 @@ underlying helpers are exercised in their own dedicated test files.
 
 from __future__ import annotations
 
-import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -349,12 +348,15 @@ class TestOsintAnalystTools:
         from models import LlmEndpoint
         from squad.osint_analyst import llm_detection_tool
 
-        endpoints_json = json.dumps([endpoint.model_dump(mode="json")])
+        # CrewAI's args_schema validation hands us list[dict] at runtime;
+        # the both-shape adapter inside the wrapper accepts either Endpoint
+        # instances or dicts, so this exercises the dict path.
+        endpoints_payload = [endpoint.model_dump(mode="json")]
         with patch(
             "squad.osint_analyst.detect_llm_endpoints",
             return_value=[endpoint],
         ) as m:
-            result = llm_detection_tool.func(endpoints_json)
+            result = llm_detection_tool.func(endpoints_payload)
 
         assert result == [LlmEndpoint.model_validate(endpoint.model_dump())]
         assert len(m.call_args[0][0]) == 1


### PR DESCRIPTION
## Summary

Closes #148. Extends the args_schema discipline from #143 / #146 / #147 to the 14 OSINT Analyst `@tool` wrappers covering subfinder / httpx / nmap / ffuf / crt.sh / waybackurls / dnsx / LLM endpoint detection / recon-query slicers / host annotation / finalisation.

**Mea culpa on scope**: the PR title is "OSINT args_schema sweep" but the diff is larger than that suggests. Every addition is review-driven (the comment thread is the audit trail) and conceptually tied to the args_schema work, but I want to be honest about how we got from "sweep 14 wrappers" to ~1300 line diff. See the timeline at the end if you want the gory details.

## What landed

### OSINT args_schema sweep (the original #148 scope)

14 OSINT wrappers swept to `@cyber_tool` with inline `_<Name>Args` schemas. Field descriptions written as agent-facing targeting guidance, with particular care on recon filter parameters (`host_filter`, `host_contains`, `status`, `tech`) where mis-targeting is the scope-leak risk specific to recon.

The 2 remaining `@tool` wrappers on OSINT (workspace readers re-exported from `squad.workspace_tools`) stay inferred-path - covered by #150.

### Helper rename: `typed_tool` -> `cyber_tool`

Picked up mid-sweep on review feedback. `cyber_tool` makes the brand visible at every consumer site; the helper is conceptually "the cybersquad-blessed `@tool` replacement". sed across 6 files (definition, PT module, OSINT module, the cybersquad-tool skill, both args_schema test files). No behaviour change.

### `endpoints_json: str` -> `list[Endpoint]` on `llm_detection_tool`

The last surviving instance of the #139-retired stringified-JSON pattern. Migrated to the canonical `list[Endpoint]` shape with the both-shape adapter pattern (`Endpoint.model_validate(e)` accepts both Endpoint instances and dicts; covers runtime + direct-test paths).

### `Hostname` typed-string primitive

New `Hostname = Annotated[str, AfterValidator(_validate_hostname)]` in `models/primitives.py`. RFC 1123 hostname validation - rejects schemes, ports, paths, empty input, leading/trailing-hyphen labels, oversized labels (>63 chars), oversized total (>253 chars), garbage chars. Lowercases + strips on the way through.

Applied across 6 fields on 5 OSINT schemas (Probe Hostnames, Detect Takeover Candidates, Recon Open Ports, Annotate Host, Cert Transparency, Historical URL Discovery) plus composed into `HostInsight.hostname`, `OpenPortsMap.hosts` keys, `ReconResult.subdomains` / `open_ports` keys / `network_hops` keys.

### `HttpUrl` typed-string primitive

Light flavour: `Annotated[str, AfterValidator(_validate_endpoint_url)]`. Parses with `urlparse`, asserts http/https scheme, runs the embedded hostname through the `Hostname` validator. Runtime type stays `str` so existing `endpoint.url.startswith(...)` call sites keep working.

Applied to `Endpoint.url` and `LlmEndpoint.url`. FIXME comments in `primitives.py` and `asset.py` point at Pydantic's built-in `HttpUrl` as the stronger future contract, gated on auditing every consumer.

### StrEnum on Annotate Host

`_AnnotateHostArgs.role` / `.priority` typed as `HostRole` / `HostPriority` StrEnums directly (was `str`). Schema rejects unknown values upstream of the wrapper's coercion. Signature updated to match.

### Models package split

`models/__init__.py` reduced from 319 lines to a pure re-export surface (all `from models import X` consumer imports unchanged). Per-domain modules:

- `models/primitives.py` - Severity, Hostname, HttpUrl
- `models/finding.py` - RawFinding, VerifiedVulnerability, RawFindingSummary
- `models/asset.py` - Endpoint, EndpointPage, HostRole, HostPriority, HostInsight, OpenPortsMap, LlmEndpoint, ReconResult
- `models/workspace.py` - RunFile, RunFileContent
- `models/cve.py` - CveEntry
- `models/metrics.py` - RunMetrics
- ProgrammeReportSummary moved to `models/h1.py` (it is H1-shaped)

Pre-split circular-import dance (h1 importing Severity while __init__ initialised) removed; dependency layers flow primitives -> finding -> h1 -> asset.

### LlmEndpoint FIXME

Class kept as-is for now but carries a FIXME pointing at #144 (MCP discipline) and #83 (framework probes). The realisation surfaced during review: `LlmEndpoint` today is `Endpoint` with a docstring change, and what the original author was reaching for is properly the `DiscoveredMCP` shape #144 sketched. The class will migrate into `models/framework.py` per #83 as the first framework-typed model. Until then, do not extend it as a generic LLM endpoint shape.

### Skill refresh

Both contributor skills brought back into alignment with the codebase:

- **`cybersquad-tool`**: new "Typed string primitives" section (Hostname + HttpUrl), new "Where models live" section with the per-domain layout table, all example code blocks switched from bare `@tool` to `@cyber_tool` / `@pentest_tool`, anti-patterns gained "bare str on hostname / URL fields", "dict[str, ...] keys that should be Hostname", "adding to __init__.py". Canonical examples updated (OSINT joins PT as fully migrated; `read_attack_plan_tool` is the typed-reader example, not the backlog target).
- **`cybersquad-pentest-tool`**: two rename fixes (`test_pentest_args_schemas.py` -> `test_pt_args_schemas.py`, `_PROBE_SCHEMAS` -> `_PT_SCHEMAS`).

### Contract tests

- `tests/test_osint_args_schemas.py` mirrors `test_pt_args_schemas.py`: closed-world `_OSINT_SCHEMAS` mapping, every-field-has-description check, parametrized accept / reject cases for the URL-less schemas, fixture-using dedicated methods for the URL / hostname-shaped ones.
- `tests/test_models.py` `TestHostname` and `TestHttpUrl` exhaustively cover both validators (accept paths from the `victim_url` fixture, reject corpus derived from the same fixture so test intent reads as "in-scope target, deliberately mis-shaped").
- `tests/test_recon_insights.py` two tests updated for the upstream-validation change (HostInsight construction now rejects empty / mis-shaped hostnames; the `validate_insight` branch that handled them is now dead defensive code).

## Out of scope (filed as follow-ups)

- **#153** - `@cyber_tool(scope_filter=...)` check_fn for hostname-taking tools (the "scope_guard as check_fn" Frankensteiney pattern is real but contained; lifted out into its own focused PR).
- Broader OSINT API refactor (programme_handle threading, sweep_path implicit, HostInsight-shaped Annotate Host input, deduplicated CWE / OWASP lookups across agents) - user is taking that on directly.
- `LlmEndpoint` -> `DiscoveredMCP` migration into `models/framework.py` - flagged via FIXME, sequenced after #83 lands the framework-probe infrastructure.
- Migration of `Endpoint.url` from the light validator to Pydantic's built-in `HttpUrl` - FIXME comment + audit of every consumer-side `url.startswith(...)` site needed first.

## Test plan

- [x] `ruff check .` - clean
- [x] `ruff format --check .` - clean
- [x] `mypy . --ignore-missing-imports` - clean
- [x] `pylint .` - 9.87/10 (no regression)
- [x] `pytest -m unit --cov` - 1320 passed, 91.73% coverage
- [x] `bandit -c pyproject.toml -r . -q` - clean
- [x] OSINT registry post-sweep: 14 explicit schemas, 2 inferred (workspace readers, out of scope)

## Commit timeline (for the curious)

The review thread tells the full story; the short version of how scope accreted:

1. `56ef905` - the actual #148 sweep + `typed_tool` rename to `cyber_tool`.
2. `9da0647` - `endpoints_json: str` migration on `llm_detection_tool` (you flagged the anti-pattern in flight).
3. `cb289c3` - StrEnum on `role` / `priority` + fixture-using test for LlmDetection (small review fixes).
4. `9406fa9` - URL fixtures replacing example.com literals across tests (review clarification).
5. `5a0eac1` - `Hostname` typed-string primitive + composition through OSINT schemas (you talked me into it).
6. `c06143f` - Hostname tests derived from victim_url fixture (review fix).
7. `9e21166` - models package split + `HttpUrl` primitive + `Hostname` composition through `HostInsight` / `OpenPortsMap` / `ReconResult` (the big one).
8. `6ac16bb` - cybersquad-tool + cybersquad-pentest-tool skill refresh (audit caught both stale).
9. `d0bd5c3` - LlmEndpoint FIXME pointing at #144 / #83 / `models/framework.py` (review surfaced the design lineage).

Each step was a small, defensible expansion in response to specific review feedback. The cumulative diff is bigger than "OSINT args_schema sweep" implies, but the connective tissue is real: every addition tightens or composes the typed-input discipline this PR series exists to land.