### PR TITLE
feat(crew): wire output_log_file to reports/<run_id>/crew.log (#167)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,4 @@ CYBERSQUAD_HUMAN_INPUT=true  # set false for unattended runs
 
 # -- Debug ----------------------------------------------------
 VERBOSE=false
+# CYBERSQUAD_OUTPUT_LOG=true   # write CrewAI's event stream to reports/<run_id>/crew.log (default on)

--- a/config.py
+++ b/config.py
@@ -300,6 +300,14 @@ class AppConfig:
     # can reach the operator directly instead of banning the IP. See #46.
     contact_email: str = field(default_factory=lambda: os.environ["CYBERSQUAD_CONTACT_EMAIL"])
     reports_dir: str = field(default_factory=lambda: os.getenv("REPORTS_DIR", "./reports"))
+    # CrewAI writes its task / tool / event stream to this log for post-hoc
+    # inspection (see #167). build_crew() resolves it to
+    # {reports_dir}/{run_id}/crew.log - alongside metrics.json - so the log
+    # and the run it describes archive as a unit. On by default; flip off
+    # with CYBERSQUAD_OUTPUT_LOG=false.
+    output_log_enabled: bool = field(
+        default_factory=lambda: os.getenv("CYBERSQUAD_OUTPUT_LOG", "true").lower() == "true"
+    )
     verbose: bool = field(default_factory=lambda: os.getenv("VERBOSE", "false").lower() == "true")
     human_input: bool = field(
         default_factory=lambda: os.getenv("CYBERSQUAD_HUMAN_INPUT", "true").lower() == "true"

--- a/crew.py
+++ b/crew.py
@@ -12,6 +12,7 @@ from crewai import LLM, Agent, Crew, Process, Task
 from crewai.agents.agent_builder.base_agent import BaseAgent
 from crewai.memory import Memory
 
+import runtime
 from config import config
 from mcp_servers import ProvisionedMCPTools
 from squad import SQUAD_SKILLS_DIR, SquadMember, build_agent
@@ -68,6 +69,33 @@ def _build_long_term_memory() -> Memory | None:
     return Memory(storage="lancedb", root_scope="/long_term")
 
 
+def _resolve_output_log_file() -> str | None:
+    """Resolve the CrewAI event-stream log path for this run, or None (#167).
+
+    Returns ``{reports_dir}/{run_id}/crew.log`` - alongside ``metrics.json``
+    (see ``tools.metrics.save_metrics``) so the log and the run it describes
+    archive as a unit. ``runtime.run_id`` is bound by ``main.py`` before
+    ``build_crew()``; the ``--dry-run`` path leaves it empty, so we return
+    None there (and when ``CYBERSQUAD_OUTPUT_LOG`` is off) rather than wiring
+    a log for a crew that never executes.
+
+    The parent directory is created eagerly: CrewAI's ``FileHandler`` appends
+    without creating it, and the first write lands at the first task's start -
+    before any tool has made the run folder.
+
+    We key on ``run_id`` alone, not ``runtime.run_dir()`` (which also needs
+    ``programme_handle``). The handle is bound mid-run by the PM's Save
+    Selected Programme - long after this resolves, and after the first log
+    line is already written - so the per-programme run dir is unavailable
+    here by construction.
+    """
+    if not config.output_log_enabled or not runtime.run_id:
+        return None
+    log_path = Path(config.reports_dir) / runtime.run_id / "crew.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    return str(log_path)
+
+
 def build_crew(
     verbose: bool | None = None,
     mcp_tools: ProvisionedMCPTools | None = None,
@@ -108,4 +136,5 @@ def build_crew(
         memory=memory,
         embedder=None,
         skills=[SQUAD_SKILLS_DIR] if SQUAD_SKILLS_DIR.is_dir() else None,
+        output_log_file=_resolve_output_log_file(),
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -205,3 +205,17 @@ class TestAppConfig:
 
         c = AppConfig()
         assert c.verbose is False
+
+    def test_output_log_enabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("CYBERSQUAD_OUTPUT_LOG", raising=False)
+        from config import AppConfig
+
+        c = AppConfig()
+        assert c.output_log_enabled is True
+
+    def test_output_log_disabled_via_env(self, monkeypatch):
+        monkeypatch.setenv("CYBERSQUAD_OUTPUT_LOG", "false")
+        from config import AppConfig
+
+        c = AppConfig()
+        assert c.output_log_enabled is False

--- a/tests/test_crew.py
+++ b/tests/test_crew.py
@@ -75,3 +75,59 @@ class TestBuildCrewMCPDistribution:
         assert captured, "expected build_agent to be called for at least one member"
         for slug, extras in captured.items():
             assert extras == (fake_tool,), f"member {slug!r} did not receive the MCP tool"
+
+    def test_build_crew_forwards_resolved_output_log_file(self, monkeypatch):
+        """``build_crew`` passes ``_resolve_output_log_file()``'s value straight
+        through to ``Crew(output_log_file=...)`` (#167)."""
+        import crew
+
+        captured: dict[str, tuple] = {}
+        _wire_build_crew_mocks(monkeypatch, captured)
+        monkeypatch.setattr(crew, "_resolve_output_log_file", lambda: "/runs/r1/crew.log")
+
+        crew.build_crew()
+
+        _, kwargs = crew.Crew.call_args
+        assert kwargs["output_log_file"] == "/runs/r1/crew.log"
+
+
+class TestResolveOutputLogFile:
+    """``_resolve_output_log_file`` keys on ``run_id`` alone (not the
+    per-programme ``run_dir()``) so it resolves at ``build_crew()`` time, before
+    the PM binds ``programme_handle`` mid-run - see #167."""
+
+    def test_returns_run_scoped_path_and_creates_parent(self, monkeypatch, tmp_path):
+        import crew
+
+        monkeypatch.setattr(crew.config, "output_log_enabled", True)
+        monkeypatch.setattr(crew.config, "reports_dir", str(tmp_path))
+        monkeypatch.setattr("runtime.run_id", "20260531-000000-abc123")
+
+        result = crew._resolve_output_log_file()
+
+        expected = tmp_path / "20260531-000000-abc123" / "crew.log"
+        assert result == str(expected)
+        # Parent created eagerly: CrewAI's FileHandler appends without mkdir,
+        # and the first write lands before any tool makes the run folder.
+        assert expected.parent.is_dir()
+
+    def test_returns_none_when_disabled(self, monkeypatch, tmp_path):
+        import crew
+
+        monkeypatch.setattr(crew.config, "output_log_enabled", False)
+        monkeypatch.setattr(crew.config, "reports_dir", str(tmp_path))
+        monkeypatch.setattr("runtime.run_id", "run-1")
+
+        assert crew._resolve_output_log_file() is None
+        assert not (tmp_path / "run-1").exists()
+
+    def test_returns_none_when_no_run_bound(self, monkeypatch, tmp_path):
+        """Dry-run path: ``build_crew`` runs without ``bind_run_id``, so
+        ``runtime.run_id`` is empty and no log is wired."""
+        import crew
+
+        monkeypatch.setattr(crew.config, "output_log_enabled", True)
+        monkeypatch.setattr(crew.config, "reports_dir", str(tmp_path))
+        monkeypatch.setattr("runtime.run_id", "")
+
+        assert crew._resolve_output_log_file() is None


### PR DESCRIPTION
Closes #167.

`Crew(output_log_file=...)` writes CrewAI's task / tool / event stream to a single file per run for post-hoc inspection. We did not set it before, so runs left nothing behind beyond what individual tools wrote to the workspace.

## What changed

- **`config.py`**: new `AppConfig.output_log_enabled` knob (`CYBERSQUAD_OUTPUT_LOG`, default on), read via `default_factory=lambda` per `docs/contributing/adding-config.md`.
- **`crew.py`**: `_resolve_output_log_file()` returns `{reports_dir}/{run_id}/crew.log` and `mkdir`s the parent (CrewAI's `FileHandler` appends without creating it). Returns `None` on `--dry-run` / when disabled. Wired into `Crew(output_log_file=...)` in `build_crew()`.
- **`.env.example`**: documents the knob.
- **tests**: `test_config.py` (default-on / env-off) and `test_crew.py` (`_resolve_output_log_file` path + parent creation, disabled, no-run-bound; plus `build_crew` forwarding).

## Design note: location differs from the issue text

The issue asked for `<run_dir>/crew.log`, i.e. `runtime.run_dir()` = `programs/<handle>/<run_id>`. That is unbuildable as written:

- `output_log_file` is captured **eagerly** at `Crew` construction (a `model_validator` builds the `FileHandler`), which happens in `build_crew()`.
- At that point `programme_handle` is not bound - the PM binds it mid-run via `Save Selected Programme` - so `runtime.run_dir()` raises.
- Even deferring to first write does not help: the first log event is the PM task *start*, which fires *before* programme selection.

So the log keys on `run_id` alone and lands at `{reports_dir}/{run_id}/crew.log`, mirroring the existing `tools.metrics.save_metrics()` convention (`{reports_dir}/{run_id}/metrics.json`). The log and the run's metrics now sit together and archive as a unit. This was confirmed with the issue owner before implementation.

## Verification

Full CONTRIBUTING "Before you commit" stack run locally: ruff check, ruff format --check, mypy (no issues), pylint (only the pre-existing `too-many-instance-attributes` on `config.py`, untouched here), bandit, and `pytest -m unit` (1948 passed, coverage 96.18%; `crew.py` and `config.py` both 100%).

---
_Generated by [Claude Code](https://claude.ai/code/session_019Sj5Z3FsFBLLniy1RvSvvk)_