### PR TITLE
ci(codeql): add advanced setup with explicit python + actions languages

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,55 @@
+# CodeQL advanced setup. Replaces the repo's CodeQL *default* setup, which
+# auto-detected only the `actions` language and silently left the ~300 Python
+# source files unscanned. Listing the languages explicitly here makes the
+# coverage version-controlled and immune to that detection drift.
+#
+# Default setup must be turned off (Settings > Code security > Code scanning)
+# for this workflow's results to be processed - the two cannot run together.
+#
+# Actions are pinned to full commit SHAs per docs/ci.md; the codeql-action
+# pins match the upload-sarif pin already in ci.yml (same repo, same v3.29.4
+# tag) so Dependabot bumps them together. Python uses build-mode `none` - the
+# extractor reads source directly and needs no build step.
+name: CodeQL
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  schedule:
+    # Weekly catch-all so new CodeQL queries run against main even in quiet
+    # weeks. Off-the-hour minute per GitHub's scheduling guidance.
+    - cron: "27 3 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write  # required by github/codeql-action/analyze to upload results
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: actions
+            build-mode: none
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@4e828ff8d448a8a6e532957b1811f387a63867e8  # v3.29.4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@4e828ff8d448a8a6e532957b1811f387a63867e8  # v3.29.4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

CodeQL default setup auto-detected only the `actions` language, so the repo's ~300 Python source files were never scanned. Every CodeQL run reported "success" because analysing the workflow files passed - but the latest run on `main` had a single `Analyze (actions)` job and no `Analyze (python)` job at all. This switches to advanced setup, which lists the languages explicitly so coverage is version-controlled and cannot silently drift again.

- `.github/workflows/codeql.yml` - matrix over `python` and `actions`, `build-mode: none` for both (CodeQL reads Python source directly; no build step).
- Runs on push to `main`, all PRs, and a weekly schedule (so new CodeQL queries run against `main` even in quiet weeks).
- Action SHAs reuse the pins already in `ci.yml`: `codeql-action` v3.29.4 (matching the existing `upload-sarif` pin) and `checkout` v4.3.1, so Dependabot bumps them in lockstep per `docs/ci.md`.

Complements the existing bandit + semgrep SAST job in `ci.yml` rather than replacing it.

## Required manual step

Advanced and default CodeQL setup cannot run together. **Disable default setup** (Settings > Code security > Code scanning > CodeQL) before this workflow runs, otherwise the `analyze` step fails at upload with a "default setup is enabled" error. Do this before merge so the PR's CodeQL check runs green.

## Test plan

- ASCII-only scan: clean.
- `yaml.safe_load` parses the workflow; both `python` and `actions` confirmed in the matrix.
- No Python changed, so the ruff / mypy / pylint / pytest / bandit stack has nothing in scope.
- End-to-end verification is the PR's own CodeQL run: expect two jobs, `Analyze (python)` and `Analyze (actions)`, both green (once default setup is off).

## Out of scope

Follow-on #100 items still open: the PR-body CI check workflow, `CODE_OF_CONDUCT.md` (parked), and the remaining repo-settings toggles (secret scanning + push protection, Dependabot alerts/security updates, documenting branch protection in `docs/ci.md`).

Relates to #100.