### PR TITLE
chore(github): add community templates, SECURITY.md, CODEOWNERS, dependabot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Code owners for cybersquad.
+# The last matching pattern takes precedence; a match auto-requests review from
+# the listed owner(s) on every PR that touches it.
+# See https://docs.github.com/articles/about-code-owners
+
+# Default owner for everything in the repository.
+*                       @coolhandle01
+
+# Security-sensitive surfaces, called out explicitly so they keep routing to the
+# maintainer even after ownership is split across co-maintainers.
+/SECURITY.md            @coolhandle01
+/.github/               @coolhandle01
+# Scope enforcement is a documented safety invariant (see CONTRIBUTING.md).
+/tools/recon/scope.py   @coolhandle01

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,62 @@
+name: Bug report
+description: Report a defect in cybersquad so it can be reproduced and fixed.
+title: "fix: <short summary of the bug>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Fields marked required must be filled in before
+        the form will submit.
+
+        Do NOT use this form for security vulnerabilities. Report those privately
+        via the GitHub Security tab - see SECURITY.md.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences describing what is wrong.
+      placeholder: The recon finaliser drops hosts whose scope pattern is a bare apex domain.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: The minimal sequence that triggers the bug. Include the command, inputs, and any relevant config or environment variables.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs actual behaviour
+      description: What you expected to happen, and what actually happened.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      description: Output of `git rev-parse --short HEAD`, or the release tag.
+    validations:
+      required: false
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Python version, OS, and anything else relevant. cybersquad targets Python 3.12 (see CONTRIBUTING.md).
+    validations:
+      required: false
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: This is not a security vulnerability (those go through SECURITY.md).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/coolhandle01/cybersquad/security/advisories/new
+    about: Disclose vulnerabilities privately via GitHub's private reporting. Never file a public issue for a security bug - see SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: Feature request
+description: Propose a new capability or enhancement.
+title: "feat: <short description of the feature>"
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing, skim CONTRIBUTING.md and the skill catalogue in CLAUDE.md -
+        some capabilities are better expressed as a skill update than a code change.
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: What problem does this solve, and for whom (a contributor, a runtime agent, a SOC operator reading the traffic)? Describe the gap, not the solution.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How you imagine it working. Sketch the shape; the implementation can be refined in review.
+    validations:
+      required: false
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: The checklist that, when every item is ticked, means this is done. Be concrete enough that a reviewer can verify each item.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed and why you set them aside.
+    validations:
+      required: false
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+# Dependabot keeps dependency pins current. Two ecosystems:
+#   - pip: the Python deps declared in pyproject.toml (incl. the [dev] extras).
+#   - github-actions: the SHA-pinned actions in .github/workflows/.
+# Actions are pinned to full commit SHAs (see docs/ci.md); Dependabot bumps the
+# SHA and the trailing version comment together.
+# Commit-message prefixes match the Conventional Commit types in
+# docs/git-workflow.md (build = dependency changes, ci = CI config).
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "build"
+    groups:
+      python-production:
+        dependency-type: "production"
+      python-development:
+        dependency-type: "development"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 15
     commit-message:
       prefix: "build"
     groups:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- What does this PR do, and why? Link the issue it closes: "Closes #NN". -->
