### PR TITLE
fix(recon): pass hostnames (not URLs) from run_recon to nmap

### DIFF
--- a/tests/tools/recon/test_recon.py
+++ b/tests/tools/recon/test_recon.py
@@ -86,6 +86,32 @@ class TestRunRecon:
         mock_compose.assert_called_once_with(["8.8.8.8"])
         assert attack_graph.ip_assets == [ip_asset]
 
+    def test_port_scan_receives_hostnames_not_urls(self, programme, target_apex):
+        # Regression: nmap scans hosts, not URLs. run_recon must extract the
+        # hostname from each live Endpoint.url before handing it to
+        # port_scan - feeding the full ``https://.../`` URL makes nmap fail
+        # to resolve the target and keys open_ports by URL instead of host.
+        from tools.recon import run_recon
+
+        live = Endpoint(url=f"https://api.{target_apex}/admin", status_code=200)
+        dead = Endpoint(url=f"https://down.{target_apex}/", status_code=503)
+        with (
+            patch("tools.recon.enumerate_subdomains", return_value=[f"api.{target_apex}"]),
+            patch("tools.recon.probe_endpoints", return_value=[live, dead]),
+            patch("tools.recon.port_scan", return_value={}) as mock_port_scan,
+            patch("tools.recon.discover_paths", return_value=[]),
+            patch("tools.recon.check_tls", return_value=[]),
+            patch("tools.recon.check_dns_email_security", return_value=[]),
+            patch("tools.recon.run_traceroute", return_value={}),
+            patch("tools.recon.resolve_records", return_value=[]),
+            patch("tools.recon.compose_ip_assets", return_value=[]),
+        ):
+            run_recon(programme)
+
+        # Bare hostname extracted (scheme + path stripped); the 5xx endpoint
+        # is filtered out, so only the live host reaches nmap.
+        mock_port_scan.assert_called_once_with([f"api.{target_apex}"])
+
     def test_promotes_in_scope_tls_sans_to_subdomains(self, programme, target_apex):
         # When httpx runs in WEB_INVENTORY mode, Endpoint.tls_sans carries
         # the SAN-leaked hostnames. run_recon promotes the ones the scope

--- a/tools/recon/__init__.py
+++ b/tools/recon/__init__.py
@@ -137,7 +137,16 @@ def run_recon(programme: Programme) -> AttackGraph:
         promoted = filter_in_scope(san_candidates, programme)
         in_scope_hosts = list(dict.fromkeys(in_scope_hosts + promoted))
 
-    live_hosts = [ep.url for ep in endpoints if ep.status_code and ep.status_code < 500]
+    # nmap scans hosts, not URLs - extract the hostname from each live
+    # endpoint (``host_of`` returns "" for a hostless URL, which the
+    # ``if host`` clause drops) so ``open_ports`` keys by FQDN, matching
+    # the host-keyed lookups the ``Recon Open Ports`` slicer does downstream.
+    live_hosts = [
+        host
+        for ep in endpoints
+        if ep.status_code and ep.status_code < 500
+        if (host := host_of(ep.url))
+    ]
     open_ports = port_scan(live_hosts[:20])
 
     discovered = discover_paths(_dirfuzz_targets(endpoints, seed_domains))

--- a/tools/recon/nmap/scanner.py
+++ b/tools/recon/nmap/scanner.py
@@ -119,7 +119,7 @@ def nmap_scan(
     return NmapScanResult(mode=mode, hosts=parsed, evidence_path=evidence_rel)
 
 
-def port_scan(hosts: list[FQDN]) -> dict[str, list[int]]:
+def port_scan(hosts: list[FQDN]) -> dict[FQDN, list[int]]:
     """Backwards-compatible thin shim over ``nmap_scan``.
 
     Calls ``nmap_scan(mode=QUICK_PORTS, persist_evidence=False)`` and
@@ -133,7 +133,7 @@ def port_scan(hosts: list[FQDN]) -> dict[str, list[int]]:
         scripts=NmapScripts.NONE,
         persist_evidence=False,
     )
-    out: dict[str, list[int]] = {host: [] for host in hosts}
+    out: dict[FQDN, list[int]] = {host: [] for host in hosts}
     for host_result in result.hosts:
         open_ports = [s.port for s in host_result.services if s.state == "open"]
         out[host_result.host] = open_ports

--- a/tools/recon/nmap/scanner.py
+++ b/tools/recon/nmap/scanner.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 import runtime
 from config import config
+from models import FQDN
 from models.scanner import NmapBanner, NmapMode, NmapScanResult, NmapScripts
 from tools._helpers import _require_binary, _run
 from tools.recon.nmap.flags import _assemble_flags
@@ -52,7 +53,7 @@ def _resolve_evidence_path(filename: str) -> Path | None:
 
 
 def nmap_scan(
-    hosts: list[str],
+    hosts: list[FQDN],
     mode: NmapMode = NmapMode.QUICK_PORTS,
     banner: NmapBanner = NmapBanner.NONE,
     scripts: NmapScripts = NmapScripts.NONE,
@@ -118,7 +119,7 @@ def nmap_scan(
     return NmapScanResult(mode=mode, hosts=parsed, evidence_path=evidence_rel)
 
 
-def port_scan(hosts: list[str]) -> dict[str, list[int]]:
+def port_scan(hosts: list[FQDN]) -> dict[str, list[int]]:
     """Backwards-compatible thin shim over ``nmap_scan``.
 
     Calls ``nmap_scan(mode=QUICK_PORTS, persist_evidence=False)`` and


### PR DESCRIPTION
## What

`run_recon` built `live_hosts` from `Endpoint.url` — full `https://host/path` URLs — and handed them to `port_scan` → nmap. nmap scans hosts / IPs, not URLs, so it failed to resolve the URL targets: the Initial Sweep's port scan returned nothing useful and `open_ports` ended up keyed by URL instead of host, breaking the host-keyed lookups the `Recon Open Ports` slicer does downstream. (`tools/recon/__init__.py:153` already used the correct `urlparse(ep.url).hostname` idiom elsewhere — line 140 just didn't.)

## How

- Extract the hostname via the existing `host_of()` helper before `port_scan`, dropping hostless URLs and keeping the live-endpoint (`< 500`) filter.
- Tighten `nmap_scan` / `port_scan` signatures from `list[str]` to `list[FQDN]` to document that nmap takes concrete hosts — the type that would have surfaced this mismatch at the call site.

## Why this surfaced

Came out of an audit of the OSINT Analyst tool surface for loose `list[str]` host inputs (originally chasing whether wildcard / SAN entries like `*.example.com` could reach a scanner). The agent-facing `@cyber_tool` boundary turned out to be correctly typed already — every host field is `FQDN`-typed (which rejects wildcards), and wildcards are resolved upstream by subfinder, not by the type system. The only genuine defect was this wrong-*value* (URL vs host) bug in the legacy sweep path, not a wrong-*type* at the boundary.

## Tests

- New regression test `test_port_scan_receives_hostnames_not_urls` asserts `port_scan` receives the bare hostname (scheme + path stripped) and that 5xx endpoints are filtered out. Verified it fails on the pre-fix code (`['https://api.example.com/admin']`) and passes on the fix.
- `ruff`, `mypy`, and the recon / nmap / OSINT-analyst test suites all green.

## Scope

Single concern (nmap host-input correctness). Not in scope: the async fan-out work (tracked in #183) or the `#176` / `#180` closures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnQfpk4c3RrmXpLWkpjXVo)_