### PR TITLE
feat(squad): JSONSearchTool semantic search over recon.json (#169)

### DIFF
--- a/.claude/skills/cybersquad-task/SKILL.md
+++ b/.claude/skills/cybersquad-task/SKILL.md
@@ -40,7 +40,9 @@ DO NOT use `output_pydantic=SomeModel` on tasks for inter-agent flow. Three reas
 2. **Prose-coercion cost.** `output_pydantic` constrains the agent to JSON-only output. Agents naturally want to produce "Here is my reasoning, then the JSON" and JSON parsing breaks on the prose. Suppressing the prose reliably takes non-trivial prompt engineering.
 3. **Both-and.** Workspace files let the task's textual output be reasoning-narrative (which the next agent uses to orient) AND the typed artefact be the structured contract (which downstream code consumes). `output_pydantic` collapses these into one.
 
-For the tool-side conventions (writer/reader pair, return types, where shared tools live), load `cybersquad-tool`.
+A consumer agent does not have to re-read the whole artefact to use it. The typed slicers (`Recon Endpoints` / `Recon Open Ports` / `Recon Subdomains`) pull narrow schema-filtered views on demand, and `Recon Semantic Search` (the #169 spike, `squad/tools/recon_search.py`) lets an agent *query* `recon.json` in natural language - a vector search over the same file - without loading it whole. Both are the size argument (reason 1) applied at read time: the workspace file is the contract, the slicer/search is how a downstream agent samples it cheaply. The vector path complements the typed slicers (it catches cross-cutting questions a filter cannot phrase); it is size-dependent, so reach for the typed slicer first when the question fits an axis.
+
+For the tool-side conventions (writer/reader pair, return types, where shared tools live, wrapping CrewAI built-ins like `JSONSearchTool`), load `cybersquad-tool`.
 
 ## When `output_pydantic` is acceptable
 

--- a/.claude/skills/cybersquad-tool/SKILL.md
+++ b/.claude/skills/cybersquad-tool/SKILL.md
@@ -161,7 +161,16 @@ The reader returns the typed model; downstream agents work against the schema, n
 ## Where tools live
 
 - **Per-agent**: the wrapper modules live under `squad/<agent>/tools/` (one module per cohesive responsibility - e.g. `discovery.py` / `curation.py`, `probes/` / `cloud/`, `selection.py`, `submission.py`, `authoring.py`). The agent's `squad/<agent>/__init__.py` imports each wrapper, assembles the `MEMBER.tools` list, and re-exports the wrappers + their args_schema classes so consumers keep importing `from squad.<agent> import ...`.
-- **Shared between agents**: `squad/tools/workspace_tools.py`. Re-export through `squad/__init__.py` (`__all__` and the explicit re-export) so consumers `from squad import read_attack_forest_tool`, not from the deeper path.
+- **Shared between agents**: `squad/tools/workspace_tools.py` (and siblings like `squad/tools/recon_search.py`). Re-export through `squad/__init__.py` (`__all__` and the explicit re-export) so consumers `from squad import read_attack_forest_tool`, not from the deeper path.
+
+## CrewAI built-in tools are first-class
+
+A `crewai_tools` built-in (`JSONSearchTool`, `ScrapeWebsiteTool`, ...) is a legitimate `MEMBER.tools` entry - it already satisfies the `SquadTool` Protocol (`name` / `description` / `args_schema` / `func`). Two ways to register one:
+
+- **Register the instance directly** when it needs no run-context: construct it, drop it in `MEMBER.tools`. The agent passes whatever the built-in's own `args_schema` declares.
+- **Wrap it through `@cyber_tool`** when it needs *workspace-aware path resolution* or a *typed return*. The built-ins take absolute paths the agent should never see; a wrapper resolves the relative artefact name via `resolve_run_path` (lazily, at call time - `run_dir()` binds mid-run) and hands the resolved path to the built-in inside the body. This keeps the "agents pass relative paths" invariant true and lets the wrapper return a typed model instead of the built-in's raw string.
+
+`recon_semantic_search_tool` (`squad/tools/recon_search.py`, the #169 spike) is the worked example: it wraps `JSONSearchTool` so the agent queries `recon.json` by relative name, defaults to a local no-key/no-spend `onnx` embedder (the built-in's own default is OpenAI, which this project carries no key for), and returns a typed `ReconSearchResult`. Note the size-dependence it documents: vector retrieval only discriminates once the document spans many chunks, so it complements - does not replace - the typed `Recon *` slicers. The atomic per-host `assets/<fqdn>/*.json` store is *not* a valid target for a single-document RAG tool (each facet is tiny and the host lives in the dir name, not the body); the typed `load_host_*` readers own that store.
 
 ## Where models live
 

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -33,7 +33,7 @@ across every consumer.
 | ``models.h1`` | HackerOne shapes incl. ``ProgrammeReportSummary`` |
 | ``models.attack`` | ``AttackGraph``, ``AttackForest``, ``AttackTree``, |
 |                   | ``AttackForestValidationIssue``, ``AttackForestValidationReport``, |
-|                   | ``AttackForestFinalisationError`` |
+|                   | ``AttackForestFinalisationError``, ``ReconSearchResult`` |
 | ``models.triage`` | ``AuthoredAssessment``, ``SeverityDecision`` |
 | ``models.report`` | ``AuthoredDraft`` |
 
@@ -87,6 +87,7 @@ from models.attack import (
     AttackForestValidationReport,
     AttackGraph,
     AttackTree,
+    ReconSearchResult,
 )
 from models.dns import PtrRecord, TakeoverCandidate
 from models.finding import RawFinding, RawFindingSummary, VerifiedVulnerability
@@ -183,6 +184,7 @@ __all__ = [
     "RawFindingSummary",
     "RdapRecord",
     "ReconFinalisationError",
+    "ReconSearchResult",
     "RegistrantBundle",
     "Relation",
     "RelationType",

--- a/models/attack/__init__.py
+++ b/models/attack/__init__.py
@@ -29,7 +29,7 @@ from models.attack.forest import (
     AttackForestValidationIssue,
     AttackForestValidationReport,
 )
-from models.attack.graph import AttackGraph
+from models.attack.graph import AttackGraph, ReconSearchResult
 from models.attack.tree import AttackTree
 
 __all__ = [
@@ -39,4 +39,5 @@ __all__ = [
     "AttackForestValidationReport",
     "AttackGraph",
     "AttackTree",
+    "ReconSearchResult",
 ]

--- a/models/attack/graph.py
+++ b/models/attack/graph.py
@@ -63,3 +63,29 @@ class AttackGraph(BaseModel):
     # (additive: empty when the WEB_INVENTORY pass did not run).
     tls_certificates: list[TLSCertificate] = Field(default_factory=list)
     completed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class ReconSearchResult(BaseModel):
+    """The vector-search slice of ``recon.json`` (the #169 spike's return shape).
+
+    Sibling of ``EndpointPage`` / ``OpenPortsMap`` (the *typed*-query result
+    shapes): where those carry a schema-filtered slice the agent asked for by
+    axis, this carries the *semantically* retrieved slice the agent asked for in
+    prose. ``matches`` is the concatenated relevant-chunk text JSONSearchTool
+    returned - free-text, not re-parsed back into the asset shapes, because the
+    whole point of the vector path is to surface cross-cutting material the typed
+    slicers cannot express as a filter.
+
+    ``matches`` is tool-captured recon content (httpx/nmap banners et al. already
+    live in ``recon.json``); it is a retrieved *subset* of an artefact the agents
+    already read wholesale via Read Run File, so it opens no injection surface the
+    typed readers do not - defence 3 (the field travels no further than the agent
+    that queried) applies, same as Read Run File's ``content``.
+    """
+
+    query: str = Field(description="The natural-language query that was run.")
+    recon_path: str = Field(description="The recon.json the query was run against.")
+    matches: str = Field(
+        default="",
+        description="The concatenated relevant-chunk text vector search retrieved.",
+    )

--- a/squad/__init__.py
+++ b/squad/__init__.py
@@ -112,6 +112,9 @@ def cyber_tool(
 # would hit a circular import if pulled in alongside the top-of-module
 # imports. The deferred-import pattern is explicitly endorsed by ruff for
 # this case: https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file/
+from squad.tools.recon_search import (  # noqa: E402 - deferred to break import cycle (see comment above)
+    recon_semantic_search_tool,
+)
 from squad.tools.workspace_tools import (  # noqa: E402 - deferred to break import cycle (see comment above)
     read_attack_forest_tool,
     read_run_file_tool,
@@ -246,4 +249,5 @@ __all__ = [
     "read_attack_forest_tool",
     "read_run_file_tool",
     "read_run_filelist_tool",
+    "recon_semantic_search_tool",
 ]

--- a/squad/penetration_tester/__init__.py
+++ b/squad/penetration_tester/__init__.py
@@ -28,6 +28,7 @@ from squad import (
     read_attack_forest_tool,
     read_run_file_tool,
     read_run_filelist_tool,
+    recon_semantic_search_tool,
 )
 from squad.penetration_tester.tools._decorator import (
     _parse_endpoints,
@@ -145,6 +146,7 @@ from squad.penetration_tester.tools.recon import (
     recon_open_ports_tool,
     recon_subdomains_tool,
 )
+from squad.tools.recon_search import _ReconSemanticSearchArgs
 from squad.tools.workspace_tools import (
     _ListRunFilesArgs,
     _ReadAttackForestArgs,
@@ -208,6 +210,7 @@ MEMBER = SquadMember(
         recon_subdomains_tool,
         recon_endpoints_tool,
         recon_open_ports_tool,
+        recon_semantic_search_tool,
         save_findings_tool,
         # Shared workspace wrappers
         read_attack_forest_tool,
@@ -269,6 +272,7 @@ MEMBER = SquadMember(
         "Recon Subdomains": _PtReconSubdomainsArgs,
         "Recon Endpoints": _PtReconEndpointsArgs,
         "Recon Open Ports": _PtReconOpenPortsArgs,
+        "Recon Semantic Search": _ReconSemanticSearchArgs,
         "Save Findings": _SaveFindingsArgs,
         # Shared workspace wrappers (re-exported via squad.tools.workspace_tools)
         "List Run Files": _ListRunFilesArgs,

--- a/squad/tools/recon_search.py
+++ b/squad/tools/recon_search.py
@@ -1,0 +1,145 @@
+"""squad/tools/recon_search.py - the #169 spike: vector search over ``recon.json``.
+
+A *complement to* the typed slicers (``Recon Endpoints`` / ``Recon Open Ports`` /
+``Recon Subdomains``), not a replacement. Those let the agent pick a known filter
+axis (``status=200``, ``tech="wordpress"``); this lets it ask in prose ("which
+login pages serve WordPress?", "endpoints serving JSON over plain HTTP?") and get
+the semantically nearest chunks of the same ``recon.json`` back. The spike
+question (#169): does the vector path unlock cross-cutting queries the typed path
+cannot express as a filter, or just give the agent another way to ask the same
+things?
+
+Shape decisions, all driven by the spike framing:
+
+* **Single document, not the per-host store.** ``JSONSearchTool`` (a
+  ``crewai_tools`` ``RagTool``) indexes *one* JSON file. The consolidated
+  ``recon.json`` bundle is self-contained - every record carries its host inline
+  - so it embeds coherently. The atomic ``assets/<fqdn>/*.json`` facets are the
+  wrong target: each is tiny and context-stripped (the host lives in the
+  *directory name*, not the file body), so "ports on api.example.com" cannot
+  retrieve the right file. The typed ``load_host_*`` readers own that store; this
+  tool deliberately does not touch it.
+
+* **Local embedder by default (no key, no spend).** ``JSONSearchTool``'s default
+  embedder is OpenAI ``text-embedding-3-small`` (needs ``OPENAI_API_KEY``), which
+  this Anthropic-only project does not carry. We default to chromadb's local
+  ``onnx`` all-MiniLM embedder instead: no API key, no per-query embedding spend,
+  runs offline (one ~79MB model download, cached). Override the provider via
+  ``CYBERSQUAD_RECON_SEARCH_EMBEDDER`` if a hosted embedder is wanted for the A/B.
+
+* **Size-dependent retrieval - read the A/B honestly.** Vector search only
+  discriminates once the document spans many chunks. On a small ``recon.json``
+  the whole file fits in one chunk and every query returns all of it - no better
+  than ``Read Run File``. The payoff only appears on the large (~100KB+) real
+  artefacts; judge the spike on those, not on a toy surface.
+
+Wired through ``@cyber_tool`` (not registered as a bare ``JSONSearchTool``)
+because it needs workspace-aware path resolution: ``run_dir()`` is bound mid-run,
+so the path is resolved lazily at call time via ``resolve_run_path`` - the same
+relative-path-only contract the typed slicers honour, so the agent never passes
+an absolute path.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from models import ReconSearchResult
+from squad import cyber_tool
+from tools.workspace import resolve_run_path
+
+# chromadb's local, no-API-key embedder (all-MiniLM-L6-v2 via ONNX). Overridable
+# for the A/B - e.g. ``openai`` once a key is in the environment - via env so the
+# default path stays free and offline without a config.py change for a spike.
+_EMBEDDER_PROVIDER = os.getenv("CYBERSQUAD_RECON_SEARCH_EMBEDDER", "onnx")
+
+# One indexed JSONSearchTool per resolved recon.json path. Indexing happens at
+# construction (the ``add`` call), so caching keeps repeat queries in a run cheap;
+# keyed by the resolved absolute path so two runs' recon.json never share an
+# index. Populated lazily because the import-time cost (chromadb + the embedder
+# model) should not land on every process that imports the squad surface.
+_INDEX_CACHE: dict[str, object] = {}
+
+
+def _search_tool(recon_file: Path) -> object:
+    """Return the cached JSONSearchTool indexing ``recon_file`` (building once).
+
+    Imported lazily: ``crewai_tools.JSONSearchTool`` pulls in chromadb and the
+    embedder backend, a cost the squad's import graph should not pay just to
+    register the tool.
+    """
+    key = str(recon_file)
+    cached = _INDEX_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    from crewai_tools import JSONSearchTool
+
+    tool = JSONSearchTool(
+        json_path=key,
+        config={"embedding_model": {"provider": _EMBEDDER_PROVIDER, "config": {}}},
+        # Unique collection per path so a process that searches two runs' recon
+        # files does not blend their chunks into one default-named collection.
+        collection_name=f"recon_search_{abs(hash(key))}",
+    )
+    _INDEX_CACHE[key] = tool
+    return tool
+
+
+class _ReconSemanticSearchArgs(BaseModel):
+    """Explicit args_schema for the Recon Semantic Search tool."""
+
+    query: str = Field(
+        description=(
+            "A natural-language question about the recon surface - the way you"
+            " would ask a teammate, not a filter. Use this when the slice you"
+            " want does not fit the typed slicers' axes (status / tech / host"
+            " substring): cross-cutting questions like 'which endpoints serve"
+            " JSON over plain HTTP?' or 'which hosts run an unusual tech"
+            " combination?'. For a single known axis (all 200s, all WordPress)"
+            " prefer ``Recon Endpoints`` - it is exact, free, and deterministic."
+        ),
+    )
+    recon_path: str = Field(
+        default="recon.json",
+        description=(
+            "Relative path to the OSINT Analyst's ``recon.json`` in the current"
+            " run directory (the consolidated artefact ``Finalise Recon`` wrote)."
+            " Pass ``recon.json`` unless a non-default writer produced it."
+            " Absolute paths and any segment containing ``..`` are rejected by the"
+            " workspace layer. The per-host ``assets/<fqdn>/`` facet files are not"
+            " a valid target here - query those via the typed List Host * tools."
+        ),
+    )
+
+
+@cyber_tool("Recon Semantic Search", args_schema=_ReconSemanticSearchArgs)
+def recon_semantic_search_tool(query: str, recon_path: str = "recon.json") -> ReconSearchResult:
+    """
+    Vector-search the OSINT Analyst's ``recon.json`` in natural language and get
+    the semantically nearest chunks back. A complement to the typed slicers
+    (``Recon Endpoints`` / ``Recon Open Ports`` / ``Recon Subdomains``): reach
+    for those when your question fits a known filter axis; reach for this for the
+    cross-cutting questions a filter cannot phrase.
+
+    Returns a ``ReconSearchResult`` carrying the query, the recon path, and the
+    retrieved ``matches`` text. The matches are relevant *chunks*, not the parsed
+    asset shapes - read them as evidence to orient the next probe, then confirm
+    specifics with a typed slicer. On a small recon surface retrieval may return
+    most of the file; its value grows with the size of the inventory.
+
+    Refuses (raises) if ``recon_path`` is absolute, escapes the run directory, or
+    does not exist - finalise recon first, and pass the bare ``recon.json``.
+    """
+    recon_file = resolve_run_path(recon_path)
+    if not recon_file.is_file():
+        raise FileNotFoundError(
+            f"{recon_path!r} not found in the run directory; the OSINT Analyst must "
+            "Finalise Recon before the recon surface can be searched"
+        )
+    tool = _search_tool(recon_file)
+    matches = tool.run(search_query=query)  # type: ignore[attr-defined]
+    return ReconSearchResult(query=query, recon_path=recon_path, matches=matches)

--- a/squad/vulnerability_researcher/__init__.py
+++ b/squad/vulnerability_researcher/__init__.py
@@ -33,7 +33,9 @@ from squad import (
     read_attack_forest_tool,
     read_run_file_tool,
     read_run_filelist_tool,
+    recon_semantic_search_tool,
 )
+from squad.tools.recon_search import _ReconSemanticSearchArgs
 from squad.tools.workspace_tools import (
     _ListRunFilesArgs,
     _ReadAttackForestArgs,
@@ -112,6 +114,7 @@ MEMBER = SquadMember(
         discard_finding_tool,
         finalise_triage_tool,
         # Workspace
+        recon_semantic_search_tool,
         read_attack_forest_tool,
         read_run_filelist_tool,
         read_run_file_tool,
@@ -139,6 +142,7 @@ MEMBER = SquadMember(
         "Discard Finding": _DiscardFindingArgs,
         "Finalise Triage": _FinaliseTriageArgs,
         # Shared workspace wrappers (re-exported via squad.tools.workspace_tools)
+        "Recon Semantic Search": _ReconSemanticSearchArgs,
         "List Run Files": _ListRunFilesArgs,
         "Read Run File": _ReadRunFileArgs,
         "Read Attack Plan": _ReadAttackForestArgs,

--- a/tests/test_squad_recon_search.py
+++ b/tests/test_squad_recon_search.py
@@ -1,0 +1,147 @@
+"""
+tests/test_squad_recon_search.py - the #169 spike tool: vector search over
+``recon.json`` (``recon_semantic_search_tool``).
+
+The wrapper is thin: resolve the relative recon path under the run dir, hand the
+file to a cached ``JSONSearchTool``, and wrap the retrieved text in the typed
+``ReconSearchResult``. The actual embedding / vector index is third-party
+(``crewai_tools``) and pulls a ~79MB ONNX model on first real use, so it is
+mocked here - coverage is of the wrapping (path resolution, refusal conditions,
+return shape, the per-file index cache), not of chromadb.
+
+The ``args_schema`` contract is co-located in ``TestReconSearchArgsSchema``,
+mirroring ``tests/test_squad_workspace_tools.py`` (the recon-search tool is
+shared between the VR and PT rather than agent-scoped).
+"""
+
+from typing import ClassVar
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _clear_index_cache():
+    """Drop the per-path JSONSearchTool cache around each test.
+
+    The cache is module-level and keyed by resolved path; ``run_dir`` is a fresh
+    ``tmp_path`` per test, so stale entries would not collide, but clearing keeps
+    the mocked-tool identity assertions honest.
+    """
+    from squad.tools import recon_search
+
+    recon_search._INDEX_CACHE.clear()
+    yield
+    recon_search._INDEX_CACHE.clear()
+
+
+class _FakeJSONSearchTool:
+    """Stand-in for ``crewai_tools.JSONSearchTool``.
+
+    Records the ``json_path`` it indexed and the queries it ran, and returns a
+    canned relevant-chunk string - enough to exercise the wrapper without the
+    embedding backend.
+    """
+
+    instances: ClassVar[list["_FakeJSONSearchTool"]] = []
+
+    def __init__(self, json_path=None, config=None, collection_name=None, **kwargs):
+        self.json_path = json_path
+        self.config = config
+        self.collection_name = collection_name
+        self.queries: list[str] = []
+        _FakeJSONSearchTool.instances.append(self)
+
+    def run(self, search_query: str) -> str:
+        self.queries.append(search_query)
+        return f"Relevant Content:\nchunk-for::{search_query}"
+
+
+@pytest.fixture()
+def fake_json_search(monkeypatch):
+    """Patch ``crewai_tools.JSONSearchTool`` with the recording fake."""
+    import crewai_tools
+
+    _FakeJSONSearchTool.instances = []
+    monkeypatch.setattr(crewai_tools, "JSONSearchTool", _FakeJSONSearchTool)
+    return _FakeJSONSearchTool
+
+
+class TestReconSemanticSearchTool:
+    def test_returns_typed_result_with_retrieved_matches(self, run_dir, fake_json_search) -> None:
+        from models import ReconSearchResult
+        from squad import recon_semantic_search_tool
+
+        (run_dir / "recon.json").write_text('{"subdomains": []}', encoding="utf-8")
+        result = recon_semantic_search_tool.func("which hosts serve WordPress?")
+
+        assert isinstance(result, ReconSearchResult)
+        assert result.query == "which hosts serve WordPress?"
+        assert result.recon_path == "recon.json"
+        assert "chunk-for::which hosts serve WordPress?" in result.matches
+
+    def test_indexes_the_resolved_recon_file(self, run_dir, fake_json_search) -> None:
+        from squad import recon_semantic_search_tool
+
+        (run_dir / "recon.json").write_text("{}", encoding="utf-8")
+        recon_semantic_search_tool.func("anything")
+
+        assert len(fake_json_search.instances) == 1
+        assert fake_json_search.instances[0].json_path == str(run_dir / "recon.json")
+
+    def test_caches_index_across_queries_on_same_file(self, run_dir, fake_json_search) -> None:
+        """A second query against the same recon file reuses the built index."""
+        from squad import recon_semantic_search_tool
+
+        (run_dir / "recon.json").write_text("{}", encoding="utf-8")
+        recon_semantic_search_tool.func("first")
+        recon_semantic_search_tool.func("second")
+
+        # One construction (indexing happens once), two queries on that instance.
+        assert len(fake_json_search.instances) == 1
+        assert fake_json_search.instances[0].queries == ["first", "second"]
+
+    def test_raises_when_recon_missing(self, run_dir, fake_json_search) -> None:
+        from squad import recon_semantic_search_tool
+
+        with pytest.raises(FileNotFoundError, match="Finalise Recon"):
+            recon_semantic_search_tool.func("anything")
+        # No index built when the file does not exist.
+        assert fake_json_search.instances == []
+
+    def test_refuses_path_escape(self, run_dir, fake_json_search) -> None:
+        from squad import recon_semantic_search_tool
+
+        with pytest.raises(ValueError, match=r"must not contain '\.\.'"):
+            recon_semantic_search_tool.func("anything", "../etc/passwd")
+
+
+class TestReconSearchArgsSchema:
+    """Contract tests for the shared tool's explicit ``args_schema``."""
+
+    def test_every_field_has_description(self) -> None:
+        from squad.tools.recon_search import _ReconSemanticSearchArgs
+
+        for field_name, field_info in _ReconSemanticSearchArgs.model_fields.items():
+            desc = field_info.description
+            assert desc, f"{field_name} missing Field(description=...)"
+            assert isinstance(desc, str) and desc.strip(), f"{field_name} description is blank"
+
+    def test_recon_path_defaults_to_recon_json(self) -> None:
+        from squad.tools.recon_search import _ReconSemanticSearchArgs
+
+        instance = _ReconSemanticSearchArgs.model_validate({"query": "anything"})
+        assert instance.recon_path == "recon.json"
+
+    def test_query_is_required(self) -> None:
+        from squad.tools.recon_search import _ReconSemanticSearchArgs
+
+        with pytest.raises(ValidationError):
+            _ReconSemanticSearchArgs.model_validate({})
+
+    def test_schema_is_a_basemodel(self) -> None:
+        from squad.tools.recon_search import _ReconSemanticSearchArgs
+
+        assert issubclass(_ReconSemanticSearchArgs, BaseModel)


### PR DESCRIPTION
Carve-off spike from #169, framed as the issue asks: a **complement to** the typed `recon_query` slicers, not a replacement. Adds a `Recon Semantic Search` tool that vector-searches the OSINT Analyst's consolidated `recon.json` in natural language, attached to the Vulnerability Researcher and Penetration Tester **alongside** the existing typed slicers.

## The spike question

> Does the vector path unlock queries the typed path can't, or just give the agent another way to ask the same things?

This PR ships the runnable surface to answer that on a real run. The typed path (`Recon Endpoints(status=, tech=)`) is optimal when the question fits a known filter axis; the vector path is for the cross-cutting questions a filter can't phrase ("endpoints serving JSON over plain HTTP?", "hosts with an unusual tech combination?"). The prose-heavy `host_insights[].notes` field is the one place vector search could plausibly beat typed filters — there's no filter axis for "why did the OA think this host was interesting".

## What's here

| File | Change |
|---|---|
| `squad/tools/recon_search.py` | **New.** `JSONSearchTool` wrapped through `@cyber_tool` for workspace-aware path resolution + a per-path index cache. |
| `models/attack/graph.py` | **New** `ReconSearchResult` return model (sibling of `EndpointPage` / `OpenPortsMap`). |
| `squad/__init__.py` | Re-export `recon_semantic_search_tool` as a shared tool. |
| `squad/penetration_tester/__init__.py`, `squad/vulnerability_researcher/__init__.py` | Register in `MEMBER.tools` + `MEMBER.schemas`. |
| `tests/test_squad_recon_search.py` | **New.** Wrapping / refusal / cache / return-shape + args_schema contract (mocks the embedder so CI stays offline). |
| `.claude/skills/cybersquad-tool/SKILL.md`, `cybersquad-task/SKILL.md` | The two skill notes #169 asked for. |

## Three findings, validated against the real `crewai_tools` library (not assumed)

1. **Runs offline and free.** The built-in's *actual* default embedder is OpenAI `text-embedding-3-small` (needs `OPENAI_API_KEY`) despite a docstring claiming all-MiniLM — so out of the box it would fail on this Anthropic-only project. Defaulted to chromadb's local `onnx` all-MiniLM embedder: no key, no per-query spend, one ~79MB model cached once. Override via `CYBERSQUAD_RECON_SEARCH_EMBEDDER`.
2. **Single document only — the atomic per-host store is the wrong target.** `JSONSearchTool` indexes *one* file; the `assets/<fqdn>/*.json` facets are tiny and host-stripped (the host lives in the directory name, not the file body), so they can't retrieve. The tool points only at the consolidated `recon.json`; the typed `load_host_*` readers keep the atomic store. Baked into the docstring + skill notes.
3. **Retrieval is size-dependent — read the A/B honestly.** On a small `recon.json` the whole file fits in one chunk, so every query returns all of it (no better than `Read Run File`). The payoff only shows on the large (~100KB+) real artefacts. The docstring says so, so the spike isn't judged on a toy surface.

## Decision after testing

This is a spike: try it on a real run, then decide. If the typed tools cover ~95% of real queries, the vector path isn't worth keeping; if it consistently catches queries the agent couldn't phrase as filters, it earns its keep — and we can decide whether to lean into it for `attack_plan.json` / `verified.json`. **Planned validation: run against a large CloudFlare `recon.json` and compare which tool each agent reaches for.**

## Stale references in #169, for the record

The issue (filed before the OAM emit work in #176–#187 landed) cites `ReconResult (models/asset.py:142)` — that model is gone (`models/asset.py` became a package; the bundle is now `AttackGraph`). The `dict[Hostname, list[int]]` embedding-coherence worry only applies to the consolidated `recon.json` (where `open_ports` keeps the host inline), not the atomic store.

## CI

ruff / ruff format / mypy / pylint (10.00/10) / 2156 unit tests (new module 100% covered) / bandit — all green locally.

Closes #169 on a "ship the spike surface" basis; the keep/drop verdict follows the real-run A/B.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwJvRLV2SmuzyZ4q1gZp1b)_