### PR TITLE
refactor(squad): wrapper-level scope guard via @cyber_tool(scope_filter=...) (#153)

### DIFF
--- a/.claude/skills/cybersquad-tool/SKILL.md
+++ b/.claude/skills/cybersquad-tool/SKILL.md
@@ -49,7 +49,6 @@ Any tool that takes an agent-supplied target (hostname, endpoint, URL) and runs 
 
 ```python
 from squad import cyber_tool
-from squad.workspace_tools import current_programme  # noqa: F401  (loaded lazily)
 
 def _normalise_and_filter_hostnames(
     hostnames: list[Hostname], programme: Programme

--- a/.claude/skills/cybersquad-tool/SKILL.md
+++ b/.claude/skills/cybersquad-tool/SKILL.md
@@ -43,6 +43,43 @@ Rules:
 
 Specialist wrappers compose on top of `@cyber_tool`: `@pentest_tool` (pentest probes - layers OWASP categories from `check_fn.owasp_categories` into the docstring) and `@research_brief_tool` (Vulnerability Researcher - layers `PROBE_VOCABULARY` and `RECON_EVIDENCE_KINDS`) both call `cyber_tool` underneath and pass `args_schema=` through.
 
+### Scope guards belong on the wrapper, not in the body
+
+Any tool that takes an agent-supplied target (hostname, endpoint, URL) and runs an external scan / attack against it declares the guard on the decorator, not inline in the body:
+
+```python
+from squad import cyber_tool
+from squad.workspace_tools import current_programme  # noqa: F401  (loaded lazily)
+
+def _normalise_and_filter_hostnames(
+    hostnames: list[Hostname], programme: Programme
+) -> list[Hostname]:
+    cleaned = [h.strip().lower() for h in hostnames if h.strip()]
+    return filter_in_scope(cleaned, programme)
+
+
+@cyber_tool(
+    "Probe Hostnames",
+    args_schema=_ProbeHostnamesArgs,
+    scope_filter=("hostnames", _normalise_and_filter_hostnames),
+)
+def probe_hostnames_tool(hostnames: list[Hostname]) -> list[Endpoint]:
+    """The wrapper has already dropped out-of-scope hostnames; the body
+    just runs the probe."""
+    if not hostnames:
+        return []
+    return list(probe_endpoints_impl(hostnames))
+```
+
+Mechanics: when `scope_filter=(field_name, filter_fn)` is set, the wrapper validates args via `args_schema`, looks up the named field, and - if non-empty - calls `filter_fn(values, current_programme())` to replace the field's value before invoking the body. The `Programme` is read from `<run_dir>/programme.json` (the snapshot the PM's `Save Selected Programme` writes at run start), so the body never carries `programme_handle` as a parameter and the LLM cannot mis-thread it mid-run.
+
+Rules:
+
+- The `filter_fn` lives at module scope, not as a lambda. Multiple tools sharing the same shape (e.g. `Probe Hostnames` and `Detect Takeover Candidates` both normalise + scope-check hostnames) share one helper, not one per call site.
+- The body must still handle an empty filtered list. The wrapper does not short-circuit on empty; it forwards the empty list and the body decides.
+- Bodies skip the redundant `if not values: return []` guard only when the upstream typed input is already scope-filtered (e.g. PT wrappers that take `list[Endpoint]` from `recon.json`, which `Finalise Recon` already filtered).
+- Do not duplicate the wrapper-level guard inside the body. The whole point of lifting it out is that the contract lives at the wrapper site where reviewers can see it.
+
 ## Typed string primitives
 
 `models.primitives` carries the typed-string layer every higher-level model composes:
@@ -150,6 +187,8 @@ Dependency layers flow `primitives -> finding -> h1 -> asset`; modules import on
 - Adding a new model directly to `models/__init__.py`. The package is split per domain; put it in the matching module and let the re-export carry it.
 - New workspace writer with no typed reader.
 - `from squad.workspace_tools import ...` in a consumer instead of `from squad import ...` - the re-export exists so the import path stays stable when shared tools move.
+- Inline scope dance in a tool body that takes agent-supplied targets (the `_load_programme + filter_in_scope` pattern). Lift it onto the decorator via `scope_filter=(field_name, filter_fn)` so the guarantee lives at the wrapper site.
+- A new `programme_handle: str` field on an args_schema for a tool whose body would only thread it into `current_programme()` or `filter_in_scope`. Workspace state (`runtime.programme_handle` / `<run_dir>/programme.json`) is the contract; the per-call handle is duplication.
 
 ## Canonical examples
 

--- a/squad/__init__.py
+++ b/squad/__init__.py
@@ -26,6 +26,8 @@ Assembly (LLM wiring, pipeline order, approval gates) lives in crew.py / tasks.p
 
 from __future__ import annotations
 
+import functools
+import inspect
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -74,8 +76,14 @@ class SquadTool(Protocol):
     def func(self) -> Callable[..., object]: ...
 
 
+ScopeFilter = tuple[str, Callable[..., object]]
+
+
 def cyber_tool(
-    name: str, *, args_schema: type[BaseModel]
+    name: str,
+    *,
+    args_schema: type[BaseModel],
+    scope_filter: ScopeFilter | None = None,
 ) -> Callable[[Callable[..., object]], SquadTool]:
     """The blessed cybersquad replacement for bare ``@crewai.tools.tool``.
 
@@ -91,14 +99,61 @@ def cyber_tool(
     docstring-injection (OWASP categories for the pentest wrapper, brief
     formatting for the research one). Anything that does not need a
     specialist wrapper uses ``@cyber_tool`` directly.
+
+    ``scope_filter=(field_name, filter_fn)`` lifts the in-line scope
+    guard out of every "agent picked a target, run something external
+    against it" tool body. When set, the wrapper validates args via
+    ``args_schema`` (CrewAI's path), then - if the named field is non-
+    empty - calls ``filter_fn(values, current_programme())`` and
+    replaces the field's value with the filtered list before invoking
+    the body. The ``Programme`` is sourced from
+    ``squad.workspace_tools.current_programme()`` (which reads
+    ``<run_dir>/programme.json``), so the wrapper carries the
+    workspace-state lookup and the body just runs the tool. Bodies
+    must still handle an empty filtered list - the wrapper does not
+    short-circuit on empty.
     """
 
     def decorator(fn: Callable[..., object]) -> SquadTool:
-        wrapped = tool(name)(fn)
+        target = _apply_scope_filter(fn, scope_filter) if scope_filter else fn
+        wrapped = tool(name)(target)
         wrapped.args_schema = args_schema
         return cast(SquadTool, wrapped)
 
     return decorator
+
+
+def _apply_scope_filter(
+    fn: Callable[..., object], scope_filter: ScopeFilter
+) -> Callable[..., object]:
+    """Wrap ``fn`` so the named field is run through ``filter_fn`` first.
+
+    Kept out of ``cyber_tool``'s body so the decorator's closure is small
+    and the wrapping is testable on its own. The lookup of
+    ``current_programme`` is deferred to call time to avoid the
+    ``squad.workspace_tools`` -> ``squad`` import cycle that would fire
+    at decoration time otherwise.
+
+    ``inspect.signature.bind_partial`` resolves the named field whether
+    the caller passes it positionally or by keyword - CrewAI's runtime
+    path uses kwargs (built from ``args_schema``), but direct
+    ``tool.func(value)`` test invocations pass positionally and the
+    wrapper has to cover both shapes.
+    """
+    field_name, filter_fn = scope_filter
+    sig = inspect.signature(fn)
+
+    @functools.wraps(fn)
+    def guarded(*args: object, **kwargs: object) -> object:
+        bound = sig.bind_partial(*args, **kwargs)
+        values = bound.arguments.get(field_name)
+        if values:
+            from squad.workspace_tools import current_programme
+
+            bound.arguments[field_name] = filter_fn(values, current_programme())
+        return fn(*bound.args, **bound.kwargs)
+
+    return guarded
 
 
 # Shared workspace wrappers are imported after ``cyber_tool`` is defined,

--- a/squad/osint_analyst/__init__.py
+++ b/squad/osint_analyst/__init__.py
@@ -6,9 +6,11 @@ cohesive responsibility:
 - ``discovery`` - sweep + slicers + passive expansion (cert
   transparency, historical URLs, LLM endpoint detection) + active
   hostname probes + takeover detection. The "what is the surface"
-  half. Imports the shared ``load_programme`` from
-  ``squad.workspace_tools`` (was a per-agent ``_helpers.py`` before
-  the dedupe).
+  half. The two active-probe wrappers (``Probe Hostnames``, ``Detect
+  Takeover Candidates``) use ``@cyber_tool(scope_filter=...)`` so the
+  programme scope guard runs in the wrapper rather than inline in the
+  body; the shared ``current_programme`` reader lives in
+  ``squad.workspace_tools``.
 - ``curation`` - lookup (CWE / OWASP) + ``Annotate Host`` +
   ``Uncovered Hosts`` + ``Finalise Recon``. The "what do we record
   about the surface" half.

--- a/squad/osint_analyst/curation.py
+++ b/squad/osint_analyst/curation.py
@@ -21,7 +21,7 @@ from models import (
     ReconFinalisationError,
 )
 from squad import cyber_tool
-from squad.workspace_tools import load_programme as _load_programme
+from squad.workspace_tools import current_programme
 from tools.cwe_data import lookup as cwe_lookup
 from tools.owasp_data import lookup as owasp_lookup
 from tools.recon_insights import (
@@ -175,7 +175,11 @@ def annotate_host_tool(
     validation.ok is false.
     """
     sweep = load_sweep_impl(sweep_path)
-    programme = _load_programme(programme_handle)
+    # FIXME(#156): drop ``programme_handle`` from schema+signature - it
+    # duplicates ``runtime.programme_handle`` and is unused here now that
+    # the Programme is sourced from the workspace.
+    _ = programme_handle
+    programme = current_programme()
 
     insight = HostInsight(
         hostname=hostname.strip().lower(),
@@ -247,7 +251,11 @@ def finalise_recon_tool(
     errors, or if the surface is non-empty but no host has been marked
     HIGH priority. Returns the bare filename ``recon.json`` on success.
     """
-    programme = _load_programme(programme_handle)
+    # FIXME(#156): drop ``programme_handle`` from schema+signature - it
+    # duplicates ``runtime.programme_handle`` and is unused here now that
+    # the Programme is sourced from the workspace.
+    _ = programme_handle
+    programme = current_programme()
     try:
         path = finalise_recon(programme, sweep_filename=sweep_path)
     except ReconFinalisationError as exc:

--- a/squad/osint_analyst/discovery.py
+++ b/squad/osint_analyst/discovery.py
@@ -19,8 +19,8 @@ from models import (
     OpenPortsMap,
     TakeoverCandidate,
 )
+from models.h1 import Programme
 from squad import cyber_tool
-from squad.workspace_tools import load_programme as _load_programme
 from tools import http
 from tools.h1_api import h1
 from tools.recon import (
@@ -294,6 +294,22 @@ def llm_detection_tool(endpoints: list[Endpoint]) -> list[LlmEndpoint]:
     return [LlmEndpoint.model_validate(ep.model_dump()) for ep in detect_llm_endpoints(parsed)]
 
 
+def _normalise_and_filter_hostnames(
+    hostnames: list[Hostname], programme: Programme
+) -> list[Hostname]:
+    """Strip / lowercase before delegating to the canonical scope filter.
+
+    Wraps ``tools.recon.scope.filter_in_scope`` (imported as
+    ``filter_in_scope_impl``) with the input-shaping the two OSINT
+    probe tools used to do inline. Lives at module scope - rather than
+    as a lambda passed to ``scope_filter=...`` - so the ``Probe
+    Hostnames`` and ``Detect Takeover Candidates`` wrappers share the
+    same normalisation step exactly once.
+    """
+    cleaned = [h.strip().lower() for h in hostnames if h.strip()]
+    return filter_in_scope_impl(cleaned, programme)
+
+
 class _ProbeHostnamesArgs(BaseModel):
     """Explicit args_schema for the Probe Hostnames tool."""
 
@@ -306,41 +322,35 @@ class _ProbeHostnamesArgs(BaseModel):
             " a hostname' case before the scope filter silently drops it)."
             " Typically the net-new ones surfaced by Certificate"
             " Transparency or Historical URL Discovery that were missed by"
-            " the initial sweep. After this, each hostname is scope-"
-            "filtered against the programme before any HTTP traffic fires."
-        ),
-    )
-    programme_handle: str = Field(
-        description=(
-            "Exact HackerOne programme handle for the scope guard. Required"
-            " so the scope filter has the structured scope to check against;"
-            " the scope guard never probes outside scope, even for"
-            " fingerprinting."
+            " the initial sweep. The wrapper's scope filter drops any"
+            " hostname outside the selected programme's structured scope"
+            " before HTTP traffic fires."
         ),
     )
 
 
-@cyber_tool("Probe Hostnames", args_schema=_ProbeHostnamesArgs)
-def probe_hostnames_tool(hostnames: list[Hostname], programme_handle: str) -> list[Endpoint]:
+@cyber_tool(
+    "Probe Hostnames",
+    args_schema=_ProbeHostnamesArgs,
+    scope_filter=("hostnames", _normalise_and_filter_hostnames),
+)
+def probe_hostnames_tool(hostnames: list[Hostname]) -> list[Endpoint]:
     """
     Re-probe a list of hostnames with httpx to confirm liveness, capture
     status codes, and fingerprint technologies. Use this on hostnames
     surfaced by Certificate Transparency or Historical URL Discovery that
     were not in the initial sweep.
 
-    The hostnames are filtered against the programme's structured scope
-    before any HTTP traffic is generated; out-of-scope hostnames are
-    dropped silently (we never probe outside scope, even for fingerprinting).
-    Returns a list of Endpoint with {url, status_code, technologies,
-    parameters}. Net-new endpoints can then be annotated with Annotate Host.
+    The wrapper scope-filters the hostnames against the selected
+    programme's structured scope before this body runs; out-of-scope
+    hostnames are dropped silently (we never probe outside scope, even
+    for fingerprinting). Returns a list of Endpoint with {url,
+    status_code, technologies, parameters}. Net-new endpoints can then
+    be annotated with Annotate Host.
     """
     if not hostnames:
         return []
-    programme = _load_programme(programme_handle)
-    in_scope = filter_in_scope_impl([h.strip().lower() for h in hostnames if h.strip()], programme)
-    if not in_scope:
-        return []
-    return list(probe_endpoints_impl(in_scope))
+    return list(probe_endpoints_impl(hostnames))
 
 
 class _DetectTakeoverCandidatesArgs(BaseModel):
@@ -353,22 +363,20 @@ class _DetectTakeoverCandidatesArgs(BaseModel):
             " / paths reject upstream. A candidate fires when the CNAME"
             " points to a known-vulnerable provider (AWS S3, Heroku,"
             " GitHub Pages, Azure, Vercel, Netlify, ...) or when the CNAME"
-            " chain dangles. Hostnames are scope-filtered before any DNS"
-            " traffic fires."
-        ),
-    )
-    programme_handle: str = Field(
-        description=(
-            "Exact HackerOne programme handle for the scope guard. The"
-            " resolver does not query outside the programme's structured"
-            " scope - the handle is the authoritative key."
+            " chain dangles. The wrapper's scope filter drops any hostname"
+            " outside the selected programme's structured scope before any"
+            " DNS traffic fires."
         ),
     )
 
 
-@cyber_tool("Detect Takeover Candidates", args_schema=_DetectTakeoverCandidatesArgs)
+@cyber_tool(
+    "Detect Takeover Candidates",
+    args_schema=_DetectTakeoverCandidatesArgs,
+    scope_filter=("hostnames", _normalise_and_filter_hostnames),
+)
 def detect_takeover_candidates_tool(
-    hostnames: list[Hostname], programme_handle: str
+    hostnames: list[Hostname],
 ) -> list[TakeoverCandidate]:
     """
     Resolve each hostname via dnsx and flag subdomain-takeover candidates.
@@ -385,12 +393,9 @@ def detect_takeover_candidates_tool(
     the "no such bucket" / "no such app" / "there isn't a GitHub Pages
     site here" body fingerprint).
 
-    Hostnames are scope-filtered before any DNS traffic is generated.
+    The wrapper scope-filters the hostnames against the selected
+    programme's structured scope before this body runs.
     """
     if not hostnames:
         return []
-    programme = _load_programme(programme_handle)
-    in_scope = filter_in_scope_impl([h.strip().lower() for h in hostnames if h.strip()], programme)
-    if not in_scope:
-        return []
-    return list(detect_takeover_candidates(in_scope))
+    return list(detect_takeover_candidates(hostnames))

--- a/squad/vulnerability_researcher/__init__.py
+++ b/squad/vulnerability_researcher/__init__.py
@@ -13,7 +13,7 @@ cohesive responsibility:
   CWE, Lookup OWASP Guidance, Assess Raw Finding, Discard Finding,
   Finalise Triage). The LLM-authored content for ``Assess Raw
   Finding`` is the typed ``AuthoredAssessment`` from
-  ``models.triage``; the shared ``load_programme`` loader lives in
+  ``models.triage``; the shared ``current_programme`` loader lives in
   ``squad.workspace_tools``.
 
 This module imports each wrapper, assembles ``MEMBER.tools``, and re-

--- a/squad/vulnerability_researcher/triage.py
+++ b/squad/vulnerability_researcher/triage.py
@@ -30,7 +30,7 @@ from models import (
     RawFindingSummary,
 )
 from squad import cyber_tool
-from squad.workspace_tools import load_programme as _load_programme
+from squad.workspace_tools import current_programme
 from tools.cwe_data import lookup as cwe_lookup
 from tools.owasp_data import lookup as owasp_lookup
 from tools.report_tools import calculate_cvss_score
@@ -289,7 +289,11 @@ def assess_finding_tool(
         raise ValueError(f"finding_index {finding_index} out of range")
     finding = raw[finding_index]
 
-    programme = _load_programme(programme_handle)
+    # FIXME(#156): drop ``programme_handle`` from schema+signature - it
+    # duplicates ``runtime.programme_handle`` and is unused here now that
+    # the Programme is sourced from the workspace.
+    _ = programme_handle
+    programme = current_programme()
     # Both-shapes adapter: CrewAI hands the wrapper a dict (LLM path);
     # direct test invocations hand it an AuthoredAssessment instance.
     # ``model_validate`` returns the same instance when given one and
@@ -426,7 +430,11 @@ def finalise_triage_tool(
     Returns the bare filename "verified.json" on success.
     """
     raw = load_raw_findings(resolve_run_path(findings_path))
-    programme = _load_programme(programme_handle)
+    # FIXME(#156): drop ``programme_handle`` from schema+signature - it
+    # duplicates ``runtime.programme_handle`` and is unused here now that
+    # the Programme is sourced from the workspace.
+    _ = programme_handle
+    programme = current_programme()
     try:
         path = finalise_triage_impl(programme, raw)
     except TriageFinalisationError as exc:

--- a/squad/workspace_tools.py
+++ b/squad/workspace_tools.py
@@ -4,45 +4,44 @@ Two halves:
 
 - ``@cyber_tool`` wrappers around the workspace artefact IO (``List
   Run Files``, ``Read Run File``, ``Read Attack Plan``).
-- ``load_programme(programme_handle)`` - the shared programme-loader
-  helper used by every agent that needs a parsed ``Programme`` to
-  reason against (OSINT's curation + active-probe tools, VR triage).
-  Lives here because it is the workspace's other authoritative
-  context: the run directory tells us what we wrote, and this loader
-  tells us who we wrote it about.
+- ``current_programme()`` - the shared programme-loader used by every
+  agent (and by ``@cyber_tool(scope_filter=...)``) that needs the
+  parsed ``Programme`` to reason against. Reads from
+  ``<run_dir>/programme.json`` - the snapshot the Programme Manager's
+  ``Save Selected Programme`` tool writes at the top of every run.
+  No H1 API call: the workspace is the authoritative source once a
+  programme has been selected.
 """
 
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
+import runtime
 from models import RunFile, RunFileContent
 from models.attack import AttackPlan
 from models.h1 import Programme
 from squad import cyber_tool
-from tools import http, workspace
-from tools.h1_api import h1
+from tools import workspace
 from tools.research_tools import attack_plan_path, load_attack_plan
 
 
-def load_programme(programme_handle: str | None) -> Programme:
-    """Fetch and parse the Programme for the current run.
+def current_programme() -> Programme:
+    """Return the Programme selected for the current run.
 
-    Centralised here (rather than duplicated as a private helper in
-    each agent's package) because the programme is workspace-level
-    state - every agent that needs to scope-check against the
-    selected programme calls this. ``programme_handle`` is required:
-    a None / empty handle is a hard error rather than a silent fall-
-    through to the run directory's metadata, because the scope guard
-    needs the parsed ``Programme`` model and the H1 API is the
-    authoritative source for it.
+    Reads ``<run_dir>/programme.json`` - written by the Programme
+    Manager's ``Save Selected Programme`` tool at run start
+    (``squad/programme_manager/__init__.py``). Every downstream agent
+    and every ``@cyber_tool(scope_filter=...)`` wrapper sources its
+    Programme through this function rather than hitting the H1 API
+    again: the workspace snapshot is the contract.
+
+    Raises ``FileNotFoundError`` if the file is missing - that means
+    the PM has not run yet, and any caller reaching this code path is
+    out of pipeline order.
     """
-    if not programme_handle:
-        raise ValueError("programme_handle is required")
-    http.set_programme(programme_handle)
-    policy = h1.get_programme_policy(programme_handle)
-    scope = h1.get_structured_scope(programme_handle)
-    return h1.parse_programme(policy["data"], scope)
+    path = runtime.run_dir() / "programme.json"
+    return Programme.model_validate_json(path.read_text(encoding="utf-8"))
 
 
 class _ListRunFilesArgs(BaseModel):

--- a/tests/test_osint_args_schemas.py
+++ b/tests/test_osint_args_schemas.py
@@ -205,25 +205,23 @@ class TestSchemaAcceptReject:
         _HistoricalUrlsArgs.model_validate({"domain": apex})
 
     def test_probe_hostnames_accepts_victim_hostname(self, victim_url: str) -> None:
-        """Probe Hostnames takes a list of hostnames plus the programme handle."""
-        _ProbeHostnamesArgs.model_validate(
-            {
-                "hostnames": [urlparse(victim_url).hostname],
-                "programme_handle": "example",
-            }
-        )
+        """Probe Hostnames takes a list of hostnames - no programme handle.
+
+        The wrapper-level ``scope_filter`` sources the Programme from
+        the workspace (``current_programme()`` -> ``programme.json``),
+        so the schema does not require a per-call handle.
+        """
+        _ProbeHostnamesArgs.model_validate({"hostnames": [urlparse(victim_url).hostname]})
 
     def test_detect_takeover_candidates_accepts_bystander_hostname(
         self, bystander_url: str
     ) -> None:
         """Detect Takeover Candidates models the case where a CNAME dangles to a
         bystander - the ``bystander_url`` fixture is the conventional handle
-        for an out-of-scope target."""
+        for an out-of-scope target. The wrapper-level scope filter drops
+        the bystander before any DNS traffic fires."""
         _DetectTakeoverCandidatesArgs.model_validate(
-            {
-                "hostnames": [urlparse(bystander_url).hostname],
-                "programme_handle": "example",
-            }
+            {"hostnames": [urlparse(bystander_url).hostname]}
         )
 
     def test_annotate_host_accepts_victim_hostname(self, victim_url: str) -> None:
@@ -258,8 +256,8 @@ class TestSchemaAcceptReject:
             _CertTransparencyArgs,  # domain required
             _HistoricalUrlsArgs,  # domain required
             _LlmDetectionArgs,  # endpoints required
-            _ProbeHostnamesArgs,  # hostnames + programme_handle required
-            _DetectTakeoverCandidatesArgs,  # hostnames + programme_handle required
+            _ProbeHostnamesArgs,  # hostnames required (scope_filter sources Programme)
+            _DetectTakeoverCandidatesArgs,  # hostnames required (scope_filter sources Programme)
             _OsintLookupCweArgs,  # query required
             _OsintLookupOwaspArgs,  # query required
             _AnnotateHostArgs,  # hostname / role / priority / notes / programme_handle required
@@ -270,14 +268,6 @@ class TestSchemaAcceptReject:
         """At least one required field is missing: model_validate must fail."""
         with pytest.raises(ValidationError):
             schema_cls.model_validate({})
-
-    def test_probe_hostnames_requires_both_hostnames_and_handle(self, victim_url: str) -> None:
-        """Both hostnames and programme_handle are required - one alone fails."""
-        host = urlparse(victim_url).hostname
-        with pytest.raises(ValidationError):
-            _ProbeHostnamesArgs.model_validate({"hostnames": [host]})
-        with pytest.raises(ValidationError):
-            _ProbeHostnamesArgs.model_validate({"programme_handle": "example"})
 
     def test_annotate_host_requires_core_fields(self, victim_url: str) -> None:
         """hostname / role / priority / notes / programme_handle are all required."""
@@ -313,18 +303,8 @@ class TestSchemaAcceptReject:
             (_CertTransparencyArgs, "domain", f"https://{host}", {}),
             (_HistoricalUrlsArgs, "domain", f"{host}:8080", {}),
             (_ReconOpenPortsArgs, "host", f"{host}/path", {}),
-            (
-                _ProbeHostnamesArgs,
-                "hostnames",
-                [f"https://{host}"],
-                {"programme_handle": "example"},
-            ),
-            (
-                _DetectTakeoverCandidatesArgs,
-                "hostnames",
-                [f"{host}:9000"],
-                {"programme_handle": "example"},
-            ),
+            (_ProbeHostnamesArgs, "hostnames", [f"https://{host}"], {}),
+            (_DetectTakeoverCandidatesArgs, "hostnames", [f"{host}:9000"], {}),
         ]
         for schema_cls, field, value, base in cases:
             with pytest.raises(ValidationError):

--- a/tests/test_squad_osint_analyst.py
+++ b/tests/test_squad_osint_analyst.py
@@ -40,14 +40,18 @@ class TestOsintAnalystTools:
 
     @staticmethod
     def _patch_programme(programme):
+        """Stub ``current_programme()`` at every site that imports it.
+
+        The wrapper-level ``scope_filter`` looks up
+        ``squad.workspace_tools.current_programme`` at call time (lazy
+        import in the decorator closure), so patching that name covers
+        the active-probe tools. The curation tools do a module-load
+        ``from squad.workspace_tools import current_programme``, so
+        their local alias has to be patched directly.
+        """
         return [
-            patch("squad.workspace_tools.http.set_programme"),
-            patch(
-                "squad.workspace_tools.h1.get_programme_policy",
-                return_value={"data": {}},
-            ),
-            patch("squad.workspace_tools.h1.get_structured_scope", return_value={}),
-            patch("squad.workspace_tools.h1.parse_programme", return_value=programme),
+            patch("squad.workspace_tools.current_programme", return_value=programme),
+            patch("squad.osint_analyst.curation.current_programme", return_value=programme),
         ]
 
     def test_annotate_host_tool_writes_insight_and_returns_validation(
@@ -177,13 +181,17 @@ class TestOsintAnalystTools:
                 p.stop()
 
     def test_probe_hostnames_tool(self, programme, endpoint) -> None:
+        """Happy path: in-scope hostname passes the wrapper's scope filter,
+        the body fires, the endpoint is returned.
+
+        Exercises the real ``filter_in_scope`` against the fixture
+        programme (in-scope: ``example.com`` + ``*.example.com``) -
+        ``api.example.com`` matches the wildcard, so the wrapper hands
+        the body the cleaned hostname.
+        """
         from squad.osint_analyst import probe_hostnames_tool
 
         patches = self._patch_programme(programme) + [
-            patch(
-                "squad.osint_analyst.discovery.filter_in_scope_impl",
-                return_value=["api.example.com"],
-            ),
             patch(
                 "squad.osint_analyst.discovery.probe_endpoints_impl",
                 return_value=[endpoint],
@@ -192,9 +200,7 @@ class TestOsintAnalystTools:
         for p in patches:
             p.start()
         try:
-            result = probe_hostnames_tool.func(
-                ["api.example.com"], programme_handle="test-programme"
-            )
+            result = probe_hostnames_tool.func(["api.example.com"])
         finally:
             for p in reversed(patches):
                 p.stop()
@@ -203,11 +209,21 @@ class TestOsintAnalystTools:
         assert result[0].url == endpoint.url
 
     def test_probe_hostnames_tool_empty_list(self) -> None:
+        """Empty input short-circuits in the body without touching the
+        workspace - no ``current_programme()`` lookup, no run dir read."""
         from squad.osint_analyst import probe_hostnames_tool
 
-        assert probe_hostnames_tool.func([], programme_handle="test-programme") == []
+        assert probe_hostnames_tool.func([]) == []
 
     def test_probe_hostnames_tool_drops_out_of_scope(self, programme, bystander_url) -> None:
+        """Out-of-scope hostnames are dropped by the wrapper before the body fires.
+
+        Asserts on the real scope-guard path: the fixture programme's
+        structured scope (``example.com`` + ``*.example.com``) does not
+        cover ``bystander.example.org``, so the wrapper's
+        ``scope_filter`` empties the list and ``probe_endpoints_impl``
+        is never called.
+        """
         from urllib.parse import urlparse
 
         from squad.osint_analyst import probe_hostnames_tool
@@ -215,16 +231,12 @@ class TestOsintAnalystTools:
         oos_host = urlparse(bystander_url).hostname
         mprobe = MagicMock()
         patches = self._patch_programme(programme) + [
-            patch(
-                "squad.osint_analyst.discovery.filter_in_scope_impl",
-                return_value=[],
-            ),
             patch("squad.osint_analyst.discovery.probe_endpoints_impl", mprobe),
         ]
         for p in patches:
             p.start()
         try:
-            result = probe_hostnames_tool.func([oos_host], programme_handle="test-programme")
+            result = probe_hostnames_tool.func([oos_host])
         finally:
             for p in reversed(patches):
                 p.stop()
@@ -244,10 +256,6 @@ class TestOsintAnalystTools:
         )
         patches = self._patch_programme(programme) + [
             patch(
-                "squad.osint_analyst.discovery.filter_in_scope_impl",
-                return_value=["legacy.example.com"],
-            ),
-            patch(
                 "squad.osint_analyst.discovery.detect_takeover_candidates",
                 return_value=[candidate],
             ),
@@ -255,9 +263,7 @@ class TestOsintAnalystTools:
         for p in patches:
             p.start()
         try:
-            result = detect_takeover_candidates_tool.func(
-                ["legacy.example.com"], programme_handle="test-programme"
-            )
+            result = detect_takeover_candidates_tool.func(["legacy.example.com"])
         finally:
             for p in reversed(patches):
                 p.stop()
@@ -268,11 +274,14 @@ class TestOsintAnalystTools:
     def test_detect_takeover_candidates_tool_empty(self) -> None:
         from squad.osint_analyst import detect_takeover_candidates_tool
 
-        assert detect_takeover_candidates_tool.func([], programme_handle="test-programme") == []
+        assert detect_takeover_candidates_tool.func([]) == []
 
     def test_detect_takeover_candidates_tool_drops_out_of_scope(
         self, programme, bystander_url
     ) -> None:
+        """Same scope-guard contract as ``test_probe_hostnames_tool_drops_out_of_scope``,
+        on the DNS side: the wrapper drops the out-of-scope hostname
+        before any DNS traffic fires."""
         from urllib.parse import urlparse
 
         from squad.osint_analyst import detect_takeover_candidates_tool
@@ -280,18 +289,12 @@ class TestOsintAnalystTools:
         oos_host = urlparse(bystander_url).hostname
         mdetect = MagicMock()
         patches = self._patch_programme(programme) + [
-            patch(
-                "squad.osint_analyst.discovery.filter_in_scope_impl",
-                return_value=[],
-            ),
             patch("squad.osint_analyst.discovery.detect_takeover_candidates", mdetect),
         ]
         for p in patches:
             p.start()
         try:
-            result = detect_takeover_candidates_tool.func(
-                [oos_host], programme_handle="test-programme"
-            )
+            result = detect_takeover_candidates_tool.func([oos_host])
         finally:
             for p in reversed(patches):
                 p.stop()

--- a/tests/test_squad_vulnerability_researcher.py
+++ b/tests/test_squad_vulnerability_researcher.py
@@ -309,15 +309,16 @@ class TestVulnerabilityResearcherTools:
 
     @staticmethod
     def _patch_programme(programme):
+        """Stub ``current_programme()`` where the VR triage module imports it.
+
+        Triage does a module-load
+        ``from squad.workspace_tools import current_programme``, so the
+        local alias in ``squad.vulnerability_researcher.triage`` is the
+        one that needs patching - not the source module.
+        """
         return [
-            patch("squad.workspace_tools.http.set_programme"),
             patch(
-                "squad.workspace_tools.h1.get_programme_policy",
-                return_value={"data": {}},
-            ),
-            patch("squad.workspace_tools.h1.get_structured_scope", return_value={}),
-            patch(
-                "squad.workspace_tools.h1.parse_programme",
+                "squad.vulnerability_researcher.triage.current_programme",
                 return_value=programme,
             ),
         ]

--- a/tests/test_squad_workspace_tools.py
+++ b/tests/test_squad_workspace_tools.py
@@ -1,7 +1,8 @@
 """
 tests/test_squad_workspace_tools.py - exercise the shared workspace @tool
 wrappers (``read_run_filelist_tool`` / ``read_run_file_tool`` /
-``read_attack_plan_tool``).
+``read_attack_plan_tool``) plus the ``current_programme()`` reader and the
+``@cyber_tool(scope_filter=...)`` mechanism that builds on it.
 
 The wrappers are thin: unmarshal JSON, call into tools/workspace helpers,
 serialise the result. Coverage here is regression coverage of the wrapping
@@ -71,6 +72,108 @@ class TestSharedWorkspaceTools:
         with patch("tools.research_tools.runtime.run_dir", return_value=tmp_path):
             with pytest.raises(FileNotFoundError, match="attack plan not found"):
                 read_attack_plan_tool.func()
+
+
+class TestCurrentProgramme:
+    """``current_programme()`` reads the PM's run-dir snapshot.
+
+    The PM's Save Selected Programme writes ``programme.json`` to the
+    run directory at run start. Every downstream agent and every
+    ``@cyber_tool(scope_filter=...)`` wrapper sources its Programme
+    through ``current_programme()``; no second H1 API call.
+    """
+
+    def test_returns_programme_from_run_dir(self, programme, tmp_path) -> None:
+        from squad.workspace_tools import current_programme
+
+        (tmp_path / "programme.json").write_text(programme.model_dump_json(), encoding="utf-8")
+        with patch("runtime.run_dir", return_value=tmp_path):
+            result = current_programme()
+        assert result.handle == programme.handle
+        assert result.in_scope == programme.in_scope
+
+    def test_raises_when_programme_json_missing(self, tmp_path) -> None:
+        from squad.workspace_tools import current_programme
+
+        with patch("runtime.run_dir", return_value=tmp_path):
+            with pytest.raises(FileNotFoundError):
+                current_programme()
+
+
+class TestCyberToolScopeFilter:
+    """``@cyber_tool(scope_filter=(field, fn))`` runs the filter before the body.
+
+    Closes the wrapper-level scope-guard contract: every "agent picked
+    a target, run a scan / attack against it" tool can declare its
+    field + filter once, and the wrapper applies the guard exactly the
+    same way for every consumer. Tested against a minimal stub body
+    here; the OSINT-Analyst-side exercise of the same mechanism lives
+    in ``tests/test_squad_osint_analyst.py``.
+    """
+
+    def test_filter_runs_before_body(self, programme, tmp_path) -> None:
+        """``filter_fn(values, current_programme())`` rewrites the field's
+        value before the body sees it."""
+        from pydantic import BaseModel, Field
+
+        from models.h1 import Programme
+        from squad import cyber_tool
+
+        seen_values: list[list[str]] = []
+
+        class _StubArgs(BaseModel):
+            targets: list[str] = Field(description="Targets the wrapper filters.")
+
+        def _keep_in_scope(values: list[str], prog: Programme) -> list[str]:
+            assert prog.handle == programme.handle
+            return [v for v in values if v.endswith(".example.com")]
+
+        @cyber_tool(
+            "Stub Scope-Guarded Tool",
+            args_schema=_StubArgs,
+            scope_filter=("targets", _keep_in_scope),
+        )
+        def stub_tool(targets: list[str]) -> list[str]:
+            """Stub body that records what it was handed and returns it."""
+            seen_values.append(targets)
+            return targets
+
+        (tmp_path / "programme.json").write_text(programme.model_dump_json(), encoding="utf-8")
+        with patch("runtime.run_dir", return_value=tmp_path):
+            result = stub_tool.func(targets=["api.example.com", "bystander.example.org"])
+
+        assert result == ["api.example.com"]
+        assert seen_values == [["api.example.com"]]
+
+    def test_empty_input_skips_programme_lookup(self) -> None:
+        """An empty field value short-circuits the wrapper - no ``current_programme()``
+        lookup, no run-dir read, body receives the empty list verbatim."""
+        from pydantic import BaseModel, Field
+
+        from squad import cyber_tool
+
+        class _StubArgs(BaseModel):
+            targets: list[str] = Field(description="Targets the wrapper filters.")
+
+        filter_calls: list[object] = []
+
+        def _filter(values: list[str], prog: object) -> list[str]:
+            filter_calls.append((values, prog))
+            return values
+
+        @cyber_tool(
+            "Stub Empty-Skip Tool",
+            args_schema=_StubArgs,
+            scope_filter=("targets", _filter),
+        )
+        def stub_tool(targets: list[str]) -> list[str]:
+            """Stub body that returns the input verbatim."""
+            return targets
+
+        # No ``runtime.run_dir`` patch is required - the wrapper must
+        # not reach for the workspace when the field is empty.
+        assert stub_tool.func(targets=[]) == []
+        assert filter_calls == []
 
 
 # Tool-name -> explicit schema class. The workspace wrappers are shared


### PR DESCRIPTION
## Summary

Closes the design half of #153 that survives once #156 absorbs the broader `programme_handle` dedupe across the squad. Every "agent picked a target, run a scan / attack against it" tool can now declare its scope guard on the decorator instead of repeating the dance in every body.

- **Mechanism** (`squad/__init__.py`): `@cyber_tool` takes an optional `scope_filter=(field_name, filter_fn)`. When set, the wrapper validates args via `args_schema`, looks up the named field, and - if non-empty - calls `filter_fn(values, current_programme())` and rewrites the field before the body runs. Positional and keyword call sites are both honoured via `inspect.signature.bind_partial`; the `current_programme` lookup is lazy to dodge the `squad.workspace_tools` -> `squad` import cycle.
- **Loader** (`squad/workspace_tools.py`): `load_programme(programme_handle)` (which hit the H1 API every call) replaced by `current_programme()` which reads `<run_dir>/programme.json` - the snapshot the PM's `Save Selected Programme` already writes at run start. No more redundant H1 calls; the workspace is the contract.
- **First application** (`squad/osint_analyst/discovery.py`): `probe_hostnames_tool` and `detect_takeover_candidates_tool` use `scope_filter=("hostnames", _normalise_and_filter_hostnames)`. `programme_handle` dropped from both args_schemas and signatures (per #153 acceptance criteria). The shared helper lives at module scope so both wrappers normalise + filter exactly once.
- **Pending #156**: the other five `load_programme()` callers (`annotate_host_tool`, `finalise_recon_tool`, `assess_finding_tool`, `finalise_triage_tool`) switch to `current_programme()` in their bodies and carry a `FIXME(#156)` on the now-unused `programme_handle` parameter. #156 is the PR that drops the field from their args_schemas in one sweep.
- **Skill**: `.claude/skills/cybersquad-tool/SKILL.md` gains a "Scope guards belong on the wrapper" section with the canonical shape, plus two new anti-patterns (inline scope dance in a tool body; `programme_handle` field on schemas where it duplicates workspace state).

## Design notes

- `current_programme()` is no-arg by design (per discussion on #153 - the run dir already implies the programme via `runtime.programme_handle`). Sourcing from `<run_dir>/programme.json` rather than `sweep.json` keeps recon-finalisation orthogonal to scope guards.
- The mechanism is generic, but only the two OSINT probes that already had an inline scope dance are converted here. The bigger "tools that take a `recon_path` should take typed picks instead" surface (which the wrapper enables) is deliberately deferred to a follow-up - the parameter-shape refactor is a separate slice from introducing the scope guard.
- The PT cloud pre-flight gate is left to #156's third bullet - it has a different shape (refuses rather than filters) and the same wrapper can grow that pattern once the filter pattern is bedded in.

## Test plan

- [x] `ruff check .` + `ruff format --check .` clean
- [x] `mypy . --ignore-missing-imports` clean (179 source files)
- [x] `pylint .` at 9.90/10 (floor 9.85); no new R0913 / R0917
- [x] `pytest -m unit --cov --cov-report=term-missing`: 1536 passing, 93.43% combined line + branch coverage (floor 90%)
- [x] `bandit -c pyproject.toml -r . -q` - only pre-existing nosec warning
- [x] New `TestCurrentProgramme` covers the run-dir read path + the missing-file `FileNotFoundError` branch
- [x] New `TestCyberToolScopeFilter` covers the filter-runs-before-body path + the empty-input short-circuit (asserts `current_programme()` is not reached)
- [x] OSINT probe "drops out of scope" tests now exercise the real `filter_in_scope` against the fixture programme end-to-end (no more closure-captured mocks)

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZtVnw7gfEcLPZKtmsTqnE)_