+
+## Test plan
+
+<!--
+How you verified the change. Paste the relevant output from the "Before you
+commit" CI parity stack in CONTRIBUTING.md (ruff, ruff format, mypy, pylint,
+pytest, bandit). New behaviour and bug fixes need a test - see the test-first
+discipline in CONTRIBUTING.md.
+-->
+
+## Out of scope
+
+<!-- What this PR deliberately does NOT do, and where that work is tracked (issue number, or "follow-up under #NN"). Write "none" if not applicable. -->
+
+---
+
+- [ ] Branch follows `<type>/<short-description>` and the commit follows Conventional Commits (`docs/git-workflow.md`).
+- [ ] `git diff origin/main --stat` shows only changes related to this PR (minimal-diff rule).
+- [ ] New or changed behaviour is covered by tests; diff coverage is 100% or the exceptions are justified.
+- [ ] ASCII-only; no unrelated renames, comment rewrites, or formatting churn.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,63 @@
+# Security policy
+
+cybersquad is an autonomous bug bounty pipeline: it runs network reconnaissance
+and active vulnerability checks against third-party targets. That makes its own
+security posture - scope enforcement, credential handling, and safe-by-default
+tool wiring - load-bearing. We take vulnerability reports seriously.
+
+## Supported versions
+
+The project is pre-1.0 (see `version` in `pyproject.toml`) and ships from
+`main`. Only the latest `main` is supported; please confirm a report still
+reproduces against the current `main` before filing.
+
+| Version | Supported |
+|---|---|
+| `main` (latest) | yes |
+| older commits / tags | no |
+
+## Reporting a vulnerability
+
+**Do not open a public issue, pull request, or discussion for a security
+vulnerability.** Public disclosure before a fix is available puts every user of
+the pipeline at risk.
+
+Report privately through GitHub's private vulnerability reporting:
+
+1. Go to the [Security tab](https://github.com/coolhandle01/cybersquad/security)
+   of this repository.
+2. Click **Report a vulnerability** to open a private advisory (direct link:
+   <https://github.com/coolhandle01/cybersquad/security/advisories/new>).
+3. Include the details listed below.
+
+If you cannot use private reporting for any reason, contact the repository owner
+[@coolhandle01](https://github.com/coolhandle01) through GitHub and ask for a
+secure channel - still without disclosing the details publicly.
+
+### What to include
+
+- A description of the vulnerability and its impact.
+- The minimal steps or proof-of-concept needed to reproduce it.
+- The affected commit (`git rev-parse --short HEAD`) or tag.
+- Any suggested remediation, if you have one.
+
+### What to expect
+
+- **Acknowledgement** within 3 business days.
+- **Initial assessment** (severity, and whether we can reproduce) within 7
+  business days.
+- We will keep you updated as we work on a fix, and credit you in the published
+  advisory unless you prefer to remain anonymous.
+
+Please give us a reasonable window to ship a fix before any public disclosure.
+We follow coordinated disclosure and will agree a timeline with you.
+
+## Scope
+
+This policy covers the cybersquad codebase in this repository. It does **not**
+cover:
+
+- Vulnerabilities in upstream dependencies - report those to the relevant
+  project. Our `.github/dependabot.yml` keeps our pins current.
+- Findings produced by *running* the pipeline against a target. Those belong to
+  that target's own disclosure programme, not here.


### PR DESCRIPTION
## Summary

Addresses the code-shaped subtasks of the #100 epic (public-FOSS hygiene baseline). Adds GitHub Community Standards templates, a private security-disclosure policy, code ownership, and automated dependency updates. All ASCII, all `.github/`-scoped plus root `SECURITY.md`.

- `.github/ISSUE_TEMPLATE/bug_report.yml` - issue form, `required` on summary + steps-to-reproduce + expected-vs-actual, plus a "this is not a security bug" preflight.
- `.github/ISSUE_TEMPLATE/feature_request.yml` - issue form, `required` on motivation + acceptance criteria.
- `.github/ISSUE_TEMPLATE/config.yml` - disables blank issues, routes vulnerability reports to private reporting.
- `.github/pull_request_template.md` - Summary / Test plan / Out-of-scope, plus a minimal-diff and CI-parity checklist.
- `SECURITY.md` - supported versions (pre-1.0, `main` only), private-disclosure path, response-time expectations, scope carve-outs.
- `.github/CODEOWNERS` - default owner plus explicit security-sensitive surfaces (`SECURITY.md`, `.github/`, the `scope.py` safety invariant).
- `.github/dependabot.yml` - weekly pip + github-actions updates, grouped prod/dev, with `build`/`ci` commit prefixes matching the repo's Conventional Commit types.

Choices worth flagging:

- Woven into the repo's own conventions rather than generic boilerplate: the bug form references the Python 3.12 floor, the PR template points at the "Before you commit" stack and minimal-diff rule, dependabot's commit prefixes match the type table in `docs/git-workflow.md`, and `SECURITY.md` cites `pyproject.toml`'s version and dependabot for upstream deps.
- No public email in `SECURITY.md`: `CYBERSQUAD_CONTACT_EMAIL` is an outbound User-Agent value, not an inbound security inbox, so the disclosure path is GitHub private reporting with "contact @coolhandle01 via GitHub" as the fallback.

## Test plan

- Non-ASCII scan over `.github/` and `SECURITY.md`: clean.
- `yaml.safe_load` parses all four YAML files.
- No Python changed, so the ruff / mypy / pylint / pytest / bandit stack has nothing in scope here.

## Out of scope

Deliberately left for separate work (per the epic's split and the maintainer's request):

- `CODE_OF_CONDUCT.md` - skipped for now.
- The PR-body CI check workflow (the `require-checklist`-style gate that fails CI on empty required sections) - same issue group as the PR template, but a meatier CI change.
- The repo-settings toggles that need owner access: enable private vulnerability reporting, secret scanning + push protection, Dependabot alerts/security updates, and documenting branch protection in `docs/ci.md`.

Closes part of #100.

---
_Generated by [Claude Code](https://claude.ai/code/session_019TABe2hFoEG4c1Uw5L3xqr)_