### PR TITLE
feat(tasks): guardrail the select -> recon handoff (#168)

### DIFF
--- a/.claude/skills/cybersquad-task/SKILL.md
+++ b/.claude/skills/cybersquad-task/SKILL.md
@@ -69,6 +69,27 @@ triage = build_task(
 
 Always pass `human_input=hi` where `hi = config.human_input` (set via the `CYBERSQUAD_HUMAN_INPUT` env var). Never hardcode `True` or `False` - the toggle exists so production runs can be unattended while interactive runs gate at each step.
 
+## Guardrails: validate a handoff before it derails downstream
+
+A CrewAI *function* guardrail is `(TaskOutput) -> tuple[bool, Any]`: return `(True, value)` to pass `value` to the next task, or `(False, error)` to feed `error` back to the agent, which re-runs the task up to `max_retries`. Use the **function** variant (plain Python against our typed artefacts), not the LLM-judge variant - our workspace outputs are typed models we can just construct, so there is no free-text judgement to delegate and no extra LLM spend.
+
+Canonical example: `squad/guardrails.py:validate_select_output`, guarding `select -> recon`.
+
+**Validate the workspace artefact, not `result.raw`.** Inter-agent handoff flows through workspace files (see the section above), so the thing that actually derails recon is a malformed `<run_dir>/programme.json`, not the agent's prose answer. `validate_select_output` therefore calls the same `current_programme()` recon will call - validating the exact artefact the next agent reads - and only passes `result.raw` *through* (as the `True` value) so the `context=` chain is unchanged. Keying a guardrail off `result.raw` instead would validate the agent's free-text, which is fragile (agents wrap JSON in prose / fences) and checks the wrong surface.
+
+Wire it through `build_task`, never a bare `Task(guardrail=...)`:
+
+```python
+select = build_task(
+    "select", PROGRAMME_MANAGER, agents["programme_manager"],
+    human_input=hi,
+    guardrail=validate_select_output,
+    max_retries=2,
+)
+```
+
+`build_task`'s `guardrail` / `max_retries` params default to `None` (CrewAI's own defaults), so un-guarded tasks are unchanged. Keep `max_retries` modest - guardrail failures should converge or fail loudly, not loop expensively. Unit-test the guardrail directly with the `make_task_output` fixture (`tests/fixtures/task_output.py`) plus the rundir-staging fixtures (`run_dir` / `programme_in_workspace`); see `tests/squad/test_guardrails.py`. Other handoff boundaries (`recon -> research`, ...) stay un-guarded until the pattern earns its keep there.
+
 ## Upstream alignment
 
 CrewAI's [crewAIInc/skills `design-task`](https://github.com/crewAIInc/skills/blob/main/skills/design-task/SKILL.md) is the canonical upstream best-practice for task design. Its strong recommendation is `output_pydantic` for structured handoff between tasks. Cybersquad deliberately diverges on that one point - see the "workspace files" section above. The rest of upstream `design-task` (single-purpose tasks, specific `expected_output`, function/LLM guardrails, conditional tasks, async, callbacks) we follow without exception.

--- a/.claude/skills/cybersquad-test-fixtures/SKILL.md
+++ b/.claude/skills/cybersquad-test-fixtures/SKILL.md
@@ -19,6 +19,7 @@ Use these fixtures rather than redefining local equivalents - duplicates drift, 
 | `tests/fixtures/findings.py` | `raw_finding_high` / `raw_finding_low` / `raw_finding_oos`, `verified_vuln`, `disclosure_report`, `attack_tree`, `attack_forest`; helpers `draft_report_kwargs(**overrides)` / `assess_finding_kwargs(**overrides)` (canonical `Draft Vulnerability Report` / `Assess Raw Finding` kwargs - the inner `Authored*` shape is at `["authored"]`; imported, not fixtures) |
 | `tests/fixtures/responses.py` | `make_response`, `clean_response_body` |
 | `tests/fixtures/tools.py` | `invoke_tool`, `reload_module` |
+| `tests/fixtures/task_output.py` | `make_task_output` |
 
 When adding a new fixture, put it in the matching module rather than re-opening `conftest.py` - that's the single rule that keeps the catalogue navigable.
 
@@ -50,6 +51,7 @@ When adding a new fixture, put it in the matching module rather than re-opening 
 | `clean_response_body` | An HTML body verified at setup time to contain no pentest probe marker - use for "no finding" cases. |
 | `invoke_tool` | Invoke a `@cyber_tool` wrapper through its args_schema (CrewAI's production path). Tests that exercise the `Target*` scope guard take this instead of `.func(...)` so the `AfterValidator` actually fires. |
 | `reload_module` | Wraps `importlib.reload` so tests can pick up env-var changes on module-level singletons. |
+| `make_task_output` | Factory for a real `crewai.TaskOutput` (leading positional `raw`; `description` / `agent` required by the model carry placeholders). The unit-test surface for *task guardrails*, whose signature is `(TaskOutput) -> (bool, Any)` - hands the guardrail the real type rather than a `MagicMock`. Pair with `run_dir` / `programme_in_workspace` when the guardrail validates a workspace artefact (e.g. `validate_select_output`). |
 
 ## Authoring a new in-scope fixture
 

--- a/squad/__init__.py
+++ b/squad/__init__.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Protocol, cast, runtime_checkable
+from typing import Any, Protocol, cast, runtime_checkable
 
 from crewai import LLM, Agent, Task
 from crewai.tools import BaseTool, tool
@@ -210,10 +210,21 @@ def build_task(
     agent: Agent,
     context: list[Task] | None = None,
     human_input: bool = False,
+    *,
+    guardrail: Callable[..., tuple[bool, Any]] | None = None,
+    max_retries: int | None = None,
 ) -> Task:
     """Create a Task from the member's task-specific prose files.
 
     Reads description and expected_output from ``<member.dir>/<task_name>/``.
+
+    ``guardrail`` is an optional CrewAI *function* guardrail
+    (``(TaskOutput) -> (bool, Any)``) that validates the task output and, on
+    failure, feeds the reason back to the agent for a retry. ``max_retries``
+    bounds those retries; pass it alongside a guardrail so failures converge or
+    fail loudly rather than looping. Both default to ``None`` (CrewAI's own
+    defaults), keeping un-guarded tasks byte-for-byte unchanged. See the
+    ``cybersquad-task`` skill's guardrails section and ``squad/guardrails.py``.
     """
     return Task(
         description=member.read(task_name, "description"),
@@ -221,6 +232,8 @@ def build_task(
         agent=agent,
         context=context or [],
         human_input=human_input,
+        guardrail=guardrail,
+        max_retries=max_retries,
     )
 
 

--- a/squad/guardrails.py
+++ b/squad/guardrails.py
@@ -1,0 +1,54 @@
+"""squad/guardrails.py - function guardrails on pipeline task handoffs.
+
+A CrewAI *function* guardrail has signature ``(TaskOutput) -> tuple[bool, Any]``:
+return ``(True, value)`` to pass ``value`` to the downstream task, or
+``(False, error)`` to feed ``error`` back to the agent, which re-runs the task
+up to its ``max_retries``. Function guardrails validate in plain Python against
+our typed workspace artefacts - no LLM judge, no extra LLM spend (the variant
+that earns its keep when the output is a typed artefact we already model).
+
+``validate_select_output`` guards the ``select -> recon`` handoff. The Programme
+Manager hands the selected programme to recon through the workspace artefact
+``<run_dir>/programme.json`` (written by its ``Save Selected Programme`` tool),
+not through its free-text answer - so the guardrail validates *that file*, the
+exact artefact recon's ``current_programme()`` will read, rather than the
+agent's raw response. A malformed or missing ``programme.json`` is caught here,
+at the boundary, instead of derailing recon downstream.
+"""
+
+from __future__ import annotations
+
+from crewai import TaskOutput
+from pydantic import ValidationError
+
+from squad.tools.workspace_tools import current_programme
+
+
+def validate_select_output(result: TaskOutput) -> tuple[bool, str]:
+    """Reject a ``select`` task that did not persist a valid ``programme.json``.
+
+    Passes when ``<run_dir>/programme.json`` exists and deserialises to a
+    ``Programme`` carrying a non-empty ``handle`` - the snapshot recon reads via
+    ``current_programme()``. On failure returns the reason so the agent can call
+    ``Save Selected Programme`` (or fix its selection) and retry. The agent's raw
+    answer is passed through unchanged on success so the ``context=`` chain to
+    recon is unaffected.
+    """
+    try:
+        programme = current_programme()
+    except (RuntimeError, FileNotFoundError):
+        return (
+            False,
+            "No programme.json was written to the run directory. Call "
+            "'Save Selected Programme' with your chosen handle so the selection "
+            "is persisted before you finish.",
+        )
+    except ValidationError as exc:
+        return (False, f"programme.json failed schema validation: {exc}")
+    if not programme.handle:
+        return (
+            False,
+            "The persisted programme.json has an empty handle; select a real "
+            "programme before finishing.",
+        )
+    return (True, result.raw)

--- a/tasks.py
+++ b/tasks.py
@@ -17,6 +17,7 @@ from crewai import Agent, Task
 from config import config
 from squad import build_task
 from squad.disclosure_coordinator import MEMBER as DISCLOSURE_COORDINATOR
+from squad.guardrails import validate_select_output
 from squad.osint_analyst import MEMBER as OSINT_ANALYST
 from squad.penetration_tester import MEMBER as PENETRATION_TESTER
 from squad.programme_manager import MEMBER as PROGRAMME_MANAGER
@@ -27,7 +28,14 @@ from squad.vulnerability_researcher import MEMBER as VULNERABILITY_RESEARCHER
 def build_tasks(agents: dict[str, Agent]) -> list[Task]:
     hi = config.human_input
 
-    select = build_task("select", PROGRAMME_MANAGER, agents["programme_manager"], human_input=hi)
+    select = build_task(
+        "select",
+        PROGRAMME_MANAGER,
+        agents["programme_manager"],
+        human_input=hi,
+        guardrail=validate_select_output,
+        max_retries=2,
+    )
 
     recon = build_task(
         "recon", OSINT_ANALYST, agents["osint_analyst"], context=[select], human_input=hi

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ The fixtures themselves live under ``tests/fixtures/`` by concern:
                 attack_tree, attack_forest
   responses.py  make_response, clean_response_body
   tools.py      invoke_tool, reload_module
+  task_output.py  make_task_output
 
 The ``pytest_plugins`` mechanism is the upstream-blessed way to wire
 fixture modules into the discovery path - documented at
@@ -48,6 +49,7 @@ pytest_plugins = [
     "tests.fixtures.findings",
     "tests.fixtures.responses",
     "tests.fixtures.tools",
+    "tests.fixtures.task_output",
 ]
 
 

--- a/tests/fixtures/task_output.py
+++ b/tests/fixtures/task_output.py
@@ -1,0 +1,47 @@
+"""TaskOutput fixture - the unit-test surface for task guardrails.
+
+A CrewAI *function* guardrail has signature ``(TaskOutput) -> (bool, Any)``, so
+a guardrail's unit test needs a real ``TaskOutput`` to call it with.
+``make_task_output`` builds one with sensible defaults, mirroring the
+``programme`` / ``dvwa_programme`` pattern of handing the test the real Pydantic
+type rather than a ``MagicMock`` with whatever attributes the test author
+thought to set - so the guardrail runs against the same shape CrewAI would hand
+it at runtime.
+
+Loaded via ``pytest_plugins`` in ``tests/conftest.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+from crewai import TaskOutput
+
+
+@pytest.fixture()
+def make_task_output() -> Callable[..., TaskOutput]:
+    """Factory for a ``TaskOutput`` shaped like a finished task's result.
+
+    Defaults cover the common guardrail-test case - only ``raw`` carries
+    meaning to a function guardrail, so it is the leading positional argument.
+    ``description`` and ``agent`` are required by ``TaskOutput`` and carry
+    placeholders, not because a guardrail reads them; override the placeholders
+    via keyword.
+    """
+
+    def _make(
+        raw: str = "",
+        *,
+        description: str = "select task",
+        agent: str = "Programme Manager",
+        expected_output: str = "a selected programme",
+    ) -> TaskOutput:
+        return TaskOutput(
+            description=description,
+            agent=agent,
+            expected_output=expected_output,
+            raw=raw,
+        )
+
+    return _make

--- a/tests/squad/test_guardrails.py
+++ b/tests/squad/test_guardrails.py
@@ -1,0 +1,65 @@
+"""Unit tests for squad.guardrails.validate_select_output.
+
+The guardrail validates the *workspace artefact* (``<run_dir>/programme.json``,
+the snapshot recon reads via ``current_programme()``), not the agent's raw
+answer - so these tests stage the rundir state (via the shared ``run_dir`` /
+``programme_in_workspace`` fixtures) and drive the guardrail with a real
+``TaskOutput`` from ``make_task_output``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squad.guardrails import validate_select_output
+
+pytestmark = pytest.mark.unit
+
+
+def test_passes_with_valid_programme_in_workspace(programme_in_workspace, make_task_output):
+    """A persisted, schema-valid programme.json passes and returns the raw through."""
+    result = make_task_output("Selected test-programme; see programme.json.")
+    ok, value = validate_select_output(result)
+    assert ok is True
+    assert value == "Selected test-programme; see programme.json."
+
+
+def test_rejects_missing_programme_json(run_dir, make_task_output):
+    """Rundir bound but no programme.json written -> reject, point at the save tool."""
+    ok, msg = validate_select_output(make_task_output("done"))
+    assert ok is False
+    assert "Save Selected Programme" in msg
+
+
+def test_rejects_when_run_dir_unbound(monkeypatch, make_task_output):
+    """No programme bound at all (run_dir() raises RuntimeError) -> reject."""
+    monkeypatch.setattr("runtime.programme_handle", "")
+    monkeypatch.setattr("runtime.run_id", "")
+    ok, msg = validate_select_output(make_task_output("done"))
+    assert ok is False
+    assert "Save Selected Programme" in msg
+
+
+def test_rejects_malformed_programme_json(run_dir, make_task_output):
+    """A programme.json that fails schema validation -> reject with the reason."""
+    (run_dir / "programme.json").write_text('{"handle": "x"}', encoding="utf-8")
+    ok, msg = validate_select_output(make_task_output("done"))
+    assert ok is False
+    assert "schema validation" in msg
+
+
+def test_rejects_empty_handle(programme, run_dir, make_task_output):
+    """A well-formed programme.json with an empty handle -> reject."""
+    blank = programme.model_copy(update={"handle": ""})
+    (run_dir / "programme.json").write_text(blank.model_dump_json(), encoding="utf-8")
+    ok, msg = validate_select_output(make_task_output("done"))
+    assert ok is False
+    assert "handle" in msg
+
+
+@pytest.mark.parametrize("raw", ["", "free-text briefing", '{"handle": "test-programme"}'])
+def test_passes_raw_unchanged(programme_in_workspace, make_task_output, raw):
+    """On success the second tuple element is the task's raw output, verbatim."""
+    ok, value = validate_select_output(make_task_output(raw))
+    assert ok is True
+    assert value == raw

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -40,12 +40,16 @@ class _FakeTask:
         agent: object,
         context: list | None = None,
         human_input: bool = False,
+        guardrail: object = None,
+        max_retries: int | None = None,
     ) -> None:
         self.description = description
         self.expected_output = expected_output
         self.agent = agent
         self.context = context or []
         self.human_input = human_input
+        self.guardrail = guardrail
+        self.max_retries = max_retries
 
 
 class TestSquadMemberRead:
@@ -111,6 +115,20 @@ class TestBuildTasks:
         assert triage.context == [pentest, research, select]
         assert write.context == [triage, select]
         assert submit.context == [write]
+
+    def test_select_task_wired_with_guardrail(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from squad.guardrails import validate_select_output
+
+        monkeypatch.setattr(squad, "Task", _FakeTask)
+        select, *_rest = build_tasks(self._agents())
+        assert select.guardrail is validate_select_output
+        assert select.max_retries == 2
+
+    def test_only_select_task_is_guarded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(squad, "Task", _FakeTask)
+        select, *rest = build_tasks(self._agents())
+        assert select.guardrail is not None
+        assert all(t.guardrail is None for t in rest)
 
     def test_human_input_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import importlib


### PR DESCRIPTION
Closes #168.

## What

Adds a CrewAI *function* guardrail on the `select` task so a malformed or
missing programme selection is caught and fed back to the Programme Manager
for a bounded retry, rather than silently derailing `recon` downstream.

## How

- **`squad/guardrails.py` (new)** - `validate_select_output(result)`.
  Validates the *persisted workspace artefact*, not `result.raw`: it calls the
  same `current_programme()` that `recon` will call, so it checks the exact
  `<run_dir>/programme.json` the next agent reads. Distinguishes the failure
  modes with actionable messages - no programme written (RuntimeError /
  FileNotFoundError), schema-invalid JSON (ValidationError), and empty handle.
  On success it passes `result.raw` through unchanged so the `context=` chain
  is byte-for-byte identical to today.
- **`squad/__init__.py`** - `build_task` gains keyword-only `guardrail` and
  `max_retries` passthrough, both defaulting to `None` (CrewAI's own defaults),
  so every un-guarded task is unchanged.
- **`tasks.py`** - wires `select` with `guardrail=validate_select_output,
  max_retries=2`. No other handoff is guarded - the pattern earns its keep at
  `select -> recon` first.

## Tests

- **`tests/fixtures/task_output.py` (new)** - `make_task_output` factory,
  registered in `tests/conftest.py`. Hands the guardrail a real
  `crewai.TaskOutput` rather than a MagicMock.
- **`tests/squad/test_guardrails.py` (new)** - pass, missing programme.json,
  unbound run_dir, malformed JSON, empty handle, and raw passthrough.
- **`tests/test_tasks.py`** - asserts only `select` is guarded and that it
  carries `validate_select_output` / `max_retries == 2`.

## Skills

- `cybersquad-task` gains a guardrails section (function variant, validate the
  artefact not `result.raw`, wire via `build_task`, keep `max_retries` modest).
- `cybersquad-test-fixtures` documents `make_task_output`.

## Scope note

Unit-only by design. The BDD scenario that would share the `programme.json`
fixture is deliberately deferred rather than bootstrapping the repo's first
real-LLM BDD harness in this PR - the runtime guardrail stands on its own.

## CI parity (local, .venv @ 3.12.3)

ruff / ruff format / mypy (clean) / pylint (9.91, floor 9.88) / bandit clean /
pytest -m unit green / diff-cover 100% on changed production lines.
