### PR TITLE
feat(task): stamp Task.name from a per-task name.md

### DIFF
--- a/squad/__init__.py
+++ b/squad/__init__.py
@@ -216,7 +216,12 @@ def build_task(
 ) -> Task:
     """Create a Task from the member's task-specific prose files.
 
-    Reads description and expected_output from ``<member.dir>/<task_name>/``.
+    Reads name, description, and expected_output from
+    ``<member.dir>/<task_name>/``. ``task_name`` is the directory slug (a good
+    filename); ``name.md`` carries the human-readable display name stamped onto
+    ``Task.name`` (e.g. ``recon`` -> "Reconnaissance"), so a task self-describes
+    when something walks ``crew.tasks`` - the VR's two tasks (research, triage)
+    stay distinct rather than both collapsing to the agent role.
 
     ``guardrail`` is an optional CrewAI *function* guardrail
     (``(TaskOutput) -> (bool, Any)``) that validates the task output and, on
@@ -227,6 +232,7 @@ def build_task(
     ``cybersquad-task`` skill's guardrails section and ``squad/guardrails.py``.
     """
     return Task(
+        name=member.read(task_name, "name"),
         description=member.read(task_name, "description"),
         expected_output=member.read(task_name, "expected_output"),
         agent=agent,

--- a/squad/disclosure_coordinator/submit/name.md
+++ b/squad/disclosure_coordinator/submit/name.md
@@ -1,0 +1,1 @@
+Disclosure

--- a/squad/osint_analyst/recon/name.md
+++ b/squad/osint_analyst/recon/name.md
@@ -1,0 +1,1 @@
+Reconnaissance

--- a/squad/penetration_tester/pentest/name.md
+++ b/squad/penetration_tester/pentest/name.md
@@ -1,0 +1,1 @@
+Penetration Testing

--- a/squad/programme_manager/select/name.md
+++ b/squad/programme_manager/select/name.md
@@ -1,0 +1,1 @@
+Programme Selection

--- a/squad/technical_author/write/name.md
+++ b/squad/technical_author/write/name.md
@@ -1,0 +1,1 @@
+Reporting

--- a/squad/vulnerability_researcher/research/name.md
+++ b/squad/vulnerability_researcher/research/name.md
@@ -1,0 +1,1 @@
+Vulnerability Research

--- a/squad/vulnerability_researcher/triage/name.md
+++ b/squad/vulnerability_researcher/triage/name.md
@@ -1,0 +1,1 @@
+Findings Triage

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -38,11 +38,13 @@ class _FakeTask:
         description: str,
         expected_output: str,
         agent: object,
+        name: str = "",
         context: list | None = None,
         human_input: bool = False,
         guardrail: object = None,
         max_retries: int | None = None,
     ) -> None:
+        self.name = name
         self.description = description
         self.expected_output = expected_output
         self.agent = agent
@@ -104,6 +106,23 @@ class TestBuildTasks:
         for task in tasks:
             assert task.description
             assert task.expected_output
+
+    def test_each_task_has_display_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Every task carries a human-readable ``name`` from its ``name.md``,
+        so a task self-describes when something walks ``crew.tasks``."""
+        monkeypatch.setattr(squad, "Task", _FakeTask)
+        tasks = build_tasks(self._agents())
+        for task in tasks:
+            assert task.name, "task is missing a display name"
+            assert "---" not in task.name
+
+    def test_vr_two_tasks_have_distinct_names(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The VR owns both research and triage; per-task ``name.md`` keeps them
+        distinct rather than collapsing to the shared agent role."""
+        monkeypatch.setattr(squad, "Task", _FakeTask)
+        _select, _recon, research, _pentest, triage, _write, _submit = build_tasks(self._agents())
+        assert research.name != triage.name
+        assert research.agent is triage.agent  # same agent, different tasks
 
     def test_context_chaining_wired(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(squad, "Task", _FakeTask)


### PR DESCRIPTION
## Summary

`build_task` reads each task's prose from `squad/<member>/<task>/` using the directory slug (`"recon"`, `"triage"`, ...). Those slugs are good *filenames* but poor *display strings*, and we discarded them after loading the markdown - so `Task.name` stayed `None` on every task, and anything walking `crew.tasks` (logs, a pipeline TUI) could only ever see the agent role.

This adds a `name.md` alongside `description.md` / `expected_output.md` in each of the seven task folders and stamps it onto `Task.name`. Tasks now self-describe, and the Vulnerability Researcher's **two** tasks (`research`, `triage`) stay distinct instead of both collapsing to the shared agent role.

Pure addition - nothing on `main` consumes `Task.name` today, so there is no behaviour change; it lights up an OOTB CrewAI field a downstream consumer can read directly (the motivation came out of the TUI flow-panel work).

## Display names

| task | `name.md` |
|---|---|
| select | Programme Selection |
| recon | Reconnaissance |
| research | Vulnerability Research |
| pentest | Penetration Testing |
| triage | Findings Triage |
| write | Reporting |
| submit | Disclosure |

## Test plan

- `test_tasks.py`: `_FakeTask` now carries `name`; new tests pin that every task has a non-empty display name and that `research.name != triage.name` while sharing one agent.
- Full CI parity stack green locally: `ruff check` / `ruff format --check` / `mypy` clean; `pytest -m unit` 96.50%; `diff-cover` 100% (exit 0); `pylint` and `bandit` clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_015Wb89n7eoD1t7eXWjP8PWn)_