### PR TITLE
fix(programme-manager): rebuild h1 hacker-API client and de-phantom selection

### DIFF
--- a/squad/__init__.py
+++ b/squad/__init__.py
@@ -179,7 +179,10 @@ def build_agent(
     adapter and live outside the ``SquadTool`` Protocol surface by
     design.
     """
-    skills: list[Path] = [member.skills_dir] if member.skills_dir.is_dir() else []
+    # CrewAI's `skills` field rejects an explicitly-empty list (min_length=1)
+    # but accepts None (its default) - so members without a specialist
+    # skills/ dir pass None rather than [], leaving the field at its default.
+    skills: list[Path] | None = [member.skills_dir] if member.skills_dir.is_dir() else None
     # Static, contract-tested tools first; provisioned-MCP tools spliced
     # on the end. The order is observable in the LLM-visible tool menu -
     # the agent's canonical typed surface opens the menu, MCP-sourced
@@ -212,7 +215,7 @@ def build_task(
     human_input: bool = False,
     *,
     guardrail: Callable[..., tuple[bool, Any]] | None = None,
-    max_retries: int | None = None,
+    max_retries: int = 0,
 ) -> Task:
     """Create a Task from the member's task-specific prose files.
 
@@ -239,7 +242,7 @@ def build_task(
         context=context or [],
         human_input=human_input,
         guardrail=guardrail,
-        max_retries=max_retries,
+        guardrail_max_retries=max_retries,
     )
 
 

--- a/squad/guardrails.py
+++ b/squad/guardrails.py
@@ -16,8 +16,13 @@ agent's raw response. A malformed or missing ``programme.json`` is caught here,
 at the boundary, instead of derailing recon downstream.
 """
 
-from __future__ import annotations
-
+# NB: no `from __future__ import annotations` here. CrewAI's Task guardrail
+# validator (crewai/task.py) inspects `inspect.signature(fn).return_annotation`
+# with get_origin/get_args and does NOT resolve string annotations - under
+# PEP 563 the annotation would arrive as the string "tuple[bool, str]",
+# get_origin() would return None, and the task would reject the guardrail with
+# "If return type is annotated, it must be Tuple[bool, Any]". Keeping the
+# annotation a live type object is load-bearing.
 from crewai import TaskOutput
 from pydantic import ValidationError
 

--- a/squad/programme_manager/select/description.md
+++ b/squad/programme_manager/select/description.md
@@ -9,9 +9,10 @@ The catalog tools:
     policy_text, no scope, no bounty table - just enough signal to
     decide whether a programme is worth a closer look.
   - hydrate_programme_tool - one programme, fully hydrated. Expensive
-    relative to browse. Returns bounty_table, structured scope, policy
-    text, response/payout stats. Call this for the candidates you have
-    already decided to score.
+    relative to browse. Returns the full structured scope (in and out,
+    including explicit exclusions), the policy text, and the access
+    attributes. Call this for the candidates you have already decided to
+    score.
   - save_programme_tool - records your final pick. Call exactly once.
 
 Step 0 - Access authorisation (operative invariant, applies to every
@@ -43,30 +44,28 @@ Step 1 - Survey:
     curation, not to add to it.
 
   Step 1b - Catalog browse (fall-back when bookmarks did not satisfy):
-    Call browse_programmes_tool. Pass the H1 server-side filters that
-    obviously apply to the squad's goal - offers_bounties=True excludes
-    VDPs at the source. Sort by "-launched_at" or "-total_bounties_paid"
-    if you want a particular tilt. limit defaults to the H1 catalog cap;
-    raise it if you want to look wider, lower it if a tight filter
-    already narrows the field.
+    Call browse_programmes_tool. You may pass filter hints
+    (offers_bounties, submission_state, ...), but do not assume they
+    narrow anything - H1 does not reliably filter the list, so the field
+    you get back may be the whole catalog regardless.
 
-    Read the previews. The handle, name, offers_bounties, submission_state,
-    and state fields are enough to drop programmes whose access mode or
-    bounty posture is wrong. You can also call browse_programmes_tool
-    again with different filters if your first survey was too narrow.
+    The narrowing that counts is yours: read the previews and drop
+    programmes whose access mode or bounty posture is wrong on what the
+    preview carries - handle, name, offers_bounties, submission_state,
+    state, bookmarked. Shortlist tightly before paying to hydrate.
 
 Step 2 - Shortlist and hydrate:
-  From the previews, pick a shortlist of candidates worth scoring. A
-  shortlist of 3-8 is reasonable; smaller if filters were tight, larger
-  if you want a competitive field. For each shortlisted handle, call
-  hydrate_programme_tool. Do not hydrate the whole catalog - that is
-  exactly the antipattern this two-tool split exists to prevent.
+  From the previews, pick the few candidates most worth scoring.
+  Hydration is the expensive step - it pulls one programme's full policy
+  and scope - so shortlist hard on the cheap previews and hydrate only
+  the 1-3 strongest. For each, call hydrate_programme_tool. Do not
+  hydrate the whole catalog; browsing first exists precisely so you do
+  not have to.
 
 Step 3 - Hard filters (discard immediately on hydrated programmes, do
 not score):
-  - offers_bounties is false (VDP - no payment; should already be
-    filtered by browse, but check the hydrated programme as well in
-    case the server-side filter behaved unexpectedly)
+  - offers_bounties is false (VDP - no payment; browse should already
+    have dropped it client-side, but re-check on the hydrated programme)
   - accepts_new_reports is false (closed programme)
   - triage_active is false (programme is not actively triaging; a
     report will sit untouched)
@@ -81,13 +80,14 @@ Step 4 - Policy review:
 
 Step 5 - Score remaining candidates:
   Activate the programme-selection-scoring skill. It carries the
-  four-factor weighted rubric, the cap adjustment for per-asset
-  max_severity, and the tiebreak rules.
+  three-factor weighted rubric built on scope value, scope fit, and
+  method permissiveness - the real signals the hacker API returns - plus
+  the tiebreak rules. There are no bounty or speed figures to score on.
 
 Select the single highest-scoring programme that passed all filters.
 Call save_programme_tool with the chosen handle to record the selection
 and create the run directory the downstream agents will write into.
 Document your access authorisation, browse + hydrate workflow (which
 filters you ran, how many programmes you previewed, which handles you
-hydrated and why), policy reading, and scoring in selection_rationale -
+hydrated and why), policy reading, and scoring in your written brief -
 the access reasoning must be stated explicitly, not left implicit.

--- a/squad/programme_manager/select/expected_output.md
+++ b/squad/programme_manager/select/expected_output.md
@@ -1,30 +1,11 @@
-A JSON object with the following fields:
-  - handle: the programme's HackerOne handle
-  - name: the programme's display name
-  - offers_bounties: true (always true - VDPs are pre-filtered)
-  - accepts_new_reports: true (always true - closed programmes are pre-filtered)
-  - bounty_table: object mapping severity to maximum payout in USD
-  - response_efficiency_pct: percentage (float or null)
-  - avg_time_to_bounty_days: average days to payment (float or null)
-  - avg_time_to_first_response_days: average days to first programme response (float or null)
-  - total_bounties_paid_usd: lifetime payout total in USD (int or null)
-  - triage_active: whether the programme currently has active triage (bool or null)
-  - in_scope: list of asset objects, each with asset_identifier, asset_type,
-    eligible_for_bounty, and max_severity (null means uncapped)
-  - state: the programme's H1 access-state attribute, copied verbatim
-    from the input (e.g. "public_mode" or "private_mode", or null if H1
-    did not supply one). Recorded so the downstream artefact carries the
-    same signal the PM reasoned about.
-  - authorisation_basis: 1-2 sentences confirming why the squad is
-    authorised to scan this programme. State the access signal (returned
-    by find_programmes_tool, i.e. accessible to this hacker account),
-    name the value of state and how you handled it (public -> proceed;
-    non-public -> name the corroborating evidence of admission), and
-    confirm policy_text contains no contradicting private/invite-only
-    restriction.
-  - selection_rationale: 3-5 sentences explaining (a) the catalog survey
-    you ran (filters passed to browse_programmes_tool, total previews
-    seen, which handles you shortlisted and hydrated) and (b) why the
-    selected programme scored highest over the alternatives considered
-  - run_dir: the absolute path to the run folder created by
-    save_programme_tool (downstream agents write their outputs there)
+A short written brief - a few sentences in plain prose. You have already
+saved the full programme - its scope, policy, and access details - with
+your Save Selected Programme tool; this brief is the short, readable
+record of the decision that sits beside it.
+
+In the brief, say:
+  - which programme you selected, and that you saved it;
+  - the authorisation basis: the access signal that puts it in bounds, the access state and how you handled it (public, so you proceeded; or non-public, with the  evidence of admission you found), and that nothing in the policy contradicts it with an invite-only restriction;
+  - why it scored highest over the other programmes you hydrated - its
+    scope value, its scope fit, and how clearly its policy permits your
+    methods.

--- a/squad/programme_manager/skills/programme-selection-scoring/SKILL.md
+++ b/squad/programme_manager/skills/programme-selection-scoring/SKILL.md
@@ -1,43 +1,49 @@
 ---
 name: programme-selection-scoring
-description: The weighted rubric the Programme Manager uses to rank hydrated HackerOne programmes - four factors with explicit weights, and the order in which they apply. Activate during the score-and-select step of a programme survey, after hard filters have already culled VDPs and closed programmes.
+description: The weighted rubric the Programme Manager uses to rank hydrated HackerOne programmes. Three factors built only on signals the hacker API actually returns - scope value, scope fit, and method permissiveness - applied after the hard filters have culled VDPs, closed, and untriaged programmes. Activate during the score-and-select step of a programme survey.
 ---
 
 # Programme selection scoring
 
 You apply this rubric only to programmes that have already passed the
 hard filters (offers_bounties, accepts_new_reports, triage_active,
-policy permits automated tools, access authorisation per
-access-authorisation skill). Scoring an unqualified programme wastes
-the operator's time - it will be rejected regardless of score.
+policy permits automated tools, access authorisation per the
+access-authorisation skill). Scoring an unqualified programme wastes the
+operator's time - it will be rejected regardless of score.
 
-## The four factors
+## What you score on
 
-| Weight | Factor | Source field(s) |
+Rank on what a hydrated programme actually gives you: its scope - the
+assets, their types, their per-asset severity caps, and their bounty
+eligibility - weighed against its policy text. Those are your signals.
+A hydrated programme tells you nothing about payout size or response
+speed, so resist ranking on either; you would only be guessing.
+
+## The three factors
+
+| Weight | Factor | Built from |
 |---|---|---|
-| 40% | Maximum bounty for critical/high | `bounty_table` (severity -> USD max) |
-| 20% | Attack surface breadth | count of `in_scope` items where `asset_type` in {URL, WILDCARD} |
-| 20% | Programme financial health | `total_bounties_paid_usd` |
-| 20% | Response efficiency and speed | composite of `response_efficiency_pct`, `avg_time_to_first_response_days`, `avg_time_to_bounty_days` |
+| 45% | Scope value | the in-scope, bounty-eligible assets, each weighted by its max_severity cap. A programme that accepts critical findings across many eligible assets is worth more than one that caps everything at medium. |
+| 30% | Scope fit | the share of in-scope assets in the types the squad can actually test - URL and WILDCARD web surface. A programme whose scope is mostly mobile-app, hardware, or source-code assets is a poor fit for a web-focused squad however broad it looks. |
+| 25% | Method permissiveness | how clearly policy_text welcomes the squad's automated approach - scanners, fuzzing, automated tooling - beyond the bare minimum the hard filter required. Explicit permission or encouragement scores high; grudging tolerance scores low. |
 
 ## Applying the weights
 
-1. Compute each factor as a normalised 0-100 score across the
-   shortlisted candidates. Normalisation is relative within the
-   shortlist, not against a fixed scale - the best candidate on a
-   factor gets 100, the worst gets 0, others linearly interpolated.
-2. Adjust the bounty factor downward for assets whose `max_severity`
-   cap is below "critical" - a programme paying $20k critical but
-   capping its in-scope assets at "high" is effectively a high-bounty
-   programme, not a critical-bounty one. Use the cap-adjusted bounty
-   ceiling for normalisation.
-3. Multiply each normalised score by its weight; sum.
+1. Score each factor 0-100 relative to the shortlist - the strongest
+   candidate on a factor gets 100, the weakest 0, the rest interpolated.
+   Normalisation is within the shortlist, not against a fixed scale.
+2. For Scope value, count only assets that are both in scope and
+   eligible_for_bounty, and weight each by its max_severity cap: an
+   uncapped (null) or critical-capped asset counts full, high about 0.7,
+   medium about 0.4, low about 0.2. An out-of-scope or bounty-ineligible
+   asset contributes nothing - it is surface you cannot be paid for.
+3. Multiply each normalised factor by its weight and sum.
 4. Select the single highest-scoring programme.
 
 ## Tiebreaks
 
 If two candidates land within 5 points, prefer:
-- The one with the smaller (more focused) scope - fewer assets means
-  the squad spends less attention budget triaging out-of-scope noise.
-- The one with the more recent `last_updated_at` - active maintenance
-  beats stale-but-historically-rich.
+- The one whose policy most explicitly green-lights automated testing -
+  an automated squad earns more where its methods are plainly invited.
+- Failing that, the one with the smaller, more focused scope - fewer
+  assets means less attention spent triaging out-of-scope noise.

--- a/squad/programme_manager/tools/selection.py
+++ b/squad/programme_manager/tools/selection.py
@@ -8,33 +8,26 @@ handle, and ``Save Selected Programme`` binds the choice for every
 downstream agent.
 """
 
-import shutil
-
 from pydantic import BaseModel, Field
 
 import runtime
-from models.h1 import Programme, ProgrammePreview, ScopeType, SubmissionState
+from models.h1 import Programme, ProgrammePreview, SubmissionState
 from squad import cyber_tool
 from tools.h1_api import h1
+
+# Programmes hydrated during this run, keyed by handle. The PM hydrates several
+# candidates to score them, then saves exactly one. Holding the hydrated objects
+# in memory keeps that hydrate->save handoff inside the agent WITHOUT writing a
+# programme.json per candidate: the single selection save_programme_tool writes
+# to the run directory is then the only programme.json on disk - the
+# one-typed-artefact-per-stage contract the README documents, and the pre-#115
+# behaviour (one programme.json when the PM is done, not one per hydrated handle).
+_hydrated_this_run: dict[str, Programme] = {}
 
 
 class _BrowseProgrammesArgs(BaseModel):
     """Explicit args_schema for the Browse HackerOne Programmes tool."""
 
-    asset_type: ScopeType | None = Field(
-        default=None,
-        description=(
-            "H1 ``filter[asset_type]`` value, typed as the codebase's"
-            " ``ScopeType`` StrEnum (lowercase Python-side: ``ScopeType."
-            " WILDCARD`` has value ``'wildcard'``). The wrapper uppercases"
-            " on the wire to match H1's filter format. Common picks:"
-            " ``WILDCARD`` for broad surface coverage, ``URL`` for a"
-            " single application target, ``IP_ADDRESS`` / ``CIDR`` for"
-            " network-tier targets. Omit (None) to accept any asset type"
-            " - the H1 default. A wrong value here pulls the wrong"
-            " shortlist."
-        ),
-    )
     bookmarked: bool | None = Field(
         default=None,
         description=(
@@ -55,29 +48,17 @@ class _BrowseProgrammesArgs(BaseModel):
     submission_state: SubmissionState | None = Field(
         default=None,
         description=(
-            "H1 ``filter[submission_state]`` value, typed as the"
-            " ``SubmissionState`` StrEnum. ``OPEN`` excludes paused and"
-            " disabled programmes; almost always pass ``OPEN`` -"
-            " submitting against a paused or disabled programme wastes"
-            " the submission. Omit (None) to accept any state."
-        ),
-    )
-    sort: str | None = Field(
-        default=None,
-        description=(
-            "H1 JSON:API sort key. Prefix with '-' for descending."
-            " Common values: '-launched_at' (newest first),"
-            " 'launched_at' (oldest first), '-resolved_report_count' (most"
-            " active triage)."
+            "A ``SubmissionState`` StrEnum naming the report window:"
+            " ``OPEN`` for programmes accepting reports, paused/disabled"
+            " for those that are not. Omit (None) to leave it unset."
         ),
     )
     limit: int | None = Field(
         default=None,
         description=(
-            "Cap on total previews returned across pages. Omit (None) to use"
-            " the configured default (``config.h1.max_programmes``)."
-            " This is a server-side pagination ceiling, not a per-request"
-            " page size."
+            "Cap on how many previews you get back across all pages. Omit"
+            " (None) to use the configured default. This bounds the total"
+            " returned to you; it is not a per-request page size."
         ),
     )
 
@@ -87,13 +68,10 @@ class _BrowseProgrammesArgs(BaseModel):
 # to be a named parameter so the LLM can discover and pass it. Collapsing
 # into a single dict argument would force the agent to guess valid filter
 # keys.
-# pylint: disable=R0913,R0917
 def browse_programmes_tool(
-    asset_type: ScopeType | None = None,
     bookmarked: bool | None = None,
     offers_bounties: bool | None = None,
     submission_state: SubmissionState | None = None,
-    sort: str | None = None,
     limit: int | None = None,
 ) -> list[ProgrammePreview]:
     """
@@ -106,31 +84,21 @@ def browse_programmes_tool(
     state, and bookmarked - enough to narrow on access mode and bounty
     posture before pulling policy_text and scope.
 
-    Filter kwargs map to H1 filter[*] query params on /hackers/programs and
-    are sent to the server; the H1 default applies when a kwarg is omitted.
-      - asset_type: a ScopeType (e.g. ScopeType.WILDCARD)
-      - bookmarked: True for programmes you have bookmarked
-      - offers_bounties: True to exclude VDPs
-      - submission_state: SubmissionState.OPEN to exclude paused/disabled
-      - sort: e.g. "-launched_at" for newest first
-      - limit: cap on total previews (default config.h1.max_programmes)
+    The filters (bookmarked, offers_bounties, submission_state) narrow the
+    catalog. H1 does not filter its list server-side, so they are applied here
+    against each preview: a programme that does not match every filter you set
+    is dropped before you see it. offers_bounties=True drops VDPs;
+    submission_state=OPEN drops paused/disabled programmes. limit caps how many
+    previews come back.
 
-    Returns a list of ProgrammePreview. Hydrate shortlisted handles with
-    hydrate_programme_tool.
+    Returns a list of ProgrammePreview. Hydrate only the strongest shortlisted
+    handles with hydrate_programme_tool.
     """
-    # H1's filter API expects uppercase asset_type values (URL, WILDCARD,
-    # ...); ScopeType is the parsed Python-side shape with lowercase
-    # values. Normalise here so the agent passes the same enum it sees on
-    # parsed Programme objects, and the wire form stays H1's expected
-    # uppercase.
-    asset_type_wire = asset_type.value.upper() if asset_type is not None else None
     return list(
         h1.browse_programmes(
-            asset_type=asset_type_wire,
             bookmarked=bookmarked,
             offers_bounties=offers_bounties,
             submission_state=submission_state.value if submission_state is not None else None,
-            sort=sort,
             limit=limit,
         )
     )
@@ -155,17 +123,19 @@ class _HydrateProgrammeArgs(BaseModel):
 @cyber_tool("Hydrate HackerOne Programme", args_schema=_HydrateProgrammeArgs)
 def hydrate_programme_tool(handle: str) -> Programme:
     """
-    Fetch full programme detail for one handle - bounty_table, structured
-    scope, policy text, response/payout stats. One HTTP call.
+    Fetch full programme detail for one handle - access/policy attributes,
+    structured scope (in and out), explicit scope exclusions, and policy text.
+    Three HTTP calls (programme detail, structured scopes, scope exclusions).
+    Judge a programme's value from its scope, policy, and access signals.
 
     Expensive relative to browse_programmes_tool, so reserve for candidates
-    the browse step has already shortlisted. The hydrated programme is
-    cached so save_programme_tool can copy it into the run directory.
+    the browse step has already shortlisted. The hydrated programme is held in
+    memory (not written to disk) so save_programme_tool can persist the one you
+    finally select - hydrating ten candidates must not leave ten programme.json
+    files behind; the run gets exactly one, written by save.
     """
     prog = h1.hydrate_programme(handle)
-    cache_path = runtime.programme_cache_path(prog.handle)
-    cache_path.parent.mkdir(parents=True, exist_ok=True)
-    cache_path.write_text(prog.model_dump_json(), encoding="utf-8")
+    _hydrated_this_run[prog.handle] = prog
     return prog
 
 
@@ -175,11 +145,10 @@ class _SaveProgrammeArgs(BaseModel):
     handle: str = Field(
         description=(
             "Exact HackerOne programme handle as it appears in the URL"
-            " (lowercase, no slashes, no spaces). Must match a handle that"
-            " was already hydrated this run - the cached ``programme.json``"
-            " is keyed by handle and a mismatch means downstream agents see"
-            " an empty run directory and reason against a programme that"
-            " was never selected."
+            " (lowercase, no slashes, no spaces). Must match a handle you"
+            " already hydrated this run - save persists the in-memory hydrated"
+            " programme, so a handle that was never hydrated has nothing to"
+            " write and is rejected."
         ),
     )
 
@@ -188,14 +157,26 @@ class _SaveProgrammeArgs(BaseModel):
 def save_programme_tool(handle: str) -> str:
     """
     Record the selected programme for downstream agents. Binds
-    runtime.programme_handle, creates the run directory, and copies the
-    cached programme.json into it. Returns the absolute path to the run
-    directory.
+    runtime.programme_handle, creates the run directory, and writes the single
+    selected programme.json into it. Returns the absolute path to the run
+    directory. This is the only programme.json that reaches disk - one per run,
+    not one per hydrated candidate.
     """
+    prog = _hydrated_this_run.get(handle)
+    if prog is None:
+        # Fail loud instead of silently creating an empty run directory. A
+        # handle not in the hydrated set means hydrate_programme_tool was never
+        # run (or failed) for it, so there is nothing to persist - and a save
+        # that returns success while writing no programme.json is exactly what
+        # lets the select task "finish" with no artefact, only to fail the
+        # downstream guardrail. Surfacing it here lets the agent re-hydrate.
+        raise ValueError(
+            f"No hydrated programme for handle {handle!r}; run "
+            f"'Hydrate HackerOne Programme' for this exact handle first. "
+            f"Saving without a hydrated programme would write no programme.json."
+        )
     runtime.bind_programme(handle)
     run_dir = runtime.run_dir()
     run_dir.mkdir(parents=True, exist_ok=True)
-    cache = runtime.programme_cache_path(handle)
-    if cache.exists():
-        shutil.copy(cache, run_dir / "programme.json")
+    (run_dir / "programme.json").write_text(prog.model_dump_json(), encoding="utf-8")
     return str(run_dir)

--- a/tests/fixtures/h1.py
+++ b/tests/fixtures/h1.py
@@ -1,0 +1,141 @@
+"""HackerOne hacker-API response fixtures.
+
+Builder functions returning the JSON:API payloads HackerOne's hacker API
+actually returns, transcribed key-for-key from the official docs
+(api.hackerone.com/hacker-resources) - the same source the repo's H1 cheatsheet
+was copied from. Tests build doubles from these so a test payload cannot drift
+away from the real contract the way hand-faked dicts did: a phantom bounty_table
+on the detail endpoint, an un-paginated single scope page, a missing
+scope_exclusions endpoint.
+
+Faithful points the old hand-rolled fakes got wrong, pinned here once:
+  - the programme DETAIL endpoint exposes NO bounty_table and NO payout/response
+    stats - those keys are simply not in the documented attribute set;
+  - detail wraps its resource in {"data": {...}} (the same envelope as the list);
+  - structured_scopes and scope_exclusions are paginated (links.next).
+
+Plain functions (imported directly), matching the sibling tests/fixtures/*.py
+builder modules. ``next_link`` takes the absolute URL H1 puts in links.next:
+callers pass one built from the client base when exercising pagination, and omit
+it (the default) for a single terminal page. Any attribute can be overridden via
+keyword to assert on a specific value or, by passing it absent, to exercise a
+parser default.
+"""
+
+from __future__ import annotations
+
+
+def _page(items: list[dict], next_link: str | None) -> dict:
+    return {"data": items, "links": {"next": next_link} if next_link else {}}
+
+
+def programme_attributes(handle: str = "acme", **overrides: object) -> dict:
+    """The attribute block of a programme resource - the documented hacker-API
+    field set, verbatim. Note the absence of bounty_table and of any payout or
+    response-time stats: the hacker API does not expose them here."""
+    attributes: dict[str, object] = {
+        "handle": handle,
+        "name": handle,
+        "currency": "usd",
+        "policy": f"{handle}'s program policy.",
+        "profile_picture": "/assets/global-elements/add-team.png",
+        "submission_state": "open",
+        "triage_active": None,
+        "state": "public_mode",
+        "started_accepting_at": None,
+        "number_of_reports_for_user": 0,
+        "number_of_valid_reports_for_user": 0,
+        "bounty_earned_for_user": 0,
+        "last_invitation_accepted_at_for_user": None,
+        "bookmarked": False,
+        "allows_bounty_splitting": False,
+        "offers_bounties": True,
+        "open_scope": True,
+        "fast_payments": True,
+        "gold_standard_safe_harbor": False,
+    }
+    attributes.update(overrides)
+    return attributes
+
+
+def programme_resource(handle: str = "acme", **overrides: object) -> dict:
+    """One programme resource object: {id, type, attributes, relationships}."""
+    return {
+        "id": 9,
+        "type": "program",
+        "attributes": programme_attributes(handle, **overrides),
+        "relationships": {"structured_scopes": {"data": []}},
+    }
+
+
+def programme_detail(handle: str = "acme", **overrides: object) -> dict:
+    """GET /hackers/programs/{handle} - the wrapped detail response."""
+    return {"data": programme_resource(handle, **overrides)}
+
+
+def programmes_list(
+    handles: list[str] | None = None,
+    *,
+    items: list[dict] | None = None,
+    next_link: str | None = None,
+) -> dict:
+    """GET /hackers/programs - {"data": [resource, ...], "links": {...}}."""
+    if items is None:
+        items = [programme_resource(h) for h in (handles or ["acme"])]
+    return _page(items, next_link)
+
+
+def structured_scope(
+    asset_identifier: str = "https://api.hackerone.com",
+    asset_type: str = "URL",
+    *,
+    eligible_for_bounty: bool = True,
+    eligible_for_submission: bool = True,
+    instruction: str | None = "This is our API",
+    max_severity: str | None = "critical",
+) -> dict:
+    """One GET /hackers/programs/{handle}/structured_scopes entry."""
+    return {
+        "id": "1",
+        "type": "structured-scope",
+        "attributes": {
+            "asset_type": asset_type,
+            "asset_identifier": asset_identifier,
+            "eligible_for_bounty": eligible_for_bounty,
+            "eligible_for_submission": eligible_for_submission,
+            "instruction": instruction,
+            "max_severity": max_severity,
+            "created_at": "2016-02-02T04:05:06.000Z",
+            "updated_at": "2016-02-02T04:05:06.000Z",
+            "confidentiality_requirement": "high",
+            "integrity_requirement": "high",
+            "availability_requirement": "high",
+        },
+    }
+
+
+def structured_scopes(items: list[dict] | None = None, *, next_link: str | None = None) -> dict:
+    """GET /hackers/programs/{handle}/structured_scopes - paginated list."""
+    return _page([structured_scope()] if items is None else items, next_link)
+
+
+def scope_exclusion(
+    category: str = "Denial of Service",
+    details: str = "No DoS/DDoS testing of any kind.",
+) -> dict:
+    """One GET /hackers/programs/{handle}/scope_exclusions entry."""
+    return {
+        "id": "123",
+        "type": "scope-exclusion",
+        "attributes": {
+            "category": category,
+            "details": details,
+            "created_at": "2024-01-01T00:00:00.000Z",
+            "updated_at": "2024-01-01T00:00:00.000Z",
+        },
+    }
+
+
+def scope_exclusions(items: list[dict] | None = None, *, next_link: str | None = None) -> dict:
+    """GET /hackers/programs/{handle}/scope_exclusions - paginated list."""
+    return _page([scope_exclusion()] if items is None else items, next_link)

--- a/tests/squad/programme_manager/test_args_schemas.py
+++ b/tests/squad/programme_manager/test_args_schemas.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import pytest
 from pydantic import BaseModel, ValidationError
 
-from models.h1 import ScopeType, SubmissionState
+from models.h1 import SubmissionState
 from squad.programme_manager import (
     MEMBER,
     _BrowseProgrammesArgs,
@@ -77,14 +77,9 @@ class TestSchemaAcceptReject:
             (
                 _BrowseProgrammesArgs,
                 {
-                    # StrEnum values are lowercase Python-side; the
-                    # wrapper uppercases asset_type before sending it to
-                    # H1.
-                    "asset_type": "wildcard",
                     "bookmarked": True,
                     "offers_bounties": True,
                     "submission_state": "open",
-                    "sort": "-launched_at",
                     "limit": 50,
                 },
             ),
@@ -97,28 +92,16 @@ class TestSchemaAcceptReject:
         instance = schema_cls.model_validate(kwargs)
         assert isinstance(instance, schema_cls)
 
-    def test_browse_rejects_unknown_asset_type(self) -> None:
-        """``asset_type`` is a StrEnum; H1's documented types are the only
-        acceptable values."""
-        with pytest.raises(ValidationError):
-            _BrowseProgrammesArgs.model_validate({"asset_type": "not-a-real-type"})
-
     def test_browse_rejects_unknown_submission_state(self) -> None:
         """``submission_state`` is a StrEnum scoped to the documented H1
         filter values (open / disabled / paused)."""
         with pytest.raises(ValidationError):
             _BrowseProgrammesArgs.model_validate({"submission_state": "closed"})
 
-    def test_browse_accepts_strenum_members_directly(self) -> None:
-        """Passing the StrEnum members (rather than their string values)
-        also validates - the wrapper is happy with either."""
-        instance = _BrowseProgrammesArgs.model_validate(
-            {
-                "asset_type": ScopeType.WILDCARD,
-                "submission_state": SubmissionState.OPEN,
-            }
-        )
-        assert instance.asset_type is ScopeType.WILDCARD
+    def test_browse_accepts_strenum_member_directly(self) -> None:
+        """Passing the StrEnum member (rather than its string value) also
+        validates - the wrapper is happy with either."""
+        instance = _BrowseProgrammesArgs.model_validate({"submission_state": SubmissionState.OPEN})
         assert instance.submission_state is SubmissionState.OPEN
 
     def test_hydrate_accepts_programme_handle(self, programme) -> None:
@@ -147,9 +130,9 @@ class TestSchemaAcceptReject:
         """Browse's filter fields are all optional - extras silently drop.
 
         Pydantic's default is ``extra='ignore'`` and we keep that here:
-        H1's wire layer ignores unknown ``filter[*]`` keys silently
-        anyway, so additional strictness would only confuse agents that
-        pass through an extra key the wrapper would happily forward.
+        browse filters client-side on the preview fields it knows, so an
+        unknown extra key is simply not a filter - dropping it quietly beats
+        rejecting an agent call over a stray key the wrapper would ignore.
         """
         instance = _BrowseProgrammesArgs.model_validate(
             {"offers_bounties": True, "nope": "ignored"}

--- a/tests/squad/programme_manager/test_tools.py
+++ b/tests/squad/programme_manager/test_tools.py
@@ -37,16 +37,14 @@ class TestBrowseProgrammesTool:
         assert result == previews
         # No filter args defaulted, only the one we passed in flight.
         mbrowse.assert_called_once_with(
-            asset_type=None,
             bookmarked=None,
             offers_bounties=True,
             submission_state=None,
-            sort=None,
             limit=None,
         )
 
     def test_forwards_all_filter_args(self, tmp_path) -> None:
-        from models.h1 import ScopeType, SubmissionState
+        from models.h1 import SubmissionState
         from squad.programme_manager import browse_programmes_tool
 
         with patch(
@@ -54,82 +52,83 @@ class TestBrowseProgrammesTool:
             return_value=[],
         ) as mbrowse:
             browse_programmes_tool.func(
-                asset_type=ScopeType.WILDCARD,
                 bookmarked=True,
                 offers_bounties=True,
                 submission_state=SubmissionState.OPEN,
-                sort="-launched_at",
                 limit=50,
             )
 
-        # The wrapper uppercases the asset_type StrEnum value to match
-        # H1's filter[asset_type] wire format; submission_state passes
-        # through as its lowercase StrEnum value.
+        # submission_state passes through as its lowercase StrEnum value.
         mbrowse.assert_called_once_with(
-            asset_type="WILDCARD",
             bookmarked=True,
             offers_bounties=True,
             submission_state="open",
-            sort="-launched_at",
             limit=50,
         )
 
 
 class TestHydrateProgrammeTool:
-    def test_caches_hydrated_programme(self, programme, tmp_path) -> None:
+    def test_holds_hydrated_programme_in_memory_not_on_disk(
+        self, programme, tmp_path, monkeypatch
+    ) -> None:
         from squad.programme_manager import hydrate_programme_tool
+        from squad.programme_manager.tools import selection
 
-        cache_path = tmp_path / programme.handle / "programme.json"
+        monkeypatch.setattr(selection, "_hydrated_this_run", {})
 
-        with (
-            patch(
-                "squad.programme_manager.tools.selection.h1.hydrate_programme",
-                return_value=programme,
-            ) as mhydrate,
-            patch(
-                "runtime.programme_cache_path",
-                return_value=cache_path,
-            ),
-        ):
+        with patch(
+            "squad.programme_manager.tools.selection.h1.hydrate_programme",
+            return_value=programme,
+        ) as mhydrate:
             result = hydrate_programme_tool.func(programme.handle)
 
         assert result == programme
         mhydrate.assert_called_once_with(programme.handle)
-        assert cache_path.exists()
+        # Held in memory for save - NOT written to disk. Hydrating N candidates
+        # must not leave N programme.json files; the run gets exactly one (save's).
+        assert selection._hydrated_this_run[programme.handle] == programme
+        assert not list(tmp_path.rglob("programme.json"))
 
 
 class TestProgrammeManagerTools:
-    def test_save_programme_tool_sets_handle_and_copies(self, programme, tmp_path) -> None:
+    def test_save_writes_single_selection_from_memory(
+        self, programme, tmp_path, monkeypatch
+    ) -> None:
         from squad.programme_manager import save_programme_tool
+        from squad.programme_manager.tools import selection
 
-        cache = tmp_path / "cache" / "programme.json"
-        cache.parent.mkdir(parents=True)
-        cache.write_text(programme.model_dump_json(), encoding="utf-8")
         run_dir = tmp_path / "run"
+        # The handle was hydrated this run, so it is in the in-memory set.
+        monkeypatch.setattr(selection, "_hydrated_this_run", {programme.handle: programme})
 
-        with (
-            patch("runtime.run_dir", return_value=run_dir),
-            patch("runtime.programme_cache_path", return_value=cache),
-        ):
+        with patch("runtime.run_dir", return_value=run_dir):
             result = save_programme_tool.func(programme.handle)
 
         assert runtime.programme_handle == programme.handle
         assert result == str(run_dir)
+        # Exactly one programme.json on disk - the selection.
         assert (run_dir / "programme.json").exists()
+        assert len(list(run_dir.rglob("programme.json"))) == 1
 
-    def test_save_programme_tool_skips_copy_when_cache_missing(self, programme, tmp_path) -> None:
+    def test_save_programme_tool_raises_when_not_hydrated(
+        self, programme, tmp_path, monkeypatch
+    ) -> None:
+        # A handle absent from the in-memory hydrated set means hydrate never ran
+        # (or failed) for it, so there is nothing to persist. save must fail loud
+        # - NOT silently create an empty run directory with no programme.json,
+        # which is what let the select task "succeed" with no artefact and then
+        # fail the downstream guardrail with no clear cause.
         from squad.programme_manager import save_programme_tool
+        from squad.programme_manager.tools import selection
 
         run_dir = tmp_path / "run"
-        absent_cache = tmp_path / "cache" / "programme.json"
+        monkeypatch.setattr(selection, "_hydrated_this_run", {})
 
         with (
             patch("runtime.run_dir", return_value=run_dir),
-            patch("runtime.programme_cache_path", return_value=absent_cache),
+            pytest.raises(ValueError, match="No hydrated programme for handle"),
         ):
-            result = save_programme_tool.func(programme.handle)
+            save_programme_tool.func(programme.handle)
 
-        assert runtime.programme_handle == programme.handle
-        assert result == str(run_dir)
-        assert run_dir.exists()
+        # Failed loud before binding or writing anything: no empty run dir.
         assert not (run_dir / "programme.json").exists()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -42,7 +42,7 @@ class _FakeTask:
         context: list | None = None,
         human_input: bool = False,
         guardrail: object = None,
-        max_retries: int | None = None,
+        guardrail_max_retries: int | None = None,
     ) -> None:
         self.name = name
         self.description = description
@@ -51,7 +51,7 @@ class _FakeTask:
         self.context = context or []
         self.human_input = human_input
         self.guardrail = guardrail
-        self.max_retries = max_retries
+        self.guardrail_max_retries = guardrail_max_retries
 
 
 class TestSquadMemberRead:
@@ -141,7 +141,7 @@ class TestBuildTasks:
         monkeypatch.setattr(squad, "Task", _FakeTask)
         select, *_rest = build_tasks(self._agents())
         assert select.guardrail is validate_select_output
-        assert select.max_retries == 2
+        assert select.guardrail_max_retries == 2
 
     def test_only_select_task_is_guarded(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(squad, "Task", _FakeTask)

--- a/tests/tools/test_h1_api.py
+++ b/tests/tools/test_h1_api.py
@@ -17,6 +17,7 @@ import requests
 
 from models import Severity
 from models.h1 import ScopeType, SubmissionStatus
+from tests.fixtures import h1 as h1f
 
 pytestmark = pytest.mark.unit
 
@@ -36,44 +37,41 @@ def h1_client(monkeypatch):
 # parse_programme
 class TestParseProgramme:
     def _raw_programme(self):
-        return {
-            "attributes": {
-                "handle": "acme",
-                "name": "Acme Corp",
-                "policy": "We allow automated scanning with care.",
-                "bounty_table": {
-                    "data": [
-                        {"attributes": {"label": "high", "maximum_amount": 2000}},
-                        {"attributes": {"label": "critical", "maximum_amount": 5000}},
-                    ]
-                },
-            }
-        }
+        # parse_programme takes the unwrapped resource object (detail["data"]).
+        return h1f.programme_resource(
+            "acme", name="Acme Corp", policy="We allow automated scanning with care."
+        )
 
     def _raw_scope(self, eligible=True):
-        return {
-            "data": [
-                {
-                    "attributes": {
-                        "asset_identifier": "*.acme.com",
-                        "asset_type": "WILDCARD",
-                        "eligible_for_bounty": True,
-                        "eligible_for_submission": eligible,
-                        "instruction": None,
-                    }
-                }
+        return h1f.structured_scopes(
+            [
+                h1f.structured_scope(
+                    "*.acme.com",
+                    "WILDCARD",
+                    eligible_for_submission=eligible,
+                    instruction=None,
+                    max_severity=None,
+                )
             ]
-        }
+        )
 
     def test_parses_handle_and_name(self, h1_client):
         prog = h1_client.parse_programme(self._raw_programme(), self._raw_scope())
         assert prog.handle == "acme"
         assert prog.name == "Acme Corp"
 
-    def test_parses_bounty_table(self, h1_client):
+    def test_hacker_api_has_no_bounty_or_stats_data(self, h1_client):
+        # The hacker API detail endpoint exposes no bounty amounts and no payout
+        # or response-time stats, so parse leaves these at model defaults rather
+        # than fabricating them from attributes that never arrive. Regression net
+        # for the vapourware that had the PM scoring on always-empty fields.
         prog = h1_client.parse_programme(self._raw_programme(), self._raw_scope())
-        assert prog.bounty_table[Severity.HIGH] == 2000
-        assert prog.bounty_table[Severity.CRITICAL] == 5000
+        assert prog.bounty_table == {}
+        assert prog.response_efficiency_pct is None
+        assert prog.avg_time_to_bounty_days is None
+        assert prog.avg_time_to_first_response_days is None
+        assert prog.total_bounties_paid_usd is None
+        assert prog.last_updated_at is None
 
     def test_policy_text_preserved(self, h1_client):
         prog = h1_client.parse_programme(self._raw_programme(), self._raw_scope())
@@ -102,7 +100,9 @@ class TestParseProgramme:
         assert prog.offers_bounties is False
 
     def test_offers_bounties_defaults_true_when_missing(self, h1_client):
-        prog = h1_client.parse_programme(self._raw_programme(), self._raw_scope())
+        raw = self._raw_programme()
+        raw["attributes"].pop("offers_bounties", None)
+        prog = h1_client.parse_programme(raw, self._raw_scope())
         assert prog.offers_bounties is True
 
     def test_accepts_new_reports_false_when_closed(self, h1_client):
@@ -118,7 +118,9 @@ class TestParseProgramme:
         assert prog.accepts_new_reports is True
 
     def test_accepts_new_reports_defaults_true_when_missing(self, h1_client):
-        prog = h1_client.parse_programme(self._raw_programme(), self._raw_scope())
+        raw = self._raw_programme()
+        raw["attributes"].pop("submission_state", None)
+        prog = h1_client.parse_programme(raw, self._raw_scope())
         assert prog.accepts_new_reports is True
 
     def test_state_extracted_verbatim(self, h1_client):
@@ -133,35 +135,10 @@ class TestParseProgramme:
         assert prog.state == "private_mode"
 
     def test_state_none_when_missing(self, h1_client):
-        prog = h1_client.parse_programme(self._raw_programme(), self._raw_scope())
+        raw = self._raw_programme()
+        raw["attributes"].pop("state", None)
+        prog = h1_client.parse_programme(raw, self._raw_scope())
         assert prog.state is None
-
-    def test_parses_response_efficiency_pct(self, h1_client):
-        raw = self._raw_programme()
-        raw["attributes"]["response_efficiency_percentage"] = 87.5
-        prog = h1_client.parse_programme(raw, self._raw_scope())
-        assert prog.response_efficiency_pct == 87.5
-
-    def test_parses_avg_time_to_bounty_days(self, h1_client):
-        raw = self._raw_programme()
-        # 2880 minutes = 2 days exactly
-        raw["attributes"]["average_time_to_bounty_in_minutes"] = 2880
-        prog = h1_client.parse_programme(raw, self._raw_scope())
-        assert prog.avg_time_to_bounty_days == 2.0
-
-    def test_avg_time_to_bounty_days_none_when_missing(self, h1_client):
-        prog = h1_client.parse_programme(self._raw_programme(), self._raw_scope())
-        assert prog.avg_time_to_bounty_days is None
-
-    def test_parses_total_bounties_paid_usd(self, h1_client):
-        raw = self._raw_programme()
-        raw["attributes"]["total_bounties_paid_in_cents"] = 1_500_000
-        prog = h1_client.parse_programme(raw, self._raw_scope())
-        assert prog.total_bounties_paid_usd == 15_000
-
-    def test_total_bounties_paid_usd_none_when_missing(self, h1_client):
-        prog = h1_client.parse_programme(self._raw_programme(), self._raw_scope())
-        assert prog.total_bounties_paid_usd is None
 
     def test_parses_scope_item_max_severity(self, h1_client):
         scope = {
@@ -303,17 +280,54 @@ class TestListProgrammes:
         assert result == {"data": []}
         assert "/hackers/programs/acme/structured_scopes" in mock_get.call_args[0][0]
 
-    def test_get_programme_detail_uses_include_params(self, h1_client):
+    def test_get_structured_scope_paginates(self, h1_client):
+        # The sub-resource is paginated; every page must be aggregated, not just
+        # page one (else a large programme's scope is silently truncated).
+        nxt = f"{h1_client._base}/hackers/programs/acme/structured_scopes?page[number]=2"
+        page1 = {
+            "data": [{"type": "structured-scope", "attributes": {"asset_identifier": "a"}}],
+            "links": {"next": nxt},
+        }
+        page2 = {
+            "data": [{"type": "structured-scope", "attributes": {"asset_identifier": "b"}}],
+            "links": {},
+        }
+        responses = [MagicMock(), MagicMock()]
+        responses[0].json.return_value = page1
+        responses[1].json.return_value = page2
+        for r in responses:
+            r.raise_for_status = MagicMock()
+
+        with patch.object(h1_client._session, "get", side_effect=responses) as mock_get:
+            result = h1_client.get_structured_scope("acme")
+
+        assert [i["attributes"]["asset_identifier"] for i in result["data"]] == ["a", "b"]
+        assert mock_get.call_count == 2
+
+    def test_get_scope_exclusions_hits_endpoint(self, h1_client):
         mock_response = MagicMock()
-        mock_response.json.return_value = {"data": {}, "included": []}
+        mock_response.json.return_value = {"data": []}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(h1_client._session, "get", return_value=mock_response) as mock_get:
+            result = h1_client.get_scope_exclusions("acme")
+
+        assert result == {"data": []}
+        assert "/hackers/programs/acme/scope_exclusions" in mock_get.call_args[0][0]
+
+    def test_get_programme_detail_is_plain_get_no_include(self, h1_client):
+        # Plain GET: the hacker API does NOT inline structured_scopes on detail
+        # (those come from /structured_scopes) and exposes no bounty/stats data
+        # here at all. An unsupported `include` only risks a 400 mid-run.
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"data": {}}
         mock_response.raise_for_status = MagicMock()
 
         with patch.object(h1_client._session, "get", return_value=mock_response) as mock_get:
             h1_client.get_programme_detail("acme")
 
         assert "/hackers/programs/acme" in mock_get.call_args[0][0]
-        params = mock_get.call_args[1]["params"]
-        assert params == {"include": "bounty_table,structured_scopes"}
+        assert mock_get.call_args[1]["params"] is None
 
 
 class TestBrowseProgrammes:
@@ -390,34 +404,34 @@ class TestBrowseProgrammes:
         assert [p.handle for p in previews] == ["p0", "p1", "p2"]
         assert m.call_count == 1
 
-    def test_filter_kwargs_become_filter_bracket_params(self, h1_client):
-        list_payload = self._list_resp([])
-        with patch.object(h1_client, "_get", return_value=list_payload) as m:
-            h1_client.browse_programmes(
-                offers_bounties=True,
-                bookmarked=False,
-                submission_state="open",
-                asset_type="URL",
-                sort="-launched_at",
-            )
-        params = m.call_args[0][1]
-        # H1 filter params follow JSON:API bracket notation.
-        assert params["filter[offers_bounties]"] == "true"
-        assert params["filter[bookmarked]"] == "false"
-        assert params["filter[submission_state]"] == "open"
-        assert params["filter[asset_type]"] == "URL"
-        assert params["sort"] == "-launched_at"
+    def test_filters_client_side_on_preview_fields(self, h1_client):
+        # H1 does not filter server-side, so browse_programmes drops the
+        # non-matching previews itself.
+        list_payload = self._list_resp(
+            [
+                ("acme", {"handle": "acme", "offers_bounties": True, "submission_state": "open"}),
+                ("vdp", {"handle": "vdp", "offers_bounties": False, "submission_state": "open"}),
+                (
+                    "paused",
+                    {"handle": "paused", "offers_bounties": True, "submission_state": "paused"},
+                ),
+            ]
+        )
+        with patch.object(h1_client, "_get", return_value=list_payload):
+            previews = h1_client.browse_programmes(offers_bounties=True, submission_state="open")
+        # Only acme matches BOTH filters: vdp fails offers_bounties, paused fails state.
+        assert [p.handle for p in previews] == ["acme"]
 
-    def test_omits_filter_param_when_arg_is_none(self, h1_client):
-        list_payload = self._list_resp([])
-        with patch.object(h1_client, "_get", return_value=list_payload) as m:
-            h1_client.browse_programmes(offers_bounties=True)
-        params = m.call_args[0][1]
-        assert "filter[offers_bounties]" in params
-        assert "filter[bookmarked]" not in params
-        assert "filter[asset_type]" not in params
-        assert "filter[submission_state]" not in params
-        assert "sort" not in params
+    def test_no_filters_returns_every_preview(self, h1_client):
+        list_payload = self._list_resp(
+            [
+                ("acme", {"handle": "acme", "offers_bounties": True}),
+                ("vdp", {"handle": "vdp", "offers_bounties": False}),
+            ]
+        )
+        with patch.object(h1_client, "_get", return_value=list_payload):
+            previews = h1_client.browse_programmes()
+        assert [p.handle for p in previews] == ["acme", "vdp"]
 
     def test_skips_records_with_missing_handle(self, h1_client):
         # H1 list shapes that have no handle attribute and no id field are
@@ -435,112 +449,117 @@ class TestBrowseProgrammes:
 
 
 class TestHydrateProgramme:
-    """hydrate_programme fetches one full Programme from the detail endpoint."""
+    """hydrate_programme makes three calls against the real hacker API contract:
+    the detail endpoint for access/policy attributes, the dedicated
+    /structured_scopes sub-resource for scope, and /scope_exclusions for the
+    explicit prohibition set. The hacker API does NOT inline scopes on detail
+    (docs: api.hackerone.com/hacker-resources) nor expose any bounty/stats data -
+    faking either was the bug that let the old suite pass while every hydrated
+    programme came back scope-less and value-less."""
 
-    def _detail_resp(self, handle, state: str | None = "public_mode"):
-        attributes = {
-            "handle": handle,
-            "name": handle.upper(),
-            "policy": "Automated scanning permitted.",
-            "bounty_table": {
-                "data": [{"attributes": {"label": "critical", "maximum_amount": 5000}}]
-            },
-        }
-        if state is not None:
-            attributes["state"] = state
-        return {
-            "data": {"attributes": attributes},
-            "included": [
-                {
-                    "type": "structured-scope",
-                    "attributes": {
-                        "asset_identifier": f"*.{handle}.com",
-                        "asset_type": "WILDCARD",
-                        "eligible_for_bounty": True,
-                        "eligible_for_submission": True,
-                    },
-                }
-            ],
-        }
+    def _detail_resp(self, handle, state="public_mode"):
+        return h1f.programme_detail(
+            handle, name=handle.upper(), policy="Automated scanning permitted.", state=state
+        )
+
+    def _scope_resp(self, handle):
+        return h1f.structured_scopes([h1f.structured_scope(f"*.{handle}.com", "WILDCARD")])
+
+    def _excl_resp(self, category="Denial of Service", details="No DoS/DDoS testing."):
+        return h1f.scope_exclusions([h1f.scope_exclusion(category, details)])
 
     def test_returns_typed_programme(self, h1_client):
-        with patch.object(h1_client, "_get", return_value=self._detail_resp("acme")):
+        with patch.object(
+            h1_client,
+            "_get",
+            side_effect=[self._detail_resp("acme"), self._scope_resp("acme"), {"data": []}],
+        ):
             prog = h1_client.hydrate_programme("acme")
         assert prog.handle == "acme"
         assert prog.name == "ACME"
-        assert prog.bounty_table[Severity.CRITICAL] == 5000
+        # No bounty data on the hacker API - the table is empty, not fabricated.
+        assert prog.bounty_table == {}
 
     def test_hydrate_carries_state_through(self, h1_client):
         with patch.object(
-            h1_client, "_get", return_value=self._detail_resp("acme", state="private_mode")
+            h1_client,
+            "_get",
+            side_effect=[
+                self._detail_resp("acme", state="private_mode"),
+                self._scope_resp("acme"),
+                {"data": []},
+            ],
         ):
             prog = h1_client.hydrate_programme("acme")
         assert prog.state == "private_mode"
 
-    def test_uses_detail_endpoint_with_include(self, h1_client):
-        with patch.object(h1_client, "_get", return_value=self._detail_resp("acme")) as m:
+    def test_fetches_detail_then_scopes_then_exclusions(self, h1_client):
+        with patch.object(
+            h1_client,
+            "_get",
+            side_effect=[self._detail_resp("acme"), self._scope_resp("acme"), self._excl_resp()],
+        ) as m:
             h1_client.hydrate_programme("acme")
-        path = m.call_args[0][0]
-        if "params" in m.call_args[1]:
-            params = m.call_args[1]["params"]
-        elif len(m.call_args[0]) > 1:
-            params = m.call_args[0][1]
-        else:
-            params = {}
-        assert "/hackers/programs/acme" in path
-        assert params.get("include") == "bounty_table,structured_scopes"
+        assert m.call_count == 3
+        detail_path = m.call_args_list[0][0][0]
+        detail_params = m.call_args_list[0][1].get("params", {})
+        scope_path = m.call_args_list[1][0][0]
+        excl_path = m.call_args_list[2][0][0]
+        assert detail_path == "/hackers/programs/acme"
+        assert detail_params == {}
+        assert scope_path == "/hackers/programs/acme/structured_scopes"
+        assert excl_path == "/hackers/programs/acme/scope_exclusions"
 
-    def test_includes_structured_scope_from_detail(self, h1_client):
-        with patch.object(h1_client, "_get", return_value=self._detail_resp("acme")):
+    def test_includes_structured_scope_from_scope_endpoint(self, h1_client):
+        with patch.object(
+            h1_client,
+            "_get",
+            side_effect=[self._detail_resp("acme"), self._scope_resp("acme"), {"data": []}],
+        ):
             prog = h1_client.hydrate_programme("acme")
         assert prog.in_scope[0].asset_identifier == "*.acme.com"
         assert prog.in_scope[0].asset_type == ScopeType.WILDCARD
 
+    def test_folds_scope_exclusions_into_out_of_scope(self, h1_client):
+        # An explicit /scope_exclusions entry must surface as an out-of-scope
+        # item so the PenTester sees the prohibition - not only the
+        # structured_scopes entries flagged ineligible.
+        with patch.object(
+            h1_client,
+            "_get",
+            side_effect=[
+                self._detail_resp("acme"),
+                self._scope_resp("acme"),
+                self._excl_resp(category="Social engineering", details="No phishing staff."),
+            ],
+        ):
+            prog = h1_client.hydrate_programme("acme")
+        excluded = [s for s in prog.out_of_scope if s.asset_identifier == "Social engineering"]
+        assert excluded, "scope_exclusions entry did not reach out_of_scope"
+        assert excluded[0].eligible_for_bounty is False
+        assert excluded[0].instruction == "No phishing staff."
 
-class TestGetProgrammeStats:
-    def test_returns_parsed_fields(self, h1_client):
-        mock_response = MagicMock()
-        mock_response.raise_for_status = MagicMock()
-        mock_response.json.return_value = {
-            "data": {
-                "attributes": {
-                    "response_efficiency_percentage": 95,
-                    "average_time_to_first_programme_response_in_minutes": 120,
-                    "average_time_to_bounty_in_minutes": 14400,
-                    "average_time_to_resolution_in_minutes": 43200,
-                    "total_bounties_paid_in_cents": 500000,
-                    "state": "public_mode",
-                }
-            }
-        }
+    def test_hydrate_survives_scope_exclusions_error(self, h1_client):
+        # scope_exclusions is supplementary: an error fetching it must not block
+        # selecting the programme. Hydrate proceeds with the structured scope.
+        def _side_effect(path, params=None):
+            if path.endswith("/scope_exclusions"):
+                raise requests.HTTPError(response=MagicMock(status_code=404))
+            if path.endswith("/structured_scopes"):
+                return self._scope_resp("acme")
+            return self._detail_resp("acme")
 
-        with patch.object(h1_client._session, "get", return_value=mock_response):
-            stats = h1_client.get_programme_stats("acme")
+        with patch.object(h1_client, "_get", side_effect=_side_effect):
+            prog = h1_client.hydrate_programme("acme")
+        assert prog.handle == "acme"
+        assert prog.in_scope[0].asset_identifier == "*.acme.com"
 
-        assert stats["handle"] == "acme"
-        assert stats["response_efficiency_pct"] == 95
-        assert stats["avg_time_to_bounty_minutes"] == 14400
-        assert stats["total_bounties_paid_cents"] == 500000
-
-    def test_accepting_reports_true_when_public_mode(self, h1_client):
-        mock_response = MagicMock()
-        mock_response.raise_for_status = MagicMock()
-        mock_response.json.return_value = {"data": {"attributes": {"state": "public_mode"}}}
-
-        with patch.object(h1_client._session, "get", return_value=mock_response):
-            stats = h1_client.get_programme_stats("acme")
-
-        assert stats["accepting_reports"] is True
-
-    def test_accepting_reports_false_when_not_public_mode(self, h1_client):
-        mock_response = MagicMock()
-        mock_response.raise_for_status = MagicMock()
-        mock_response.json.return_value = {"data": {"attributes": {"state": "private_mode"}}}
-
-        with patch.object(h1_client._session, "get", return_value=mock_response):
-            stats = h1_client.get_programme_stats("acme")
-
-        assert stats["accepting_reports"] is False
+    def test_raises_when_detail_has_no_programme(self, h1_client):
+        # Empty/malformed detail must fail loud, not fabricate an "unknown"
+        # programme the PM then caches and "selects".
+        with patch.object(h1_client, "_get", side_effect=[{"data": {}}]):
+            with pytest.raises(ValueError, match="no usable programme detail"):
+                h1_client.hydrate_programme("ghost")
 
 
 class TestListReports:

--- a/tests/tools/test_h1_api_contract.py
+++ b/tests/tools/test_h1_api_contract.py
@@ -1,0 +1,157 @@
+"""
+tests/tools/test_h1_api_contract.py - contract/slice tests for the H1 client.
+
+These mock at the HTTP boundary (``Session.get``), NOT at ``_get``, and the
+fake server mimics HackerOne's *real* hacker-API contract
+(api.hackerone.com/hacker-resources):
+
+  - the programme DETAIL endpoint returns only ``data.attributes`` - it does
+    NOT inline structured scopes (no ``included`` array);
+  - structured scopes come only from the dedicated
+    ``/hackers/programs/{handle}/structured_scopes`` sub-resource;
+  - list pagination is an *absolute* ``links.next`` URL.
+
+The pre-existing unit tests in ``test_h1_api.py`` faked an ``included`` scope
+array on the detail response - a shape H1 never returns - which is why they
+stayed green while every hydrated programme came back scope-less (#115) and
+pagination doubled the base URL. These tests would have caught both. They are
+network-free (the session is mocked) so they run in the ``-m unit`` gate.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import runtime
+from config import config
+from models.h1 import ScopeType
+from squad.guardrails import validate_select_output
+from squad.programme_manager import (
+    browse_programmes_tool,
+    hydrate_programme_tool,
+    save_programme_tool,
+)
+from squad.programme_manager.tools import selection
+from tests.fixtures import h1 as h1f
+
+pytestmark = pytest.mark.unit
+
+_BASE = config.h1.base_url
+
+
+def _list_page1() -> dict:
+    # links.next is ABSOLUTE, exactly as H1 returns it - the shape that used
+    # to be concatenated onto the base and 404.
+    return h1f.programmes_list(
+        items=[h1f.programme_resource("acme", name="Acme")],
+        next_link=f"{_BASE}/hackers/programs?page[number]=2&page[size]=25",
+    )
+
+
+def _list_page2() -> dict:
+    return h1f.programmes_list(items=[h1f.programme_resource("beta", name="Beta")])
+
+
+def _detail() -> dict:
+    # Mirrors the documented detail shape: no `included`, no bounty_table - the
+    # hacker API inlines no scopes on detail and exposes no bounty data at all.
+    return h1f.programme_detail("acme", name="Acme", policy="Automated testing permitted.")
+
+
+def _scopes() -> dict:
+    return h1f.structured_scopes([h1f.structured_scope("*.acme.com", "WILDCARD", instruction=None)])
+
+
+def _exclusions() -> dict:
+    return h1f.scope_exclusions([h1f.scope_exclusion("Denial of Service")])
+
+
+class _FakeH1Server:
+    """Routes Session.get calls to the faithful H1 response for each path,
+    recording every requested URL so tests can assert no base-doubling."""
+
+    def __init__(self) -> None:
+        self.urls: list[str] = []
+
+    def get(self, url: str, params: dict | None = None, timeout: int | None = None):
+        self.urls.append(url)
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        if "/structured_scopes" in url:
+            resp.json.return_value = _scopes()
+        elif "/scope_exclusions" in url:
+            resp.json.return_value = _exclusions()
+        elif "/hackers/programs/" in url:  # detail (handle path) - after sub-resource checks
+            resp.json.return_value = _detail()
+        elif "page[number]=2" in url:
+            resp.json.return_value = _list_page2()
+        else:
+            resp.json.return_value = _list_page1()
+        return resp
+
+
+@pytest.fixture()
+def fake_h1(monkeypatch):
+    # Patch the session on the SAME singleton the tool wrappers call. selection
+    # binds `from tools.h1_api import h1` at import, so it keeps the original
+    # instance even after test_h1_api.py's fixture reloads tools.h1_api - patch
+    # selection.h1, not tools.h1_api.h1, or the wrappers hit the real network.
+    server = _FakeH1Server()
+    monkeypatch.setattr(selection.h1._session, "get", server.get)
+    return server
+
+
+class TestBrowsePaginationContract:
+    def test_paginates_via_absolute_next_without_doubling_base(self, fake_h1):
+        previews = browse_programmes_tool.func(limit=5)
+
+        assert [p.handle for p in previews] == ["acme", "beta"]
+        # The page-2 fetch used the absolute links.next as-is, base intact.
+        assert f"{_BASE}/hackers/programs?page[number]=2&page[size]=25" in fake_h1.urls
+        # The regression signature: base concatenated onto an absolute URL.
+        assert all("v1https://" not in u for u in fake_h1.urls), fake_h1.urls
+
+
+class TestHydrateScopeContract:
+    def test_scope_populated_from_dedicated_endpoint(self, fake_h1):
+        prog = hydrate_programme_tool.func("acme")
+
+        # The #115 regression catcher: scopes come from /structured_scopes, not
+        # from a (never-present) `included` array on detail. If hydrate read
+        # detail["included"], in_scope would be empty here.
+        assert prog.handle == "acme"
+        assert prog.in_scope, "hydrated programme has no in-scope assets"
+        assert prog.in_scope[0].asset_identifier == "*.acme.com"
+        assert prog.in_scope[0].asset_type == ScopeType.WILDCARD
+        # Both endpoints were hit: detail then structured_scopes.
+        assert f"{_BASE}/hackers/programs/acme" in fake_h1.urls
+        assert f"{_BASE}/hackers/programs/acme/structured_scopes" in fake_h1.urls
+        # And /scope_exclusions: its entries fold into out_of_scope so the
+        # PenTester sees the do-not-touch set, not only the ineligible scopes.
+        assert f"{_BASE}/hackers/programs/acme/scope_exclusions" in fake_h1.urls
+        assert any(s.asset_identifier == "Denial of Service" for s in prog.out_of_scope)
+
+
+class TestFullSelectionSlice:
+    def test_browse_hydrate_save_passes_guardrail(self, fake_h1, tmp_path, monkeypatch):
+        run_dir = tmp_path / "run"
+        monkeypatch.setattr(runtime, "programme_handle", None)
+        monkeypatch.setattr("runtime.run_dir", lambda: run_dir)
+
+        # 1. survey -> 2. hydrate the pick (held in memory) -> 3. persist the
+        #    single selection to the run dir.
+        previews = browse_programmes_tool.func(limit=5)
+        assert previews
+        hydrate_programme_tool.func("acme")
+        save_programme_tool.func("acme")
+
+        # The selection artefact the whole pipeline reads is on disk and real.
+        saved = run_dir / "programme.json"
+        assert saved.exists()
+
+        # 4. the select-task guardrail accepts it - so an empty-feedback Enter
+        # actually finishes the task instead of looping on a failed guardrail.
+        ok, _payload = validate_select_output(MagicMock(raw="selected acme"))
+        assert ok is True

--- a/tools/h1_api.py
+++ b/tools/h1_api.py
@@ -19,6 +19,7 @@ H1 hacker API docs: https://api.hackerone.com/hacker-resources/
 from __future__ import annotations
 
 import logging
+import threading
 from datetime import UTC, datetime
 from typing import cast
 
@@ -85,23 +86,67 @@ class H1Client:
             config.h1.api_token,
         )
         self._base = config.h1.base_url
-        self._session = requests.Session()
-        self._session.auth = self._auth
-        self._session.headers.update(
-            {
-                "Accept": "application/json",
-                "Content-Type": "application/json",
-                "User-Agent": http.user_agent(),
-            }
-        )
+        # requests.Session is NOT thread-safe, and CrewAI dispatches tool calls
+        # (e.g. several hydrate_programme calls in one agent turn) on separate
+        # threads that all share this single module-level client. A shared
+        # Session lets concurrent requests corrupt each other's connection
+        # state - returning programme B's detail for a request made for
+        # programme A. Give each thread its own Session (built lazily, identical
+        # auth/headers) so calls never interleave on one connection pool.
+        self._local = threading.local()
 
     # Internal helpers
+
+    @property
+    def _session(self) -> requests.Session:
+        """Per-thread requests.Session - see __init__ for the thread-safety rationale."""
+        session: requests.Session | None = getattr(self._local, "session", None)
+        if session is None:
+            session = requests.Session()
+            session.auth = self._auth
+            session.headers.update(
+                {
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                    "User-Agent": http.user_agent(),
+                }
+            )
+            self._local.session = session
+        return session
 
     def _get(self, path: str, params: dict | None = None) -> dict:
         url = f"{self._base}{path}"
         resp = self._session.get(url, params=params, timeout=30)
         resp.raise_for_status()
         return cast(dict, resp.json())
+
+    def _next_path(self, data: dict) -> str | None:
+        """Relative path for the next page, or None.
+
+        H1's JSON:API links.next is an *absolute* URL
+        (https://api.hackerone.com/v1/hackers/programs?page[number]=2...);
+        strip our base off so _get's concatenation doesn't double it and 404.
+        """
+        nxt = data.get("links", {}).get("next")
+        return nxt.removeprefix(self._base) if nxt else None
+
+    def _get_all(self, path: str, page_size: int = 100) -> list[dict]:
+        """Fetch and concatenate every page of a paginated JSON:API list.
+
+        Follows links.next from the first page to the last and joins each page's
+        ``data`` array. H1 paginates the structured_scopes and scope_exclusions
+        sub-resources, so reading only page one silently truncates a large
+        programme's scope - this aggregates the whole set.
+        """
+        items: list[dict] = []
+        params: dict | None = {"page[size]": page_size}
+        nxt: str | None = path
+        while nxt:
+            data = self._get(nxt, params)
+            items.extend(data.get("data", []))
+            nxt = self._next_path(data)
+            params = None
+        return items
 
     def _post(self, path: str, payload: dict) -> dict:
         url = f"{self._base}{path}"
@@ -120,12 +165,12 @@ class H1Client:
         """
         results: list[dict] = []
         params = {"page[size]": page_size}
-        path = "/hackers/programs"
+        path: str | None = "/hackers/programs"
 
         while path and len(results) < config.h1.max_programmes:
             data = self._get(path, params)
             results.extend(data.get("data", []))
-            path = data.get("links", {}).get("next", None)
+            path = self._next_path(data)
             params = {}
 
         return results[: config.h1.max_programmes]
@@ -134,29 +179,49 @@ class H1Client:
         """Fetch full policy detail for a given programme handle."""
         return self._get(f"/hackers/programs/{handle}")
 
-    def get_structured_scope(self, handle: str) -> dict:
-        """Fetch the structured scope (in/out) for a programme."""
-        return self._get(f"/hackers/programs/{handle}/structured_scopes")
+    def get_structured_scope(self, handle: str, page_size: int = 100) -> dict:
+        """Fetch the full structured scope (in/out) for a programme.
+
+        The /structured_scopes sub-resource is paginated (JSON:API links.next),
+        so a programme with more entries than one page is split across pages.
+        Aggregate every page so parse_programme sees the COMPLETE scope; reading
+        only page one silently truncates a large programme's in/out-of-scope set,
+        which the PenTester would then mistake for the whole attack surface.
+        """
+        return {"data": self._get_all(f"/hackers/programs/{handle}/structured_scopes", page_size)}
+
+    def get_scope_exclusions(self, handle: str, page_size: int = 100) -> dict:
+        """Fetch a programme's explicit scope exclusions (the do-not-touch set).
+
+        GET /hackers/programs/{handle}/scope_exclusions returns custom
+        out-of-scope entries - each a {category, details} pair naming an excluded
+        asset class or prohibited activity, distinct from the structured_scopes
+        items flagged not eligible_for_submission. Paginated like
+        structured_scopes. hydrate_programme folds these into
+        Programme.out_of_scope so the PenTester sees the full prohibition set.
+        """
+        return {"data": self._get_all(f"/hackers/programs/{handle}/scope_exclusions", page_size)}
 
     def get_programme_detail(self, handle: str) -> dict:
-        """Fetch programme detail with bounty_table and structured_scopes inline.
+        """Fetch programme detail attributes for one handle.
 
-        Halves the round-trips per programme compared to calling
-        get_programme_policy + get_structured_scope separately.
+        Plain GET /hackers/programs/{handle} - no `include`. The hacker API does
+        NOT expose bounty amounts or programme stats here: there is no
+        bounty_table, response-efficiency, time-to-bounty or total-paid field
+        (confirmed against the documented /hackers/* surface). The detail carries
+        the access/policy attributes plus a relationships reference for scope; the
+        full scope and exclusion sets live behind the dedicated
+        /structured_scopes and /scope_exclusions sub-resources, which
+        hydrate_programme fetches separately.
         """
-        return self._get(
-            f"/hackers/programs/{handle}",
-            params={"include": "bounty_table,structured_scopes"},
-        )
+        return self._get(f"/hackers/programs/{handle}")
 
     def browse_programmes(
         self,
         *,
-        asset_type: str | None = None,
         bookmarked: bool | None = None,
         offers_bounties: bool | None = None,
         submission_state: str | None = None,
-        sort: str | None = None,
         limit: int | None = None,
         page_size: int = 25,
     ) -> list[ProgrammePreview]:
@@ -166,38 +231,29 @@ class H1Client:
         The caller surveys the catalog, shortlists handles, then pays for
         hydration on just those candidates via hydrate_programme.
 
-        Filter kwargs map to H1's JSON:API filter[*] query params on
-        /hackers/programs. Each kwarg is omitted from the request entirely
-        when None, so the H1 default applies. Booleans are sent as lowercase
-        "true"/"false" - the wire form filter[*] params expect.
+        H1's list endpoint only paginates - it does NOT filter server-side - so
+        the filters (bookmarked, offers_bounties, submission_state) are applied
+        here, client-side, against each preview's own fields: a preview that does
+        not match every supplied filter is dropped before it is returned. Pages
+        are fetched until `limit` matching previews are collected or the catalog
+        is exhausted.
 
-        limit caps the total returned previews across pages; defaults to
-        config.h1.max_programmes. page_size is the per-request page size,
-        not the cap.
+        limit caps the total returned previews; defaults to
+        config.h1.max_programmes. page_size is the per-request page size.
         """
         cap = limit if limit is not None else config.h1.max_programmes
-
-        params: dict[str, object] = {"page[size]": page_size}
-        # FIXME: the exact H1 filter[*] keys for /hackers/programs are not
-        # exhaustively confirmed against a captured request - tracked in #43.
-        # The four below match attributes the list endpoint is known to
-        # expose; passing an unknown filter key would be silently ignored by
-        # H1, so the worst case is "filter did nothing".
-        _filter_kwargs = {
-            "asset_type": asset_type,
-            "bookmarked": bookmarked,
+        # H1 ignores filter[*] query params on this endpoint, so filtering is
+        # client-side: None means "no constraint"; otherwise the preview's own
+        # field must equal the requested value.
+        wanted: dict[str, object] = {
             "offers_bounties": offers_bounties,
             "submission_state": submission_state,
+            "bookmarked": bookmarked,
         }
-        for key, value in _filter_kwargs.items():
-            if value is None:
-                continue
-            params[f"filter[{key}]"] = str(value).lower() if isinstance(value, bool) else str(value)
-        if sort is not None:
-            params["sort"] = sort
 
         previews: list[ProgrammePreview] = []
         path: str | None = "/hackers/programs"
+        params: dict[str, object] = {"page[size]": page_size}
         while path and len(previews) < cap:
             data = self._get(path, params)
             for raw in data.get("data", []):
@@ -207,6 +263,10 @@ class H1Client:
                     # A preview with no handle cannot be hydrated downstream;
                     # the PM has no way to act on it. Drop it rather than
                     # surface a record the agent must defensively skip.
+                    continue
+                if any(
+                    want is not None and attrs.get(field) != want for field, want in wanted.items()
+                ):
                     continue
                 previews.append(
                     ProgrammePreview(
@@ -220,9 +280,7 @@ class H1Client:
                 )
                 if len(previews) >= cap:
                     break
-            path = data.get("links", {}).get("next")
-            # Pagination links from H1 already encode page params; subsequent
-            # calls should not redundantly carry the initial filter dict.
+            path = self._next_path(data)
             params = {}
 
         return previews
@@ -230,30 +288,66 @@ class H1Client:
     def hydrate_programme(self, handle: str) -> Programme:
         """Fetch full detail for one programme and return a typed Programme.
 
-        Pulls bounty_table + structured_scopes inline via the detail endpoint's
-        include parameter. One HTTP call. Use after browse_programmes to drill
+        Three calls per programme: the detail endpoint for access/policy
+        attributes, the structured_scopes sub-resource for in/out scope, and the
+        scope_exclusions sub-resource for explicit prohibitions (the hacker API
+        inlines none of these on detail). Use after browse_programmes to drill
         into a specific candidate the PM wants to score.
         """
         detail = self.get_programme_detail(handle)
-        detail_data = detail.get("data", {})
-        included = detail.get("included", [])
-        scope_data = {"data": [i for i in included if i.get("type") == "structured-scope"]}
-        return self.parse_programme(detail_data, scope_data)
+        # The detail endpoint wraps the programme in a JSON:API {"data": {...}}
+        # envelope - the same shape as the list endpoint, just a single object
+        # instead of an array. (The pre-#136 find_programmes hydrated via
+        # detail.get("data") on this same endpoint.) `or detail` is a defensive
+        # fallback so an unexpectedly unwrapped response degrades to the clear
+        # ValueError below instead of a KeyError here; it is not a claim that
+        # the API ever returns the object unwrapped.
+        detail_data = detail.get("data") or detail
+        if not detail_data.get("attributes"):
+            # No usable resource object - fail loud rather than letting
+            # parse_programme fabricate an "unknown" handle the PM then caches
+            # and "selects". H1 returns a 2xx with no attributes for a handle
+            # the account cannot access (a guessed/wrong handle), so surface
+            # what it actually returned: the agent then knows to pick a handle
+            # from browse_programmes rather than invent one, and the failure is
+            # debuggable from the message without a re-run.
+            raise ValueError(
+                f"H1 returned no usable programme detail for handle {handle!r} "
+                f"(GET /hackers/programs/{handle}; response keys={list(detail.keys())}, "
+                f"data={detail.get('data')!r}). Hydrate only handles that "
+                f"browse_programmes actually returned; do not invent handles."
+            )
+        # Scopes and exclusions come from dedicated sub-resources, not from
+        # detail's `included` (which the hacker API leaves empty). Both are
+        # paginated and aggregated; parse_programme folds the exclusions into
+        # out_of_scope.
+        scope_data = self.get_structured_scope(handle)
+        try:
+            exclusions = self.get_scope_exclusions(handle)
+        except requests.HTTPError as exc:
+            # Exclusions are supplementary do-not-touch detail, not gating: never
+            # let them block selecting a programme (the pipeline's first step).
+            # Log loudly and proceed with the structured-scope view alone.
+            logger.warning("scope_exclusions fetch failed for %s: %s", handle, exc)
+            exclusions = {"data": []}
+        return self.parse_programme(detail_data, scope_data, exclusions)
 
     # Data parsers
 
-    def parse_programme(self, raw: dict, scope_data: dict) -> Programme:
-        """Convert raw H1 API dicts into a typed Programme model."""
+    def parse_programme(
+        self, raw: dict, scope_data: dict, scope_exclusions: dict | None = None
+    ) -> Programme:
+        """Convert raw H1 API dicts into a typed Programme model.
+
+        ``scope_data`` is the aggregated /structured_scopes payload and
+        ``scope_exclusions`` the aggregated /scope_exclusions payload; the
+        latter's entries are merged into ``out_of_scope`` so the prohibition set
+        is complete. The hacker API exposes no bounty or stats data, so
+        ``bounty_table`` and the payout/response-time fields are left at their
+        model defaults - there is nothing to parse (see get_programme_detail).
+        """
         attrs = raw.get("attributes", {})
         handle = attrs.get("handle", raw.get("id", "unknown"))
-
-        bounty_table: dict[Severity, int] = {}
-        for offer in attrs.get("bounty_table", {}).get("data", []):
-            o_attrs = offer.get("attributes", {})
-            sev_str = o_attrs.get("label", "medium").lower()
-            amount = int(o_attrs.get("maximum_amount", 0) or 0)
-            sev = _H1_SEVERITY_MAP.get(sev_str, Severity.MEDIUM)
-            bounty_table[sev] = amount
 
         in_scope: list[ScopeItem] = []
         out_of_scope: list[ScopeItem] = []
@@ -274,51 +368,39 @@ class H1Client:
             else:
                 out_of_scope.append(scope_item)
 
-        policy_text: str = attrs.get("policy", "") or ""
+        # /scope_exclusions carries custom prohibitions ({category, details}) that
+        # are not structured_scopes entries - fold each into out_of_scope so the
+        # PenTester sees the full do-not-touch set. category names the excluded
+        # class/activity (it has no asset_identifier of its own); details is the
+        # human instruction; an exclusion is never bounty-eligible.
+        for excl in (scope_exclusions or {}).get("data", []):
+            e_attrs = excl.get("attributes", {})
+            out_of_scope.append(
+                ScopeItem(
+                    asset_identifier=e_attrs.get("category") or "",
+                    asset_type=ScopeType.OTHER,
+                    eligible_for_bounty=False,
+                    instruction=e_attrs.get("details"),
+                )
+            )
 
-        offers_bounties: bool = bool(attrs.get("offers_bounties", True))
         submission_state: str = attrs.get("submission_state", "open") or "open"
-        accepts_new_reports: bool = submission_state == "open"
-
-        response_efficiency_pct: float | None = attrs.get("response_efficiency_percentage")
-        avg_bounty_minutes: float | None = attrs.get("average_time_to_bounty_in_minutes")
-        avg_time_to_bounty_days: float | None = (
-            round(avg_bounty_minutes / (60 * 24), 1) if avg_bounty_minutes else None
-        )
-        avg_first_resp_minutes: float | None = attrs.get(
-            "average_time_to_first_programme_response_in_minutes"
-        )
-        avg_time_to_first_response_days: float | None = (
-            round(avg_first_resp_minutes / (60 * 24), 1) if avg_first_resp_minutes else None
-        )
-        total_cents: int | None = attrs.get("total_bounties_paid_in_cents")
-        total_bounties_paid_usd: int | None = total_cents // 100 if total_cents else None
-        triage_active: bool | None = attrs.get("triage_active")
-        state: str | None = attrs.get("state")
-        last_updated_str: str | None = attrs.get("updated_at")
-        last_updated_at: datetime | None = (
-            datetime.fromisoformat(last_updated_str.replace("Z", "+00:00"))
-            if last_updated_str
-            else None
-        )
-
+        # bounty_table and the payout/response-time stats stay at their model
+        # defaults ({} / None): the hacker API does not return them (confirmed
+        # against the docs, the captured detail shape, and a real run), so faking
+        # them from absent attributes is exactly the vapourware to avoid.
         return Programme(
             handle=handle,
             name=attrs.get("name", handle),
             url=f"https://hackerone.com/{handle}",
-            bounty_table=bounty_table,
+            bounty_table={},
             in_scope=in_scope,
             out_of_scope=out_of_scope,
-            offers_bounties=offers_bounties,
-            accepts_new_reports=accepts_new_reports,
-            response_efficiency_pct=response_efficiency_pct,
-            avg_time_to_bounty_days=avg_time_to_bounty_days,
-            avg_time_to_first_response_days=avg_time_to_first_response_days,
-            total_bounties_paid_usd=total_bounties_paid_usd,
-            triage_active=triage_active,
-            last_updated_at=last_updated_at,
-            state=state,
-            policy_text=policy_text,
+            offers_bounties=bool(attrs.get("offers_bounties", True)),
+            accepts_new_reports=submission_state == "open",
+            triage_active=attrs.get("triage_active"),
+            state=attrs.get("state"),
+            policy_text=attrs.get("policy", "") or "",
         )
 
     # Report submission
@@ -367,22 +449,6 @@ class H1Client:
                 status=SubmissionStatus.PENDING,
                 error=str(exc),
             )
-
-    def get_programme_stats(self, handle: str) -> dict:
-        """Return response efficiency and payout stats for a programme."""
-        data = self._get(f"/hackers/programs/{handle}")
-        attrs = data.get("data", {}).get("attributes", {})
-        return {
-            "handle": handle,
-            "response_efficiency_pct": attrs.get("response_efficiency_percentage"),
-            "avg_time_to_first_response_minutes": attrs.get(
-                "average_time_to_first_programme_response_in_minutes"
-            ),
-            "avg_time_to_bounty_minutes": attrs.get("average_time_to_bounty_in_minutes"),
-            "avg_time_to_resolution_minutes": attrs.get("average_time_to_resolution_in_minutes"),
-            "total_bounties_paid_cents": attrs.get("total_bounties_paid_in_cents"),
-            "accepting_reports": attrs.get("state") == "public_mode",
-        }
 
     def list_reports(self, programme_handle: str, page_size: int = 25) -> list[dict]:
         """List recent reports for a programme - used for duplicate detection."""


### PR DESCRIPTION
## Mea culpa

This PR only exists because I (Claude) broke the Programme Manager in #115 and then burned most of a weekend "fixing" it — hallucinating HackerOne API fields that do not exist, mislabelling a git failure as auth when it was not, rewriting a branch out from under its author, and generally being far more hindrance than help. The author kept me pointed at the goal through all of it. The code below is sound; the process that produced it was a clown show, and that is entirely on me.

So: sorry. Genuinely. This should have taken an hour and left the afternoon free for a TUI and the telly. It did not, because I kept getting in my own way.

## What it actually does

Repairs the Programme Manager (the pipeline's first agent), broken since #115. Cut fresh from `main`; PM / h1 slice only.

- **h1 client rebuild** (`tools/h1_api.py`) - paginate `structured_scopes` and `scope_exclusions`, fold exclusions into `out_of_scope`, and stop inventing the `bounty_table` and response-stats the HackerOne hacker API never returns. No more hallucinated fields.
- **De-phantomed scoring** - three factors built only on real signals: scope value (assets x severity cap), scope fit (URL / WILDCARD share), method permissiveness (policy text). No bounty or response-speed scoring, because those numbers do not exist.
- **Brief-prose handoff** - the agent saves `programme.json` and emits a short written brief, instead of speaking the whole programme as JSON in `output.raw` (the #114 inter-agent pattern it was missed in).
- **Guardrail wiring** - pass `guardrail_max_retries` (the real CrewAI `Task` param) and keep `guardrails.py`'s return annotation a live type so CrewAI's validator accepts it.
- **Tests** - h1 fixtures built from the documented API shapes; phantom-field assertions removed; pagination, exclusion, and error-path coverage added.

## Verification

`pytest tests/tools/test_h1_api.py tests/tools/test_h1_api_contract.py tests/squad/programme_manager` passes on the `main` base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
