### PR TITLE
docs(contributing): a pushed branch means an open, subscribed PR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,7 +209,7 @@ These exist for reasons that are not obvious from the code alone. Touching any o
 
 ## Pull requests
 
-If you create a PR, please ensure you are subscribed to it so review comments and CI events reach you. Most contributors are auto-subscribed by GitHub; some integrations require an explicit subscribe step.
+Pushing a branch and opening its PR are one action, not two. A pushed branch with no PR is invisible to review, to CI's per-PR gates (the `diff-cover` ratchet only runs on `pull_request` events), and to the maintainer's mental model - so open the PR the moment you push, and subscribe to it so review comments and CI events reach you. Most contributors are auto-subscribed by GitHub; some integrations - AI sessions included - need an explicit subscribe step. The only branch you push without opening a PR is one the maintainer has explicitly told you to leave alone.
 
 ## Where to find more
 


### PR DESCRIPTION
## Summary

The `## Pull requests` section hedged - "*if* you create a PR, subscribe to it" - which read as optional. This restates the actual intent: pushing a branch and opening its PR are one action, and you subscribe so review comments and CI signal reach you.

The rationale is made concrete: a pushed branch with no PR is invisible to review, to the per-PR `diff-cover` gate (which only runs on `pull_request` events, per `docs/ci.md`), and to the maintainer's mental model. The single exception - a branch the maintainer explicitly told you to leave alone - is named so WIP checkpoint pushes have a clear carve-out.

## Test plan

Docs-only, ASCII-only, one-line change to `CONTRIBUTING.md`; no code paths touched, so ruff / mypy / pytest / bandit are unaffected.

## Out of scope

Mirroring the wording into `CLAUDE.md` or `docs/git-workflow.md` - `CONTRIBUTING.md` is the canonical contributor surface those link to.


---
_Generated by [Claude Code](https://claude.ai/code/session_015Wb89n7eoD1t7eXWjP8PWn)_